### PR TITLE
Added c++11 "override" labels to overriden Sensor methods.

### DIFF
--- a/src/Encoder.h
+++ b/src/Encoder.h
@@ -59,31 +59,31 @@ class Encoder: public Sensor{
 
     // Abstract functions of the Sensor class implementation
     /** get current angle (rad) */
-    float getAngle();
+    float getAngle() override;
     /**  get current angular velocity (rad/s) */
-    float getVelocity();
+    float getVelocity() override;
     /** 
      *  set current angle as zero angle 
      * return the angle [rad] difference
      */
-    float initRelativeZero();
+    float initRelativeZero() override;
     /**
      * set index angle as zero angle
      * return the angle [rad] difference
      */
-    float initAbsoluteZero();
+    float initAbsoluteZero() override;
     /**
      *  returns 0 if it has no index 
      * 0 - encoder without index
      * 1 - encoder with index 
      */
-    int hasAbsoluteZero();
+    int hasAbsoluteZero() override;
     /**
      * returns 0 if it does need search for absolute zero
      * 0 - encoder without index 
      * 1 - ecoder with index
      */
-    int needsAbsoluteZeroSearch();
+    int needsAbsoluteZeroSearch() override;
 
   private:
     int hasIndex(); //!< function returning 1 if encoder has index pin and 0 if not.

--- a/src/HallSensor.h
+++ b/src/HallSensor.h
@@ -51,31 +51,31 @@ class HallSensor: public Sensor{
 
     // Abstract functions of the Sensor class implementation
     /** get current angle (rad) */
-    float getAngle();
+    float getAngle() override;
     /**  get current angular velocity (rad/s) */
-    float getVelocity();
+    float getVelocity() override;
     /** 
      *  set current angle as zero angle 
      * return the angle [rad] difference
      */
-    float initRelativeZero();
+    float initRelativeZero() override;
     /**
      * set index angle as zero angle
      * return the angle [rad] difference
      */
-    float initAbsoluteZero();
+    float initAbsoluteZero() override;
     /**
      *  returns 0 if it has no index 
      * 0 - HallSensor without index
      * 1 - HallSensor with index 
      */
-    int hasAbsoluteZero();
+    int hasAbsoluteZero() override;
     /**
      * returns 0 if it does need search for absolute zero
      * 0 - HallSensor without index 
      * 1 - ecoder with index
      */
-    int needsAbsoluteZeroSearch();
+    int needsAbsoluteZeroSearch() override;
 
     // whether last step was CW (+1) or CCW (-1) direction
     Direction direction;

--- a/src/MagneticSensorAnalog.h
+++ b/src/MagneticSensorAnalog.h
@@ -30,23 +30,23 @@ class MagneticSensorAnalog: public Sensor{
 
     // implementation of abstract functions of the Sensor class
     /** get current angle (rad) */
-    float getAngle();
+    float getAngle() override;
     /** get current angular velocity (rad/s) **/
-    float getVelocity();
+    float getVelocity() override;
     /**
      *  set current angle as zero angle 
      * return the angle [rad] difference
      */
-    float initRelativeZero();
+    float initRelativeZero() override;
     /**
      *  set absolute zero angle as zero angle
      * return the angle [rad] difference
      */
-    float initAbsoluteZero();
+    float initAbsoluteZero() override;
     /** returns 1 because it is the absolute sensor */
-    int hasAbsoluteZero();
+    int hasAbsoluteZero() override;
     /** returns 0  maning it doesn't need search for absolute zero */
-    int needsAbsoluteZeroSearch();
+    int needsAbsoluteZeroSearch() override;
     /** raw count (typically in range of 0-1023), useful for debugging resolution issues */
     int raw_count;
     int min_raw_count;

--- a/src/MagneticSensorI2C.h
+++ b/src/MagneticSensorI2C.h
@@ -24,23 +24,23 @@ class MagneticSensorI2C: public Sensor{
 
     // implementation of abstract functions of the Sensor class
     /** get current angle (rad) */
-    float getAngle();
+    float getAngle() override;
     /** get current angular velocity (rad/s) **/
-    float getVelocity();
+    float getVelocity() override;
     /**
      *  set current angle as zero angle 
      * return the angle [rad] difference
      */
-    float initRelativeZero();
+    float initRelativeZero() override;
     /**
      *  set absolute zero angle as zero angle
      * return the angle [rad] difference
      */
-    float initAbsoluteZero();
+    float initAbsoluteZero() override;
     /** returns 1 because it is the absolute sensor */
-    int hasAbsoluteZero();
+    int hasAbsoluteZero() override;
     /** returns 0  maning it doesn't need search for absolute zero */
-    int needsAbsoluteZeroSearch();
+    int needsAbsoluteZeroSearch() override;
     
 
   private:

--- a/src/MagneticSensorSPI.h
+++ b/src/MagneticSensorSPI.h
@@ -24,23 +24,23 @@ class MagneticSensorSPI: public Sensor{
 
     // implementation of abstract functions of the Sensor class
     /** get current angle (rad) */
-    float getAngle();
+    float getAngle() override;
     /** get current angular velocity (rad/s) **/
-    float getVelocity();
+    float getVelocity() override;
     /**
      *  set current angle as zero angle 
      * return the angle [rad] difference
      */
-    float initRelativeZero();
+    float initRelativeZero() override;
     /**
      *  set absolute zero angle as zero angle
      * return the angle [rad] difference
      */
-    float initAbsoluteZero();
+    float initAbsoluteZero() override;
     /** returns 1 because it is the absolute sensor */
-    int hasAbsoluteZero();
+    int hasAbsoluteZero() override;
     /** returns 0  maning it doesn't need search for absolute zero */
-    int needsAbsoluteZeroSearch();
+    int needsAbsoluteZeroSearch() override;
     
 
   private:


### PR DESCRIPTION
The override keyword causes the compiler to bark at you if when you specify a method override with a spelling error.
(As of 2014-ish, the Arduino IDE was supposed to support C++11 ... I haven't actually tried this out yet in my Arduino IDE ... I'm on a different computer).
No feelings will be hurt if you reject this one.