### PR TITLE
Removed duplicate param comment.

### DIFF
--- a/src/MagneticSensorAnalog.h
+++ b/src/MagneticSensorAnalog.h
@@ -15,7 +15,6 @@ class MagneticSensorAnalog: public Sensor{
     /**
      * MagneticSensorAnalog class constructor
      * @param _pinAnalog  the pin to read the PWM signal
-     * @param _pinAnalog  the pin to read the PWM signal
      */
     MagneticSensorAnalog(uint8_t _pinAnalog, int _min = 0, int _max = 0);
     


### PR DESCRIPTION
For the constructor of MagneticSensorAnalog (in the comments) there was a duplicated param, there were also two other arguments to the constructor that were not described (If I figure them out, I'll put them in?)