### PR TITLE
Initial support for secondary SPI bus

### DIFF
--- a/examples/utils/sensor_test/magnetic_sensors/magnetic_sensor_spi_alt_example/magnetic_sensor_spi_alt_example.ino
+++ b/examples/utils/sensor_test/magnetic_sensors/magnetic_sensor_spi_alt_example/magnetic_sensor_spi_alt_example.ino
@@ -1,0 +1,27 @@
+#include <SimpleFOC.h>
+
+// MagneticSensorSPI(int cs, float _cpr, int _angle_register)
+// config           - SPI config
+//  cs              - SPI chip select pin 
+MagneticSensorSPI sensor = MagneticSensorSPI(AS5147_SPI, PA15);
+
+// these are valid pins (mosi, miso, sclk) for 2nd SPI bus on storm32 board (stm32f107rc)
+SPIClass SPI_2(PB15, PB14, PB13);
+
+void setup() {
+  // monitoring port
+  Serial.begin(115200);
+
+  // initialise magnetic sensor hardware
+  sensor.init(&SPI_2);
+
+  Serial.println("Sensor ready");
+  _delay(1000);
+}
+
+void loop() {
+  // display the angle and the angular velocity to the terminal
+  Serial.print(sensor.getAngle());
+  Serial.print("\t");
+  Serial.println(sensor.getVelocity());
+}

--- a/src/MagneticSensorSPI.h
+++ b/src/MagneticSensorSPI.h
@@ -38,7 +38,7 @@ class MagneticSensorSPI: public Sensor{
     MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs);
 
     /** sensor initialise pins */
-    void init();
+    void init(SPIClass* _spi = &SPI);
 
     // implementation of abstract functions of the Sensor class
     /** get current angle (rad) */
@@ -103,6 +103,7 @@ class MagneticSensorSPI: public Sensor{
     int command_rw_bit; //!< the bit where read/write flag is stored in command
     int data_start_bit; //!< the the position of first bit
 
+    SPIClass* spi;
 };
 
 


### PR DESCRIPTION
I've not tested 'dual' spi but have tested a single SPI using non default pins such as storm32 whose SPI1 pins are being used for motor drivers.  The SPI2 pins on the storm32 are sort of available after desoldering a couple of resistors and an LED.

The pattern is the same as i2c and I've added an example.