### PR TITLE
Code Style: format "tab" to "two space"

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -16,7 +16,7 @@ BLDCMotor::BLDCMotor(int pp, float _R)
 
 
 /**
-	Link the driver which controls the motor
+  Link the driver which controls the motor
 */
 void BLDCMotor::linkDriver(BLDCDriver* _driver) {
   driver = _driver;

--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -37,9 +37,9 @@ class BLDCMotor: public FOCMotor
     BLDCDriver* driver; 
     
     /**  Motor hardware init function */
-  	void init() override;
+    void init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 
@@ -67,7 +67,7 @@ class BLDCMotor: public FOCMotor
     void move(float target = NOT_SET) override;
     
     float Ua, Ub, Uc;//!< Current phase voltages Ua,Ub and Uc set to motor
-    float	Ualpha, Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
+    float Ualpha, Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
 
   private:

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -17,7 +17,7 @@ StepperMotor::StepperMotor(int pp, float _R)
 }
 
 /**
-	Link the driver which controls the motor
+  Link the driver which controls the motor
 */
 void StepperMotor::linkDriver(StepperDriver* _driver) {
   driver = _driver;

--- a/src/StepperMotor.h
+++ b/src/StepperMotor.h
@@ -15,7 +15,7 @@
 #include "common/defaults.h"
 
 /**
- Stepper Motor class
+  Stepper Motor class
 */
 class StepperMotor: public FOCMotor
 {
@@ -41,9 +41,9 @@ class StepperMotor: public FOCMotor
     StepperDriver* driver; 
 
     /**  Motor hardware init function */
-  	void init() override;
+    void init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 
@@ -75,7 +75,7 @@ class StepperMotor: public FOCMotor
      */
     void move(float target = NOT_SET) override;
     
-    float	Ualpha,Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
+    float  Ualpha,Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
   private:
   

--- a/src/common/base_classes/FOCMotor.cpp
+++ b/src/common/base_classes/FOCMotor.cpp
@@ -39,14 +39,14 @@ FOCMotor::FOCMotor()
 
 
 /**
-	Sensor linking method
+  Sensor linking method
 */
 void FOCMotor::linkSensor(Sensor* _sensor) {
   sensor = _sensor;
 }
 
 /**
-	CurrentSense linking method
+  CurrentSense linking method
 */
 void FOCMotor::linkCurrentSense(CurrentSense* _current_sense) {
   current_sense = _current_sense;

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -63,9 +63,9 @@ class FOCMotor
     FOCMotor();
 
     /**  Motor hardware init function */
-  	virtual void init()=0;
+    virtual void init()=0;
     /** Motor disable function */
-  	virtual void disable()=0;
+    virtual void disable()=0;
     /** Motor enable function */
     virtual void enable()=0;
 
@@ -129,9 +129,9 @@ class FOCMotor
 
     // state variables
     float target; //!< current target value - depends of the controller
-  	float shaft_angle;//!< current motor angle
-  	float electrical_angle;//!< current electrical angle
-  	float shaft_velocity;//!< current motor velocity 
+    float shaft_angle;//!< current motor angle
+    float electrical_angle;//!< current electrical angle
+    float shaft_velocity;//!< current motor velocity 
     float current_sp;//!< target current ( q current )
     float shaft_velocity_sp;//!< current target velocity
     float shaft_angle_sp;//!< current target angle
@@ -143,7 +143,7 @@ class FOCMotor
     float velocity_index_search;//!< target velocity for index search 
     
     // motor physical parameters
-    float	phase_resistance; //!< motor phase resistance
+    float  phase_resistance; //!< motor phase resistance
     int pole_pairs;//!< motor pole pairs number
 
     // limiting variables
@@ -169,7 +169,7 @@ class FOCMotor
     LowPassFilter LPF_current_q{DEF_CURR_FILTER_Tf};//!<  parameter determining the current Low pass filter configuration 
     LowPassFilter LPF_current_d{DEF_CURR_FILTER_Tf};//!<  parameter determining the current Low pass filter configuration 
     PIDController PID_velocity{DEF_PID_VEL_P,DEF_PID_VEL_I,DEF_PID_VEL_D,DEF_PID_VEL_RAMP,DEF_PID_VEL_LIMIT};//!< parameter determining the velocity PID configuration
-    PIDController P_angle{DEF_P_ANGLE_P,0,0,1e10,DEF_VEL_LIM};	//!< parameter determining the position PID configuration 
+    PIDController P_angle{DEF_P_ANGLE_P,0,0,1e10,DEF_VEL_LIM};  //!< parameter determining the position PID configuration 
     LowPassFilter LPF_velocity{DEF_VEL_FILTER_Tf};//!<  parameter determining the velocity Low pass filter configuration 
     LowPassFilter LPF_angle{0.0};//!<  parameter determining the angle low pass filter configuration 
     unsigned int motion_downsample = DEF_MOTION_DOWNSMAPLE; //!< parameter defining the ratio of downsampling for move commad

--- a/src/current_sense/InlineCurrentSense.h
+++ b/src/current_sense/InlineCurrentSense.h
@@ -29,16 +29,16 @@ class InlineCurrentSense: public CurrentSense{
     // ADC measuremnet gain for each phase
     // support for different gains for different phases of more commonly - inverted phase currents
     // this should be automated later
-  	int gain_a; //!< phase A gain 
-  	int gain_b; //!< phase B gain 
-  	int gain_c; //!< phase C gain 
+    int gain_a; //!< phase A gain 
+    int gain_b; //!< phase B gain 
+    int gain_c; //!< phase C gain 
 
   private:
 
     // hardware variables
-  	int pinA; //!< pin A analog pin for current measurement
-  	int pinB; //!< pin B analog pin for current measurement
-  	int pinC; //!< pin C analog pin for current measurement
+    int pinA; //!< pin A analog pin for current measurement
+    int pinB; //!< pin B analog pin for current measurement
+    int pinC; //!< pin C analog pin for current measurement
 
     // gain variables
     double shunt_resistor; //!< Shunt resistor value 

--- a/src/drivers/BLDCDriver3PWM.h
+++ b/src/drivers/BLDCDriver3PWM.h
@@ -25,16 +25,16 @@ class BLDCDriver3PWM: public BLDCDriver
     BLDCDriver3PWM(int phA,int phB,int phC, int en1 = NOT_SET, int en2 = NOT_SET, int en3 = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+    int init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 
     // hardware variables
-  	int pwmA; //!< phase A pwm pin number
-  	int pwmB; //!< phase B pwm pin number
-  	int pwmC; //!< phase C pwm pin number
+    int pwmA; //!< phase A pwm pin number
+    int pwmB; //!< phase B pwm pin number
+    int pwmC; //!< phase C pwm pin number
     int enableA_pin; //!< enable pin number
     int enableB_pin; //!< enable pin number
     int enableC_pin; //!< enable pin number

--- a/src/drivers/BLDCDriver6PWM.h
+++ b/src/drivers/BLDCDriver6PWM.h
@@ -26,16 +26,16 @@ class BLDCDriver6PWM: public BLDCDriver
     BLDCDriver6PWM(int phA_h,int phA_l,int phB_h,int phB_l,int phC_h,int phC_l, int en = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+    int init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 
     // hardware variables
-  	int pwmA_h,pwmA_l; //!< phase A pwm pin number
-  	int pwmB_h,pwmB_l; //!< phase B pwm pin number
-  	int pwmC_h,pwmC_l; //!< phase C pwm pin number
+    int pwmA_h,pwmA_l; //!< phase A pwm pin number
+    int pwmB_h,pwmB_l; //!< phase B pwm pin number
+    int pwmC_h,pwmC_l; //!< phase C pwm pin number
     int enable_pin; //!< enable pin number
 
     float dead_zone; //!< a percentage of dead-time(zone) (both high and low side in low) for each pwm cycle [0,1]

--- a/src/drivers/StepperDriver2PWM.h
+++ b/src/drivers/StepperDriver2PWM.h
@@ -38,9 +38,9 @@ class StepperDriver2PWM: public StepperDriver
     StepperDriver2PWM(int pwm1, int dir1, int pwm2, int dir2, int en1 = NOT_SET, int en2 = NOT_SET);
 
     /**  Motor hardware init function */
-  	int init() override;
+    int init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 

--- a/src/drivers/StepperDriver4PWM.h
+++ b/src/drivers/StepperDriver4PWM.h
@@ -25,16 +25,16 @@ class StepperDriver4PWM: public StepperDriver
     StepperDriver4PWM(int ph1A,int ph1B,int ph2A,int ph2B, int en1 = NOT_SET, int en2 = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+    int init() override;
     /** Motor disable function */
-  	void disable() override;
+    void disable() override;
     /** Motor enable function */
     void enable() override;
 
     // hardware variables
-  	int pwm1A; //!< phase 1A pwm pin number
-  	int pwm1B; //!< phase 1B pwm pin number
-  	int pwm2A; //!< phase 2A pwm pin number
+    int pwm1A; //!< phase 1A pwm pin number
+    int pwm1B; //!< phase 1B pwm pin number
+    int pwm2A; //!< phase 2A pwm pin number
     int pwm2B; //!< phase 2B pwm pin number
     int enable_pin1; //!< enable pin number phase 1
     int enable_pin2; //!< enable pin number phase 2

--- a/src/drivers/hardware_specific/samd21_mcu.cpp
+++ b/src/drivers/hardware_specific/samd21_mcu.cpp
@@ -38,16 +38,16 @@ static void syncTCC(Tcc* TCCx) {
 
 
 struct tccConfiguration {
-	uint8_t pin;
-	uint8_t alternate; // 1=true, 0=false
-	uint8_t wo;
-	union tccChanInfo {
-		struct {
-			int8_t chan;
-			int8_t tccn;
-		};
-		uint16_t chaninfo;
-	} tcc;
+  uint8_t pin;
+  uint8_t alternate; // 1=true, 0=false
+  uint8_t wo;
+  union tccChanInfo {
+    struct {
+      int8_t chan;
+      int8_t tccn;
+    };
+    uint16_t chaninfo;
+  } tcc;
 };
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
@@ -71,24 +71,24 @@ bool tccConfigured[TCC_INST_NUM+TC_INST_NUM];
  * clocks.
  */
 void configureSAMDClock() {
-	if (!SAMDClockConfigured) {
-		SAMDClockConfigured = true;						// mark clock as configured
-		for (int i=0;i<TCC_INST_NUM;i++)				// mark all the TCCs as not yet configured
-			tccConfigured[i] = false;
-		REG_GCLK_GENDIV = GCLK_GENDIV_DIV(1) |          // Divide the 48MHz clock source by divisor N=1: 48MHz/1=48MHz
-						GCLK_GENDIV_ID(4);            	// Select Generic Clock (GCLK) 4
-		while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
+  if (!SAMDClockConfigured) {
+    SAMDClockConfigured = true;            // mark clock as configured
+    for (int i=0;i<TCC_INST_NUM;i++)        // mark all the TCCs as not yet configured
+      tccConfigured[i] = false;
+    REG_GCLK_GENDIV = GCLK_GENDIV_DIV(1) |          // Divide the 48MHz clock source by divisor N=1: 48MHz/1=48MHz
+            GCLK_GENDIV_ID(4);              // Select Generic Clock (GCLK) 4
+    while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
 
-		REG_GCLK_GENCTRL = GCLK_GENCTRL_IDC |           // Set the duty cycle to 50/50 HIGH/LOW
-						 GCLK_GENCTRL_GENEN |         	// Enable GCLK4
-						 GCLK_GENCTRL_SRC_DFLL48M |   	// Set the 48MHz clock source
-						 GCLK_GENCTRL_ID(4);          	// Select GCLK4
-		while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
+    REG_GCLK_GENCTRL = GCLK_GENCTRL_IDC |           // Set the duty cycle to 50/50 HIGH/LOW
+             GCLK_GENCTRL_GENEN |           // Enable GCLK4
+             GCLK_GENCTRL_SRC_DFLL48M |     // Set the 48MHz clock source
+             GCLK_GENCTRL_ID(4);            // Select GCLK4
+    while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-		Serial.println("Configured clock...");
+    Serial.println("Configured clock...");
 #endif
-	}
+  }
 }
 
 
@@ -100,141 +100,141 @@ void configureSAMDClock() {
  * faster won't be possible without sacrificing resolution.
  */
 void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate=false, float hw6pwm=-1) {
-	// TODO for the moment we ignore the frequency...
-	if (!tccConfigured[tccConfig.tcc.tccn]) {
-		uint32_t GCLK_CLKCTRL_ID_ofthistcc = -1;
-		switch (tccConfig.tcc.tccn>>1) {
-		case 0:
-			GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TCC0_TCC1);//GCLK_CLKCTRL_ID_TCC0_TCC1;
-			break;
-		case 1:
-			GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TCC2_TC3);//GCLK_CLKCTRL_ID_TCC2_TC3;
-			break;
-		case 2:
-			GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TC4_TC5);//GCLK_CLKCTRL_ID_TC4_TC5;
-			break;
-		case 3:
-			GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TC6_TC7);
-			break;
-		default:
-			return;
-		}
+  // TODO for the moment we ignore the frequency...
+  if (!tccConfigured[tccConfig.tcc.tccn]) {
+    uint32_t GCLK_CLKCTRL_ID_ofthistcc = -1;
+    switch (tccConfig.tcc.tccn>>1) {
+    case 0:
+      GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TCC0_TCC1);//GCLK_CLKCTRL_ID_TCC0_TCC1;
+      break;
+    case 1:
+      GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TCC2_TC3);//GCLK_CLKCTRL_ID_TCC2_TC3;
+      break;
+    case 2:
+      GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TC4_TC5);//GCLK_CLKCTRL_ID_TC4_TC5;
+      break;
+    case 3:
+      GCLK_CLKCTRL_ID_ofthistcc = GCLK_CLKCTRL_ID(GCM_TC6_TC7);
+      break;
+    default:
+      return;
+    }
 
-		// Feed GCLK4 to TCC
-		REG_GCLK_CLKCTRL = (uint16_t)  GCLK_CLKCTRL_CLKEN |         // Enable GCLK4
-									   GCLK_CLKCTRL_GEN_GCLK4 |     // Select GCLK4
-									   GCLK_CLKCTRL_ID_ofthistcc;   // Feed GCLK4 to tcc
-		while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
+    // Feed GCLK4 to TCC
+    REG_GCLK_CLKCTRL = (uint16_t)  GCLK_CLKCTRL_CLKEN |         // Enable GCLK4
+                     GCLK_CLKCTRL_GEN_GCLK4 |     // Select GCLK4
+                     GCLK_CLKCTRL_ID_ofthistcc;   // Feed GCLK4 to tcc
+    while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
 
-		tccConfigured[tccConfig.tcc.tccn] = true;
+    tccConfigured[tccConfig.tcc.tccn] = true;
 
-		if (tccConfig.tcc.tccn>=TCC_INST_NUM) {
-			Tc* tc = (Tc*)GetTC(tccConfig.tcc.chaninfo);
+    if (tccConfig.tcc.tccn>=TCC_INST_NUM) {
+      Tc* tc = (Tc*)GetTC(tccConfig.tcc.chaninfo);
 
-			// disable
-			tc->COUNT8.CTRLA.bit.ENABLE = 0;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-			// unfortunately we need the 8-bit counter mode to use the PER register...
-			tc->COUNT8.CTRLA.reg |= TC_CTRLA_MODE_COUNT8 | TC_CTRLA_WAVEGEN_NPWM ;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-			// meaning prescaler of 8, since TC-Unit has no up/down mode, and has resolution of 250 rather than 1000...
-			tc->COUNT8.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_DIV8_Val ;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-			// period is 250, period cannot be higher than 256!
-			tc->COUNT8.PER.reg = SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-			// initial duty cycle is 0
-			tc->COUNT8.CC[tccConfig.tcc.chan].reg = 0;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-			// enable
-			tc->COUNT8.CTRLA.bit.ENABLE = 1;
-			while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-
-#ifdef SIMPLEFOC_SAMD_DEBUG
-			Serial.print("Initialized TC ");
-			Serial.println(tccConfig.tcc.tccn);
-#endif
-		}
-		else {
-			Tcc* tcc = (Tcc*)GetTC(tccConfig.tcc.chaninfo);
-
-			uint8_t invenMask = ~(1<<tccConfig.tcc.chan);	// negate (invert) the signal if needed
-			uint8_t invenVal = negate?(1<<tccConfig.tcc.chan):0;
-			tcc->DRVCTRL.vec.INVEN = (tcc->DRVCTRL.vec.INVEN&invenMask)|invenVal;
-			syncTCC(tcc); // wait for sync
-
-			tcc->WAVE.reg |= TCC_WAVE_POL(0xF)|TCC_WAVEB_WAVEGENB_DSBOTH;   // Set wave form configuration
-			while ( tcc->SYNCBUSY.bit.WAVE == 1 ); // wait for sync
-
-			if (hw6pwm>0.0) {
-				tcc->WEXCTRL.vec.DTIEN |= (1<<tccConfig.tcc.chan);
-				tcc->WEXCTRL.bit.DTLS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
-				tcc->WEXCTRL.bit.DTHS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
-				syncTCC(tcc); // wait for sync
-			}
-
-			tcc->PER.reg = SIMPLEFOC_SAMD_PWM_RESOLUTION - 1;                 // Set counter Top using the PER register
-			while ( tcc->SYNCBUSY.bit.PER == 1 ); // wait for sync
-
-			// set all channels to 0%
-			uint8_t chanCount = (tccConfig.tcc.tccn==1||tccConfig.tcc.tccn==2)?2:4;
-			for (int i=0;i<chanCount;i++) {
-				tcc->CC[i].reg = 0;					// start off at 0% duty cycle
-				uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CC0_Pos+i);
-				while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
-			}
-
-			// enable double buffering
-			//tcc->CTRLBCLR.bit.LUPD = 1;
-			//while ( tcc->SYNCBUSY.bit.CTRLB == 1 );
-
-			// Enable TC
-			tcc->CTRLA.reg |= TCC_CTRLA_ENABLE | TCC_CTRLA_PRESCALER_DIV1; //48Mhz/1=48Mhz/2(up/down)=24MHz/1024=24KHz
-			while ( tcc->SYNCBUSY.bit.ENABLE == 1 ); // wait for sync
+      // disable
+      tc->COUNT8.CTRLA.bit.ENABLE = 0;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+      // unfortunately we need the 8-bit counter mode to use the PER register...
+      tc->COUNT8.CTRLA.reg |= TC_CTRLA_MODE_COUNT8 | TC_CTRLA_WAVEGEN_NPWM ;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+      // meaning prescaler of 8, since TC-Unit has no up/down mode, and has resolution of 250 rather than 1000...
+      tc->COUNT8.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_DIV8_Val ;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+      // period is 250, period cannot be higher than 256!
+      tc->COUNT8.PER.reg = SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+      // initial duty cycle is 0
+      tc->COUNT8.CC[tccConfig.tcc.chan].reg = 0;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+      // enable
+      tc->COUNT8.CTRLA.bit.ENABLE = 1;
+      while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-			Serial.print("    Initialized TCC ");
-			Serial.print(tccConfig.tcc.tccn);
-			Serial.print("-");
-			Serial.print(tccConfig.tcc.chan);
-			Serial.print("[");
-			Serial.print(tccConfig.wo);
-			Serial.println("]");
+      Serial.print("Initialized TC ");
+      Serial.println(tccConfig.tcc.tccn);
 #endif
-		}
-	}
-	else if (tccConfig.tcc.tccn<TCC_INST_NUM) {
-		// set invert bit for TCC channels in SW 6-PWM...
-		Tcc* tcc = (Tcc*)GetTC(tccConfig.tcc.chaninfo);
+    }
+    else {
+      Tcc* tcc = (Tcc*)GetTC(tccConfig.tcc.chaninfo);
 
-		tcc->CTRLA.bit.ENABLE = 0;
-		while ( tcc->SYNCBUSY.bit.ENABLE == 1 );
+      uint8_t invenMask = ~(1<<tccConfig.tcc.chan);  // negate (invert) the signal if needed
+      uint8_t invenVal = negate?(1<<tccConfig.tcc.chan):0;
+      tcc->DRVCTRL.vec.INVEN = (tcc->DRVCTRL.vec.INVEN&invenMask)|invenVal;
+      syncTCC(tcc); // wait for sync
 
-		uint8_t invenMask = ~(1<<tccConfig.tcc.chan);	// negate (invert) the signal if needed
-		uint8_t invenVal = negate?(1<<tccConfig.tcc.chan):0;
-		tcc->DRVCTRL.vec.INVEN = (tcc->DRVCTRL.vec.INVEN&invenMask)|invenVal;
-		syncTCC(tcc); // wait for sync
+      tcc->WAVE.reg |= TCC_WAVE_POL(0xF)|TCC_WAVEB_WAVEGENB_DSBOTH;   // Set wave form configuration
+      while ( tcc->SYNCBUSY.bit.WAVE == 1 ); // wait for sync
 
-		if (hw6pwm>0.0) {
-			tcc->WEXCTRL.vec.DTIEN |= (1<<tccConfig.tcc.chan);
-			tcc->WEXCTRL.bit.DTLS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
-			tcc->WEXCTRL.bit.DTHS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
-			syncTCC(tcc); // wait for sync
-		}
+      if (hw6pwm>0.0) {
+        tcc->WEXCTRL.vec.DTIEN |= (1<<tccConfig.tcc.chan);
+        tcc->WEXCTRL.bit.DTLS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
+        tcc->WEXCTRL.bit.DTHS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
+        syncTCC(tcc); // wait for sync
+      }
 
-		tcc->CTRLA.bit.ENABLE = 1;
-		while ( tcc->SYNCBUSY.bit.ENABLE == 1 );
+      tcc->PER.reg = SIMPLEFOC_SAMD_PWM_RESOLUTION - 1;                 // Set counter Top using the PER register
+      while ( tcc->SYNCBUSY.bit.PER == 1 ); // wait for sync
+
+      // set all channels to 0%
+      uint8_t chanCount = (tccConfig.tcc.tccn==1||tccConfig.tcc.tccn==2)?2:4;
+      for (int i=0;i<chanCount;i++) {
+        tcc->CC[i].reg = 0;          // start off at 0% duty cycle
+        uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CC0_Pos+i);
+        while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
+      }
+
+      // enable double buffering
+      //tcc->CTRLBCLR.bit.LUPD = 1;
+      //while ( tcc->SYNCBUSY.bit.CTRLB == 1 );
+
+      // Enable TC
+      tcc->CTRLA.reg |= TCC_CTRLA_ENABLE | TCC_CTRLA_PRESCALER_DIV1; //48Mhz/1=48Mhz/2(up/down)=24MHz/1024=24KHz
+      while ( tcc->SYNCBUSY.bit.ENABLE == 1 ); // wait for sync
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-		Serial.print("(Re-)Initialized TCC ");
-		Serial.print(tccConfig.tcc.tccn);
-		Serial.print("-");
-		Serial.print(tccConfig.tcc.chan);
-		Serial.print("[");
-		Serial.print(tccConfig.wo);
-		Serial.println("]");
+      Serial.print("    Initialized TCC ");
+      Serial.print(tccConfig.tcc.tccn);
+      Serial.print("-");
+      Serial.print(tccConfig.tcc.chan);
+      Serial.print("[");
+      Serial.print(tccConfig.wo);
+      Serial.println("]");
 #endif
-	}
+    }
+  }
+  else if (tccConfig.tcc.tccn<TCC_INST_NUM) {
+    // set invert bit for TCC channels in SW 6-PWM...
+    Tcc* tcc = (Tcc*)GetTC(tccConfig.tcc.chaninfo);
+
+    tcc->CTRLA.bit.ENABLE = 0;
+    while ( tcc->SYNCBUSY.bit.ENABLE == 1 );
+
+    uint8_t invenMask = ~(1<<tccConfig.tcc.chan);  // negate (invert) the signal if needed
+    uint8_t invenVal = negate?(1<<tccConfig.tcc.chan):0;
+    tcc->DRVCTRL.vec.INVEN = (tcc->DRVCTRL.vec.INVEN&invenMask)|invenVal;
+    syncTCC(tcc); // wait for sync
+
+    if (hw6pwm>0.0) {
+      tcc->WEXCTRL.vec.DTIEN |= (1<<tccConfig.tcc.chan);
+      tcc->WEXCTRL.bit.DTLS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
+      tcc->WEXCTRL.bit.DTHS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
+      syncTCC(tcc); // wait for sync
+    }
+
+    tcc->CTRLA.bit.ENABLE = 1;
+    while ( tcc->SYNCBUSY.bit.ENABLE == 1 );
+
+#ifdef SIMPLEFOC_SAMD_DEBUG
+    Serial.print("(Re-)Initialized TCC ");
+    Serial.print(tccConfig.tcc.tccn);
+    Serial.print("-");
+    Serial.print(tccConfig.tcc.chan);
+    Serial.print("[");
+    Serial.print(tccConfig.wo);
+    Serial.println("]");
+#endif
+  }
 
 
 }
@@ -247,8 +247,8 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate=f
  * Attach the TCC to the pin
  */
 bool attachTCC(tccConfiguration& tccConfig) {
-	if (numTccPinConfigurations>=SIMPLEFOC_SAMD_MAX_TCC_PINCONFIGURATIONS)
-		return false;
+  if (numTccPinConfigurations>=SIMPLEFOC_SAMD_MAX_TCC_PINCONFIGURATIONS)
+    return false;
     pinMode(tccConfig.pin, OUTPUT);
     pinPeripheral(tccConfig.pin, (tccConfig.alternate==1)?EPioType::PIO_TIMER_ALT:EPioType::PIO_TIMER);
     tccPinConfigurations[numTccPinConfigurations++] = tccConfig;
@@ -264,19 +264,19 @@ bool attachTCC(tccConfiguration& tccConfig) {
  * Check if the configuration is in use already.
  */
 bool inUse(tccConfiguration& tccConfig) {
-	for (int i=0;i<numTccPinConfigurations;i++) {
-		if (tccPinConfigurations[i].tcc.chaninfo==tccConfig.tcc.chaninfo)
-			return true;
-	}
-	return false;
+  for (int i=0;i<numTccPinConfigurations;i++) {
+    if (tccPinConfigurations[i].tcc.chaninfo==tccConfig.tcc.chaninfo)
+      return true;
+  }
+  return false;
 }
 
 
 tccConfiguration* getTccPinConfiguration(uint8_t pin) {
-	for (int i=0;i<numTccPinConfigurations;i++)
-		if (tccPinConfigurations[i].pin==pin)
-			return &tccPinConfigurations[i];
-	return NULL;
+  for (int i=0;i<numTccPinConfigurations;i++)
+    if (tccPinConfigurations[i].pin==pin)
+      return &tccPinConfigurations[i];
+  return NULL;
 }
 
 
@@ -287,24 +287,24 @@ tccConfiguration* getTccPinConfiguration(uint8_t pin) {
  * Get the TCC channel associated with that pin
  */
 tccConfiguration getTCCChannelNr(int pin, bool alternate) {
-	tccConfiguration result;
-	result.pin = pin;
-	result.alternate = alternate?1:0;
-	result.tcc.tccn = -2;
-	result.tcc.chan = -2;
-	const PinDescription& pinDesc = g_APinDescription[pin];
-	struct wo_association& association = getWOAssociation(pinDesc.ulPort, pinDesc.ulPin);
-	if (association.port==NOT_A_PORT)
-		return result; // could not find the port/pin
-	if (!alternate) { // && (attr & PIN_ATTR_PWM) == PIN_ATTR_PWM) {
-		result.tcc.chaninfo = association.tccE;
-		result.wo = association.woE;
-	}
-	else { // && (attr & PIN_ATTR_TIMER_ALT) == PIN_ATTR_TIMER_ALT) {
-		result.tcc.chaninfo = association.tccF;
-		result.wo = association.woF;
-	}
-	return result;
+  tccConfiguration result;
+  result.pin = pin;
+  result.alternate = alternate?1:0;
+  result.tcc.tccn = -2;
+  result.tcc.chan = -2;
+  const PinDescription& pinDesc = g_APinDescription[pin];
+  struct wo_association& association = getWOAssociation(pinDesc.ulPort, pinDesc.ulPin);
+  if (association.port==NOT_A_PORT)
+    return result; // could not find the port/pin
+  if (!alternate) { // && (attr & PIN_ATTR_PWM) == PIN_ATTR_PWM) {
+    result.tcc.chaninfo = association.tccE;
+    result.wo = association.woE;
+  }
+  else { // && (attr & PIN_ATTR_TIMER_ALT) == PIN_ATTR_TIMER_ALT) {
+    result.tcc.chaninfo = association.tccF;
+    result.wo = association.woF;
+  }
+  return result;
 }
 
 
@@ -312,45 +312,45 @@ tccConfiguration getTCCChannelNr(int pin, bool alternate) {
 
 
 bool checkPeripheralPermutationSameTCC6(tccConfiguration& pinAh, tccConfiguration& pinAl, tccConfiguration& pinBh, tccConfiguration& pinBl, tccConfiguration& pinCh, tccConfiguration& pinCl) {
-	if (inUse(pinAh) || inUse(pinAl) || inUse(pinBh) || inUse(pinBl) || inUse(pinCh) || inUse(pinCl))
-		return false;
+  if (inUse(pinAh) || inUse(pinAl) || inUse(pinBh) || inUse(pinBl) || inUse(pinCh) || inUse(pinCl))
+    return false;
 
-	if (pinAh.tcc.tccn<0 || pinAh.tcc.tccn!=pinAl.tcc.tccn || pinAh.tcc.tccn!=pinBh.tcc.tccn || pinAh.tcc.tccn!=pinBl.tcc.tccn
-		|| pinAh.tcc.tccn!=pinCh.tcc.tccn || pinAh.tcc.tccn!=pinCl.tcc.tccn || pinAh.tcc.tccn>=TCC_INST_NUM)
-		return false;
+  if (pinAh.tcc.tccn<0 || pinAh.tcc.tccn!=pinAl.tcc.tccn || pinAh.tcc.tccn!=pinBh.tcc.tccn || pinAh.tcc.tccn!=pinBl.tcc.tccn
+    || pinAh.tcc.tccn!=pinCh.tcc.tccn || pinAh.tcc.tccn!=pinCl.tcc.tccn || pinAh.tcc.tccn>=TCC_INST_NUM)
+    return false;
 
-	if (pinAh.tcc.chan==pinBh.tcc.chan || pinAh.tcc.chan==pinBl.tcc.chan || pinAh.tcc.chan==pinCh.tcc.chan || pinAh.tcc.chan==pinCl.tcc.chan)
-		return false;
-	if (pinBh.tcc.chan==pinCh.tcc.chan || pinBh.tcc.chan==pinCl.tcc.chan)
-		return false;
-	if (pinAl.tcc.chan==pinBh.tcc.chan || pinAl.tcc.chan==pinBl.tcc.chan || pinAl.tcc.chan==pinCh.tcc.chan || pinAl.tcc.chan==pinCl.tcc.chan)
-		return false;
-	if (pinBl.tcc.chan==pinCh.tcc.chan || pinBl.tcc.chan==pinCl.tcc.chan)
-		return false;
+  if (pinAh.tcc.chan==pinBh.tcc.chan || pinAh.tcc.chan==pinBl.tcc.chan || pinAh.tcc.chan==pinCh.tcc.chan || pinAh.tcc.chan==pinCl.tcc.chan)
+    return false;
+  if (pinBh.tcc.chan==pinCh.tcc.chan || pinBh.tcc.chan==pinCl.tcc.chan)
+    return false;
+  if (pinAl.tcc.chan==pinBh.tcc.chan || pinAl.tcc.chan==pinBl.tcc.chan || pinAl.tcc.chan==pinCh.tcc.chan || pinAl.tcc.chan==pinCl.tcc.chan)
+    return false;
+  if (pinBl.tcc.chan==pinCh.tcc.chan || pinBl.tcc.chan==pinCl.tcc.chan)
+    return false;
 
-	if (pinAh.tcc.chan!=pinAl.tcc.chan || pinBh.tcc.chan!=pinBl.tcc.chan || pinCh.tcc.chan!=pinCl.tcc.chan)
-		return false;
-	if (pinAh.wo==pinAl.wo || pinBh.wo==pinBl.wo || pinCh.wo!=pinCl.wo)
-		return false;
+  if (pinAh.tcc.chan!=pinAl.tcc.chan || pinBh.tcc.chan!=pinBl.tcc.chan || pinCh.tcc.chan!=pinCl.tcc.chan)
+    return false;
+  if (pinAh.wo==pinAl.wo || pinBh.wo==pinBl.wo || pinCh.wo!=pinCl.wo)
+    return false;
 
-	return true;
+  return true;
 }
 
 
 
 
 bool checkPeripheralPermutationCompatible(tccConfiguration pins[], uint8_t num) {
-	for (int i=0;i<num;i++)
-		if (pins[i].tcc.tccn<0)
-			return false;
-	for (int i=0;i<num-1;i++)
-		for (int j=i+1;j<num;j++)
-			if (pins[i].tcc.chaninfo==pins[j].tcc.chaninfo)
-				return false;
-	for (int i=0;i<num;i++)
-		if (inUse(pins[i]))
-			return false;
-	return true;
+  for (int i=0;i<num;i++)
+    if (pins[i].tcc.tccn<0)
+      return false;
+  for (int i=0;i<num-1;i++)
+    for (int j=i+1;j<num;j++)
+      if (pins[i].tcc.chaninfo==pins[j].tcc.chaninfo)
+        return false;
+  for (int i=0;i<num;i++)
+    if (inUse(pins[i]))
+      return false;
+  return true;
 }
 
 
@@ -358,37 +358,37 @@ bool checkPeripheralPermutationCompatible(tccConfiguration pins[], uint8_t num) 
 
 
 bool checkPeripheralPermutationCompatible6(tccConfiguration& pinAh, tccConfiguration& pinAl, tccConfiguration& pinBh, tccConfiguration& pinBl, tccConfiguration& pinCh, tccConfiguration& pinCl) {
-	// check we're valid PWM pins
-	if (pinAh.tcc.tccn<0 || pinAl.tcc.tccn<0 || pinBh.tcc.tccn<0 || pinBl.tcc.tccn<0 || pinCh.tcc.tccn<0 || pinCl.tcc.tccn<0)
-		return false;
-	// only TCC units for 6-PWM
-	if (pinAh.tcc.tccn>=TCC_INST_NUM || pinAl.tcc.tccn>=TCC_INST_NUM || pinBh.tcc.tccn>=TCC_INST_NUM
-			|| pinBl.tcc.tccn>=TCC_INST_NUM || pinCh.tcc.tccn>=TCC_INST_NUM || pinCl.tcc.tccn>=TCC_INST_NUM)
-		return false;
+  // check we're valid PWM pins
+  if (pinAh.tcc.tccn<0 || pinAl.tcc.tccn<0 || pinBh.tcc.tccn<0 || pinBl.tcc.tccn<0 || pinCh.tcc.tccn<0 || pinCl.tcc.tccn<0)
+    return false;
+  // only TCC units for 6-PWM
+  if (pinAh.tcc.tccn>=TCC_INST_NUM || pinAl.tcc.tccn>=TCC_INST_NUM || pinBh.tcc.tccn>=TCC_INST_NUM
+      || pinBl.tcc.tccn>=TCC_INST_NUM || pinCh.tcc.tccn>=TCC_INST_NUM || pinCl.tcc.tccn>=TCC_INST_NUM)
+    return false;
 
-	// check we're not in use
-	if (inUse(pinAh) || inUse(pinAl) || inUse(pinBh) || inUse(pinBl) || inUse(pinCh) || inUse(pinCl))
-		return false;
+  // check we're not in use
+  if (inUse(pinAh) || inUse(pinAl) || inUse(pinBh) || inUse(pinBl) || inUse(pinCh) || inUse(pinCl))
+    return false;
 
-	// check pins are all different tccs/channels
-	if (pinAh.tcc.chaninfo==pinBh.tcc.chaninfo || pinAh.tcc.chaninfo==pinBl.tcc.chaninfo || pinAh.tcc.chaninfo==pinCh.tcc.chaninfo || pinAh.tcc.chaninfo==pinCl.tcc.chaninfo)
-		return false;
-	if (pinAl.tcc.chaninfo==pinBh.tcc.chaninfo || pinAl.tcc.chaninfo==pinBl.tcc.chaninfo || pinAl.tcc.chaninfo==pinCh.tcc.chaninfo || pinAl.tcc.chaninfo==pinCl.tcc.chaninfo)
-		return false;
-	if (pinBh.tcc.chaninfo==pinCh.tcc.chaninfo || pinBh.tcc.chaninfo==pinCl.tcc.chaninfo)
-		return false;
-	if (pinBl.tcc.chaninfo==pinCh.tcc.chaninfo || pinBl.tcc.chaninfo==pinCl.tcc.chaninfo)
-		return false;
+  // check pins are all different tccs/channels
+  if (pinAh.tcc.chaninfo==pinBh.tcc.chaninfo || pinAh.tcc.chaninfo==pinBl.tcc.chaninfo || pinAh.tcc.chaninfo==pinCh.tcc.chaninfo || pinAh.tcc.chaninfo==pinCl.tcc.chaninfo)
+    return false;
+  if (pinAl.tcc.chaninfo==pinBh.tcc.chaninfo || pinAl.tcc.chaninfo==pinBl.tcc.chaninfo || pinAl.tcc.chaninfo==pinCh.tcc.chaninfo || pinAl.tcc.chaninfo==pinCl.tcc.chaninfo)
+    return false;
+  if (pinBh.tcc.chaninfo==pinCh.tcc.chaninfo || pinBh.tcc.chaninfo==pinCl.tcc.chaninfo)
+    return false;
+  if (pinBl.tcc.chaninfo==pinCh.tcc.chaninfo || pinBl.tcc.chaninfo==pinCl.tcc.chaninfo)
+    return false;
 
-	// check H/L pins are on same timer
-	if (pinAh.tcc.tccn!=pinAl.tcc.tccn || pinBh.tcc.tccn!=pinBl.tcc.tccn || pinCh.tcc.tccn!=pinCl.tcc.tccn)
-		return false;
+  // check H/L pins are on same timer
+  if (pinAh.tcc.tccn!=pinAl.tcc.tccn || pinBh.tcc.tccn!=pinBl.tcc.tccn || pinCh.tcc.tccn!=pinCl.tcc.tccn)
+    return false;
 
-	// check H/L pins aren't on both the same timer and wo
-	if (pinAh.wo==pinAl.wo || pinBh.wo==pinBl.wo || pinCh.wo==pinCl.wo)
-		return false;
+  // check H/L pins aren't on both the same timer and wo
+  if (pinAh.wo==pinAl.wo || pinBh.wo==pinBl.wo || pinCh.wo==pinCl.wo)
+    return false;
 
-	return true;
+  return true;
 }
 
 
@@ -396,54 +396,54 @@ bool checkPeripheralPermutationCompatible6(tccConfiguration& pinAh, tccConfigura
 
 
 int checkHardware6PWM(const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
-	for (int i=0;i<64;i++) {
-		tccConfiguration pinAh = getTCCChannelNr(pinA_h, (i>>0&0x01)==0x1);
-		tccConfiguration pinAl = getTCCChannelNr(pinA_l, (i>>1&0x01)==0x1);
-		tccConfiguration pinBh = getTCCChannelNr(pinB_h, (i>>2&0x01)==0x1);
-		tccConfiguration pinBl = getTCCChannelNr(pinB_l, (i>>3&0x01)==0x1);
-		tccConfiguration pinCh = getTCCChannelNr(pinC_h, (i>>4&0x01)==0x1);
-		tccConfiguration pinCl = getTCCChannelNr(pinC_l, (i>>5&0x01)==0x1);
-		if (checkPeripheralPermutationSameTCC6(pinAh, pinAl, pinBh, pinBl, pinCh, pinCl))
-			return i;
-	}
-	return -1;
+  for (int i=0;i<64;i++) {
+    tccConfiguration pinAh = getTCCChannelNr(pinA_h, (i>>0&0x01)==0x1);
+    tccConfiguration pinAl = getTCCChannelNr(pinA_l, (i>>1&0x01)==0x1);
+    tccConfiguration pinBh = getTCCChannelNr(pinB_h, (i>>2&0x01)==0x1);
+    tccConfiguration pinBl = getTCCChannelNr(pinB_l, (i>>3&0x01)==0x1);
+    tccConfiguration pinCh = getTCCChannelNr(pinC_h, (i>>4&0x01)==0x1);
+    tccConfiguration pinCl = getTCCChannelNr(pinC_l, (i>>5&0x01)==0x1);
+    if (checkPeripheralPermutationSameTCC6(pinAh, pinAl, pinBh, pinBl, pinCh, pinCl))
+      return i;
+  }
+  return -1;
 }
 
 
 
 
 int checkSoftware6PWM(const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
-	for (int i=0;i<64;i++) {
-		tccConfiguration pinAh = getTCCChannelNr(pinA_h, (i>>0&0x01)==0x1);
-		tccConfiguration pinAl = getTCCChannelNr(pinA_l, (i>>1&0x01)==0x1);
-		tccConfiguration pinBh = getTCCChannelNr(pinB_h, (i>>2&0x01)==0x1);
-		tccConfiguration pinBl = getTCCChannelNr(pinB_l, (i>>3&0x01)==0x1);
-		tccConfiguration pinCh = getTCCChannelNr(pinC_h, (i>>4&0x01)==0x1);
-		tccConfiguration pinCl = getTCCChannelNr(pinC_l, (i>>5&0x01)==0x1);
-		if (checkPeripheralPermutationCompatible6(pinAh, pinAl, pinBh, pinBl, pinCh, pinCl))
-			return i;
-	}
-	return -1;
+  for (int i=0;i<64;i++) {
+    tccConfiguration pinAh = getTCCChannelNr(pinA_h, (i>>0&0x01)==0x1);
+    tccConfiguration pinAl = getTCCChannelNr(pinA_l, (i>>1&0x01)==0x1);
+    tccConfiguration pinBh = getTCCChannelNr(pinB_h, (i>>2&0x01)==0x1);
+    tccConfiguration pinBl = getTCCChannelNr(pinB_l, (i>>3&0x01)==0x1);
+    tccConfiguration pinCh = getTCCChannelNr(pinC_h, (i>>4&0x01)==0x1);
+    tccConfiguration pinCl = getTCCChannelNr(pinC_l, (i>>5&0x01)==0x1);
+    if (checkPeripheralPermutationCompatible6(pinAh, pinAl, pinBh, pinBl, pinCh, pinCl))
+      return i;
+  }
+  return -1;
 }
 
 
 
 int scorePermutation(tccConfiguration pins[], uint8_t num) {
-	uint32_t usedtccs = 0;
-	for (int i=0;i<num;i++)
-		usedtccs |= (1<<pins[i].tcc.tccn);
-	int score = 0;
-	for (int i=0;i<TCC_INST_NUM;i++){
-		if (usedtccs&0x1)
-			score+=1;
-		usedtccs = usedtccs>>1;
-	}
-	for (int i=0;i<TC_INST_NUM;i++){
-		if (usedtccs&0x1)
-			score+=(num+1);
-		usedtccs = usedtccs>>1;
-	}
-	return score;
+  uint32_t usedtccs = 0;
+  for (int i=0;i<num;i++)
+    usedtccs |= (1<<pins[i].tcc.tccn);
+  int score = 0;
+  for (int i=0;i<TCC_INST_NUM;i++){
+    if (usedtccs&0x1)
+      score+=1;
+    usedtccs = usedtccs>>1;
+  }
+  for (int i=0;i<TC_INST_NUM;i++){
+    if (usedtccs&0x1)
+      score+=(num+1);
+    usedtccs = usedtccs>>1;
+  }
+  return score;
 }
 
 
@@ -451,48 +451,48 @@ int scorePermutation(tccConfiguration pins[], uint8_t num) {
 
 
 int checkPermutations(uint8_t num, int pins[], bool (*checkFunc)(tccConfiguration[], uint8_t) ) {
-	tccConfiguration tccConfs[num];
-	int best = -1;
-	int bestscore = 1000000;
-	for (int i=0;i<(0x1<<num);i++) {
-		for (int j=0;j<num;j++)
-			tccConfs[j] = getTCCChannelNr(pins[j], ((i>>j)&0x01)==0x1);
-		if (checkFunc(tccConfs, num)) {
-			int score = scorePermutation(tccConfs, num);
-			if (score<bestscore) {
-				bestscore = score;
-				best = i;
-			}
-		}
-	}
-	return best;
+  tccConfiguration tccConfs[num];
+  int best = -1;
+  int bestscore = 1000000;
+  for (int i=0;i<(0x1<<num);i++) {
+    for (int j=0;j<num;j++)
+      tccConfs[j] = getTCCChannelNr(pins[j], ((i>>j)&0x01)==0x1);
+    if (checkFunc(tccConfs, num)) {
+      int score = scorePermutation(tccConfs, num);
+      if (score<bestscore) {
+        bestscore = score;
+        best = i;
+      }
+    }
+  }
+  return best;
 }
 
 
 
 
 void writeSAMDDutyCycle(int chaninfo, float dc) {
-	uint8_t tccn = GetTCNumber(chaninfo);
-	uint8_t chan = GetTCChannelNumber(chaninfo);
-	if (tccn<TCC_INST_NUM) {
-		Tcc* tcc = (Tcc*)GetTC(chaninfo);
-		// set via CC
-		tcc->CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
-		uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CC0_Pos+chan);
-		while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
-		// set via CCB
-//		tcc->CCB[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
-//		tcc->STATUS.vec.CCBV = tcc->STATUS.vec.CCBV | (1<<chan);
-		// TODO do we need to wait for sync?
-//		uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CCB0_Pos+chan);
-//		while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
-	}
-	else {
-		Tc* tc = (Tc*)GetTC(chaninfo);
-		//tc->COUNT16.CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
-		tc->COUNT8.CC[chan].reg = (uint8_t)((SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1) * dc);;
-		while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
-	}
+  uint8_t tccn = GetTCNumber(chaninfo);
+  uint8_t chan = GetTCChannelNumber(chaninfo);
+  if (tccn<TCC_INST_NUM) {
+    Tcc* tcc = (Tcc*)GetTC(chaninfo);
+    // set via CC
+    tcc->CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
+    uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CC0_Pos+chan);
+    while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
+    // set via CCB
+//    tcc->CCB[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
+//    tcc->STATUS.vec.CCBV = tcc->STATUS.vec.CCBV | (1<<chan);
+    // TODO do we need to wait for sync?
+//    uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CCB0_Pos+chan);
+//    while ( (tcc->SYNCBUSY.reg & chanbit) > 0 );
+  }
+  else {
+    Tc* tc = (Tc*)GetTC(chaninfo);
+    //tc->COUNT16.CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
+    tc->COUNT8.CC[chan].reg = (uint8_t)((SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1) * dc);;
+    while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+  }
 }
 
 
@@ -512,49 +512,49 @@ void writeSAMDDutyCycle(int chaninfo, float dc) {
  */
 void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	printAllPinInfos();
+  printAllPinInfos();
 #endif
-	int pins[2] = { pinA, pinB };
-	int compatibility = checkPermutations(2, pins, checkPeripheralPermutationCompatible);
-	if (compatibility<0) {
-		// no result!
+  int pins[2] = { pinA, pinB };
+  int compatibility = checkPermutations(2, pins, checkPeripheralPermutationCompatible);
+  if (compatibility<0) {
+    // no result!
 #ifdef SIMPLEFOC_SAMD_DEBUG
-		Serial.println("Bad combination!");
+    Serial.println("Bad combination!");
 #endif
-		return;
-	}
+    return;
+  }
 
-	tccConfiguration tccConfs[2] = { getTCCChannelNr(pinA, (compatibility>>0&0x01)==0x1),
-								     getTCCChannelNr(pinB, (compatibility>>1&0x01)==0x1) };
+  tccConfiguration tccConfs[2] = { getTCCChannelNr(pinA, (compatibility>>0&0x01)==0x1),
+                     getTCCChannelNr(pinB, (compatibility>>1&0x01)==0x1) };
 
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.print("Found configuration: (score=");
-	Serial.print(scorePermutation(tccConfs, 2));
-	Serial.println(")");
-	printTCCConfiguration(tccConfs[0]);
-	printTCCConfiguration(tccConfs[1]);
+  Serial.print("Found configuration: (score=");
+  Serial.print(scorePermutation(tccConfs, 2));
+  Serial.println(")");
+  printTCCConfiguration(tccConfs[0]);
+  printTCCConfiguration(tccConfs[1]);
 #endif
 
-	// attach pins to timer peripherals
-	attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
-	attachTCC(tccConfs[1]);
+  // attach pins to timer peripherals
+  attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
+  attachTCC(tccConfs[1]);
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Attached pins...");
+  Serial.println("Attached pins...");
 #endif
 
-	// set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
-	// e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
-	configureSAMDClock();
+  // set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
+  // e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
+  configureSAMDClock();
 
-	// configure the TCC (waveform, top-value, pre-scaler = frequency)
-	configureTCC(tccConfs[0], pwm_frequency);
-	configureTCC(tccConfs[1], pwm_frequency);
+  // configure the TCC (waveform, top-value, pre-scaler = frequency)
+  configureTCC(tccConfs[0], pwm_frequency);
+  configureTCC(tccConfs[1], pwm_frequency);
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Configured TCCs...");
+  Serial.println("Configured TCCs...");
 #endif
 
-	return; // Someone with a stepper-setup who can test it?
+  return; // Someone with a stepper-setup who can test it?
 }
 
 
@@ -602,50 +602,50 @@ void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
  */
 void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	printAllPinInfos();
+  printAllPinInfos();
 #endif
-	int pins[3] = { pinA, pinB, pinC };
-	int compatibility = checkPermutations(3, pins, checkPeripheralPermutationCompatible);
-	if (compatibility<0) {
-		// no result!
+  int pins[3] = { pinA, pinB, pinC };
+  int compatibility = checkPermutations(3, pins, checkPeripheralPermutationCompatible);
+  if (compatibility<0) {
+    // no result!
 #ifdef SIMPLEFOC_SAMD_DEBUG
-		Serial.println("Bad combination!");
+    Serial.println("Bad combination!");
 #endif
-		return;
-	}
+    return;
+  }
 
-	tccConfiguration tccConfs[3] = { getTCCChannelNr(pinA, (compatibility>>0&0x01)==0x1),
-									 getTCCChannelNr(pinB, (compatibility>>1&0x01)==0x1),
-								     getTCCChannelNr(pinC, (compatibility>>2&0x01)==0x1) };
+  tccConfiguration tccConfs[3] = { getTCCChannelNr(pinA, (compatibility>>0&0x01)==0x1),
+                   getTCCChannelNr(pinB, (compatibility>>1&0x01)==0x1),
+                     getTCCChannelNr(pinC, (compatibility>>2&0x01)==0x1) };
 
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.print("Found configuration: (score=");
-	Serial.print(scorePermutation(tccConfs, 3));
-	Serial.println(")");
-	printTCCConfiguration(tccConfs[0]);
-	printTCCConfiguration(tccConfs[1]);
-	printTCCConfiguration(tccConfs[2]);
-#endif
-
-	// attach pins to timer peripherals
-	attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
-	attachTCC(tccConfs[1]);
-	attachTCC(tccConfs[2]);
-#ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Attached pins...");
+  Serial.print("Found configuration: (score=");
+  Serial.print(scorePermutation(tccConfs, 3));
+  Serial.println(")");
+  printTCCConfiguration(tccConfs[0]);
+  printTCCConfiguration(tccConfs[1]);
+  printTCCConfiguration(tccConfs[2]);
 #endif
 
-	// set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
-	// e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
-	configureSAMDClock();
-
-	// configure the TCC (waveform, top-value, pre-scaler = frequency)
-	configureTCC(tccConfs[0], pwm_frequency);
-	configureTCC(tccConfs[1], pwm_frequency);
-	configureTCC(tccConfs[2], pwm_frequency);
+  // attach pins to timer peripherals
+  attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
+  attachTCC(tccConfs[1]);
+  attachTCC(tccConfs[2]);
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Configured TCCs...");
+  Serial.println("Attached pins...");
+#endif
+
+  // set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
+  // e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
+  configureSAMDClock();
+
+  // configure the TCC (waveform, top-value, pre-scaler = frequency)
+  configureTCC(tccConfs[0], pwm_frequency);
+  configureTCC(tccConfs[1], pwm_frequency);
+  configureTCC(tccConfs[2], pwm_frequency);
+#ifdef SIMPLEFOC_SAMD_DEBUG
+  Serial.println("Configured TCCs...");
 #endif
 
 }
@@ -670,57 +670,57 @@ void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const in
  */
 void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	printAllPinInfos();
+  printAllPinInfos();
 #endif
-	int pins[4] = { pin1A, pin1B, pin2A, pin2B };
-	int compatibility = checkPermutations(4, pins, checkPeripheralPermutationCompatible);
-	if (compatibility<0) {
-		// no result!
+  int pins[4] = { pin1A, pin1B, pin2A, pin2B };
+  int compatibility = checkPermutations(4, pins, checkPeripheralPermutationCompatible);
+  if (compatibility<0) {
+    // no result!
 #ifdef SIMPLEFOC_SAMD_DEBUG
-		Serial.println("Bad combination!");
+    Serial.println("Bad combination!");
 #endif
-		return;
-	}
+    return;
+  }
 
-	tccConfiguration tccConfs[4] = { getTCCChannelNr(pin1A, (compatibility>>0&0x01)==0x1),
-									getTCCChannelNr(pin1B, (compatibility>>1&0x01)==0x1),
-									getTCCChannelNr(pin2A, (compatibility>>2&0x01)==0x1),
-									getTCCChannelNr(pin2B, (compatibility>>3&0x01)==0x1) };
+  tccConfiguration tccConfs[4] = { getTCCChannelNr(pin1A, (compatibility>>0&0x01)==0x1),
+                  getTCCChannelNr(pin1B, (compatibility>>1&0x01)==0x1),
+                  getTCCChannelNr(pin2A, (compatibility>>2&0x01)==0x1),
+                  getTCCChannelNr(pin2B, (compatibility>>3&0x01)==0x1) };
 
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.print("Found configuration: (score=");
-	Serial.print(scorePermutation(tccConfs, 4));
-	Serial.println(")");
-	printTCCConfiguration(tccConfs[0]);
-	printTCCConfiguration(tccConfs[1]);
-	printTCCConfiguration(tccConfs[2]);
-	printTCCConfiguration(tccConfs[3]);
+  Serial.print("Found configuration: (score=");
+  Serial.print(scorePermutation(tccConfs, 4));
+  Serial.println(")");
+  printTCCConfiguration(tccConfs[0]);
+  printTCCConfiguration(tccConfs[1]);
+  printTCCConfiguration(tccConfs[2]);
+  printTCCConfiguration(tccConfs[3]);
 #endif
 
-	// attach pins to timer peripherals
-	attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
-	attachTCC(tccConfs[1]);
-	attachTCC(tccConfs[2]);
-	attachTCC(tccConfs[3]);
+  // attach pins to timer peripherals
+  attachTCC(tccConfs[0]); // in theory this can fail, but there is no way to signal it...
+  attachTCC(tccConfs[1]);
+  attachTCC(tccConfs[2]);
+  attachTCC(tccConfs[3]);
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Attached pins...");
+  Serial.println("Attached pins...");
 #endif
 
-	// set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
-	// e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
-	configureSAMDClock();
+  // set up clock - Note: if we did this right it should be possible to get all TCC units synchronized?
+  // e.g. attach all the timers, start them, and then start the clock... but this would require API-changes in SimpleFOC...
+  configureSAMDClock();
 
-	// configure the TCC (waveform, top-value, pre-scaler = frequency)
-	configureTCC(tccConfs[0], pwm_frequency);
-	configureTCC(tccConfs[1], pwm_frequency);
-	configureTCC(tccConfs[2], pwm_frequency);
-	configureTCC(tccConfs[3], pwm_frequency);
+  // configure the TCC (waveform, top-value, pre-scaler = frequency)
+  configureTCC(tccConfs[0], pwm_frequency);
+  configureTCC(tccConfs[1], pwm_frequency);
+  configureTCC(tccConfs[2], pwm_frequency);
+  configureTCC(tccConfs[3], pwm_frequency);
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Configured TCCs...");
+  Serial.println("Configured TCCs...");
 #endif
 
-	return; // Someone with a stepper-setup who can test it?
+  return; // Someone with a stepper-setup who can test it?
 }
 
 
@@ -761,71 +761,71 @@ void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const 
  * @return 0 if config good, -1 if failed
  */
 int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
-	// we want to use a TCC channel with 1 non-inverted and 1 inverted output for each phase, with dead-time insertion
+  // we want to use a TCC channel with 1 non-inverted and 1 inverted output for each phase, with dead-time insertion
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	printAllPinInfos();
+  printAllPinInfos();
 #endif
-	int compatibility = checkHardware6PWM(pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
-	if (compatibility<0) {
-		compatibility = checkSoftware6PWM(pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
-		if (compatibility<0) {
-			// no result!
+  int compatibility = checkHardware6PWM(pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
+  if (compatibility<0) {
+    compatibility = checkSoftware6PWM(pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
+    if (compatibility<0) {
+      // no result!
 #ifdef SIMPLEFOC_SAMD_DEBUG
-			Serial.println("Bad combination!");
+      Serial.println("Bad combination!");
 #endif
-			return -1;
-		}
-	}
+      return -1;
+    }
+  }
 
-	tccConfiguration pinAh = getTCCChannelNr(pinA_h, (compatibility>>0&0x01)==0x1);
-	tccConfiguration pinAl = getTCCChannelNr(pinA_l, (compatibility>>1&0x01)==0x1);
-	tccConfiguration pinBh = getTCCChannelNr(pinB_h, (compatibility>>2&0x01)==0x1);
-	tccConfiguration pinBl = getTCCChannelNr(pinB_l, (compatibility>>3&0x01)==0x1);
-	tccConfiguration pinCh = getTCCChannelNr(pinC_h, (compatibility>>4&0x01)==0x1);
-	tccConfiguration pinCl = getTCCChannelNr(pinC_l, (compatibility>>5&0x01)==0x1);
+  tccConfiguration pinAh = getTCCChannelNr(pinA_h, (compatibility>>0&0x01)==0x1);
+  tccConfiguration pinAl = getTCCChannelNr(pinA_l, (compatibility>>1&0x01)==0x1);
+  tccConfiguration pinBh = getTCCChannelNr(pinB_h, (compatibility>>2&0x01)==0x1);
+  tccConfiguration pinBl = getTCCChannelNr(pinB_l, (compatibility>>3&0x01)==0x1);
+  tccConfiguration pinCh = getTCCChannelNr(pinC_h, (compatibility>>4&0x01)==0x1);
+  tccConfiguration pinCl = getTCCChannelNr(pinC_l, (compatibility>>5&0x01)==0x1);
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Found configuration: ");
-	printTCCConfiguration(pinAh);
-	printTCCConfiguration(pinAl);
-	printTCCConfiguration(pinBh);
-	printTCCConfiguration(pinBl);
-	printTCCConfiguration(pinCh);
-	printTCCConfiguration(pinCl);
-#endif
-
-	// attach pins to timer peripherals
-	bool allAttached = true;
-	allAttached |= attachTCC(pinAh); // in theory this can fail, but there is no way to signal it...
-	allAttached |= attachTCC(pinAl);
-	allAttached |= attachTCC(pinBh);
-	allAttached |= attachTCC(pinBl);
-	allAttached |= attachTCC(pinCh);
-	allAttached |= attachTCC(pinCl);
-	if (!allAttached)
-		return -1;
-#ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Attached pins...");
-#endif
-	// set up clock - if we did this right it should be possible to get all TCC units synchronized?
-	// e.g. attach all the timers, start them, and then start the clock... but this would require API changes in SimpleFOC driver API
-	configureSAMDClock();
-
-	// configure the TCC(s)
-	configureTCC(pinAh, pwm_frequency, false, (pinAh.tcc.chaninfo==pinAl.tcc.chaninfo)?dead_zone:-1);
-	if ((pinAh.tcc.chaninfo!=pinAl.tcc.chaninfo))
-		configureTCC(pinAl, pwm_frequency, true, -1.0);
-	configureTCC(pinBh, pwm_frequency, false, (pinBh.tcc.chaninfo==pinBl.tcc.chaninfo)?dead_zone:-1);
-	if ((pinBh.tcc.chaninfo!=pinBl.tcc.chaninfo))
-		configureTCC(pinBl, pwm_frequency, true, -1.0);
-	configureTCC(pinCh, pwm_frequency, false, (pinCh.tcc.chaninfo==pinCl.tcc.chaninfo)?dead_zone:-1);
-	if ((pinCh.tcc.chaninfo!=pinCl.tcc.chaninfo))
-		configureTCC(pinCl, pwm_frequency, true, -1.0);
-#ifdef SIMPLEFOC_SAMD_DEBUG
-	Serial.println("Configured TCCs...");
+  Serial.println("Found configuration: ");
+  printTCCConfiguration(pinAh);
+  printTCCConfiguration(pinAl);
+  printTCCConfiguration(pinBh);
+  printTCCConfiguration(pinBl);
+  printTCCConfiguration(pinCh);
+  printTCCConfiguration(pinCl);
 #endif
 
-	return 0;
+  // attach pins to timer peripherals
+  bool allAttached = true;
+  allAttached |= attachTCC(pinAh); // in theory this can fail, but there is no way to signal it...
+  allAttached |= attachTCC(pinAl);
+  allAttached |= attachTCC(pinBh);
+  allAttached |= attachTCC(pinBl);
+  allAttached |= attachTCC(pinCh);
+  allAttached |= attachTCC(pinCl);
+  if (!allAttached)
+    return -1;
+#ifdef SIMPLEFOC_SAMD_DEBUG
+  Serial.println("Attached pins...");
+#endif
+  // set up clock - if we did this right it should be possible to get all TCC units synchronized?
+  // e.g. attach all the timers, start them, and then start the clock... but this would require API changes in SimpleFOC driver API
+  configureSAMDClock();
+
+  // configure the TCC(s)
+  configureTCC(pinAh, pwm_frequency, false, (pinAh.tcc.chaninfo==pinAl.tcc.chaninfo)?dead_zone:-1);
+  if ((pinAh.tcc.chaninfo!=pinAl.tcc.chaninfo))
+    configureTCC(pinAl, pwm_frequency, true, -1.0);
+  configureTCC(pinBh, pwm_frequency, false, (pinBh.tcc.chaninfo==pinBl.tcc.chaninfo)?dead_zone:-1);
+  if ((pinBh.tcc.chaninfo!=pinBl.tcc.chaninfo))
+    configureTCC(pinBl, pwm_frequency, true, -1.0);
+  configureTCC(pinCh, pwm_frequency, false, (pinCh.tcc.chaninfo==pinCl.tcc.chaninfo)?dead_zone:-1);
+  if ((pinCh.tcc.chaninfo!=pinCl.tcc.chaninfo))
+    configureTCC(pinCl, pwm_frequency, true, -1.0);
+#ifdef SIMPLEFOC_SAMD_DEBUG
+  Serial.println("Configured TCCs...");
+#endif
+
+  return 0;
 }
 
 
@@ -840,11 +840,11 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
  * @param pinB  phase B hardware pin number
  */
 void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB) {
-	tccConfiguration* tccI = getTccPinConfiguration(pinA);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_a);
-	tccI = getTccPinConfiguration(pinB);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_b);
-	return;
+  tccConfiguration* tccI = getTccPinConfiguration(pinA);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_a);
+  tccI = getTccPinConfiguration(pinB);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_b);
+  return;
 }
 
 /**
@@ -860,13 +860,13 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB) {
  * @param pinC  phase C hardware pin number
  */
 void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC) {
-	tccConfiguration* tccI = getTccPinConfiguration(pinA);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_a);
-	tccI = getTccPinConfiguration(pinB);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_b);
-	tccI = getTccPinConfiguration(pinC);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_c);
-	return;
+  tccConfiguration* tccI = getTccPinConfiguration(pinA);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_a);
+  tccI = getTccPinConfiguration(pinB);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_b);
+  tccI = getTccPinConfiguration(pinC);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_c);
+  return;
 }
 
 
@@ -885,15 +885,15 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
  * @param pin2B  phase 2B hardware pin number
  */
 void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
-	tccConfiguration* tccI = getTccPinConfiguration(pin1A);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_1a);
-	tccI = getTccPinConfiguration(pin2A);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_2a);
-	tccI = getTccPinConfiguration(pin1B);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_1b);
-	tccI = getTccPinConfiguration(pin2B);
-	writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_2b);
-	return;
+  tccConfiguration* tccI = getTccPinConfiguration(pin1A);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_1a);
+  tccI = getTccPinConfiguration(pin2A);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_2a);
+  tccI = getTccPinConfiguration(pin1B);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_1b);
+  tccI = getTccPinConfiguration(pin2B);
+  writeSAMDDutyCycle(tccI->tcc.chaninfo, dc_2b);
+  return;
 }
 
 /**
@@ -920,40 +920,40 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
  *
  */
 void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-	tccConfiguration* tcc1 = getTccPinConfiguration(pinA_h);
-	tccConfiguration* tcc2 = getTccPinConfiguration(pinA_l);
-	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		// low-side on a different pin of same TCC - do dead-time in software...
-		float ls = dc_a+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_a);
-		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
-	}
-	else
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_a); // dead-time is done is hardware, no need to set low side pin explicitly
+  tccConfiguration* tcc1 = getTccPinConfiguration(pinA_h);
+  tccConfiguration* tcc2 = getTccPinConfiguration(pinA_l);
+  if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
+    // low-side on a different pin of same TCC - do dead-time in software...
+    float ls = dc_a+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+    if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_a);
+    writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
+  }
+  else
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_a); // dead-time is done is hardware, no need to set low side pin explicitly
 
-	tcc1 = getTccPinConfiguration(pinB_h);
-	tcc2 = getTccPinConfiguration(pinB_l);
-	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_b+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_b);
-		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
-	}
-	else
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_b);
+  tcc1 = getTccPinConfiguration(pinB_h);
+  tcc2 = getTccPinConfiguration(pinB_l);
+  if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
+    float ls = dc_b+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+    if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_b);
+    writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
+  }
+  else
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_b);
 
-	tcc1 = getTccPinConfiguration(pinC_h);
-	tcc2 = getTccPinConfiguration(pinC_l);
-	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_c+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_c);
-		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
-	}
-	else
-		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_c);
-	return;
+  tcc1 = getTccPinConfiguration(pinC_h);
+  tcc2 = getTccPinConfiguration(pinC_l);
+  if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
+    float ls = dc_c+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+    if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_c);
+    writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
+  }
+  else
+    writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_c);
+  return;
 }
 
 

--- a/src/drivers/hardware_specific/samd21_wo_associations.h
+++ b/src/drivers/hardware_specific/samd21_wo_associations.h
@@ -1,12 +1,12 @@
 
 
 struct wo_association {
-	EPortType port;
-	uint32_t pin;
-	ETCChannel tccE;
-	uint8_t woE;
-	ETCChannel tccF;
-	uint8_t woF;
+  EPortType port;
+  uint32_t pin;
+  ETCChannel tccE;
+  uint8_t woE;
+  ETCChannel tccF;
+  uint8_t woF;
 };
 
 
@@ -64,55 +64,55 @@ struct wo_association {
  */
 struct wo_association WO_associations[] = {
 
-		{ PORTA,  0, TCC2_CH0, 		0, NOT_ON_TIMER, 	0},
-		{ PORTA,  1, TCC2_CH1, 		1, NOT_ON_TIMER, 	0},
-		{ PORTA,  2, NOT_ON_TIMER, 	0, TCC3_CH0, 		0},
-		{ PORTA,  3, NOT_ON_TIMER,	0, TCC3_CH1, 		1},
-		// PB04, PB05, PB06, PB07 - no timers
-		{ PORTB,  8, TC4_CH0, 		0, TCC3_CH6, 		6},
-		{ PORTB,  9, TC4_CH1, 		1, TCC3_CH7, 		7},
-		{ PORTA,  4, TCC0_CH0, 		0, TCC3_CH2, 		2},
-		{ PORTA,  5, TCC0_CH1, 		1, TCC3_CH3, 		3},
-		{ PORTA,  6, TCC1_CH0, 		0, TCC3_CH4, 		4},
-		{ PORTA,  7, TCC1_CH1, 		1, TCC3_CH5, 		5},
-		{ PORTA,  8, TCC0_CH0, 		0, TCC1_CH2, 		2},
-		{ PORTA,  9, TCC0_CH1, 		1, TCC1_CH3, 		3},
-		{ PORTA, 10, TCC1_CH0, 		0, TCC0_CH2, 		2},
-		{ PORTA, 11, TCC1_CH1, 		1, TCC0_CH3, 		3},
-		{ PORTB, 10, TC5_CH0, 		0, TCC0_CH4, 		4},
-		{ PORTB, 11, TC5_CH1, 		1, TCC0_CH5, 		5},
-		{ PORTB, 12, TC4_CH0, 		0, TCC0_CH6, 		6},
-		{ PORTB, 13, TC4_CH1, 		1, TCC0_CH7, 		7},
-		{ PORTB, 14, TC5_CH0, 		0, NOT_ON_TIMER,	0},
-		{ PORTB, 15, TC5_CH1, 		1, NOT_ON_TIMER, 	0},
-		{ PORTA, 12, TCC2_CH0, 		0, TCC0_CH6, 		6},
-		{ PORTA, 13, TCC2_CH1, 		1, TCC0_CH7, 		7},
-		{ PORTA, 14, TC3_CH0, 		0, TCC0_CH4, 		4},
-		{ PORTA, 15, TC3_CH1, 		1, TCC0_CH5, 		5},
-		{ PORTA, 16, TCC2_CH0, 		0, TCC0_CH6, 		6},
-		{ PORTA, 17, TCC2_CH1, 		1, TCC0_CH7, 		7},
-		{ PORTA, 18, TC3_CH0, 		0, TCC0_CH2, 		2},
-		{ PORTA, 19, TC3_CH1, 		1, TCC0_CH3, 		3},
-		{ PORTB, 16, TC6_CH0, 		0, TCC0_CH4, 		4},
-		{ PORTB, 17, TC6_CH1, 		1, TCC0_CH5, 		5},
-		{ PORTA, 20, TC7_CH0, 		0, TCC0_CH6, 		6},
-		{ PORTA, 21, TC7_CH1, 		1, TCC0_CH7, 		7},
-		{ PORTA, 22, TC4_CH0, 		0, TCC0_CH4, 		4},
-		{ PORTA, 23, TC4_CH1, 		1, TCC0_CH5, 		5},
-		{ PORTA, 24, TC5_CH0, 		0, TCC1_CH2, 		2},
-		{ PORTA, 25, TC5_CH1, 		1, TCC1_CH3, 		3},
-		{ PORTB, 22, TC7_CH0, 		0, TCC3_CH0, 		0},
-		{ PORTB, 23, TC7_CH1, 		1, TCC3_CH1, 		1},
-		{ PORTA, 27, NOT_ON_TIMER, 	0, TCC3_CH6, 		6},
-		{ PORTA, 28, NOT_ON_TIMER, 	0, TCC3_CH7, 		7},
-		{ PORTA, 30, TCC1_CH0, 		0, TCC3_CH4, 		4},
-		{ PORTA, 31, TCC1_CH1, 		1, TCC3_CH5, 		5},
-		{ PORTB, 30, TCC0_CH0, 		0, TCC1_CH2, 		2},
-		{ PORTB, 31, TCC0_CH1, 		1, TCC1_CH3, 		3},
-		{ PORTB,  0, TC7_CH0, 		0, NOT_ON_TIMER, 	0},
-		{ PORTB,  1, TC7_CH1, 		1, NOT_ON_TIMER, 	0},
-		{ PORTB,  2, TC6_CH0, 		0, TCC3_CH2, 		2},
-		{ PORTB,  3, TC6_CH1, 		1, TCC3_CH3, 		3}
+    { PORTA,  0, TCC2_CH0,     0, NOT_ON_TIMER,   0},
+    { PORTA,  1, TCC2_CH1,     1, NOT_ON_TIMER,   0},
+    { PORTA,  2, NOT_ON_TIMER,   0, TCC3_CH0,     0},
+    { PORTA,  3, NOT_ON_TIMER,  0, TCC3_CH1,     1},
+    // PB04, PB05, PB06, PB07 - no timers
+    { PORTB,  8, TC4_CH0,     0, TCC3_CH6,     6},
+    { PORTB,  9, TC4_CH1,     1, TCC3_CH7,     7},
+    { PORTA,  4, TCC0_CH0,     0, TCC3_CH2,     2},
+    { PORTA,  5, TCC0_CH1,     1, TCC3_CH3,     3},
+    { PORTA,  6, TCC1_CH0,     0, TCC3_CH4,     4},
+    { PORTA,  7, TCC1_CH1,     1, TCC3_CH5,     5},
+    { PORTA,  8, TCC0_CH0,     0, TCC1_CH2,     2},
+    { PORTA,  9, TCC0_CH1,     1, TCC1_CH3,     3},
+    { PORTA, 10, TCC1_CH0,     0, TCC0_CH2,     2},
+    { PORTA, 11, TCC1_CH1,     1, TCC0_CH3,     3},
+    { PORTB, 10, TC5_CH0,     0, TCC0_CH4,     4},
+    { PORTB, 11, TC5_CH1,     1, TCC0_CH5,     5},
+    { PORTB, 12, TC4_CH0,     0, TCC0_CH6,     6},
+    { PORTB, 13, TC4_CH1,     1, TCC0_CH7,     7},
+    { PORTB, 14, TC5_CH0,     0, NOT_ON_TIMER,  0},
+    { PORTB, 15, TC5_CH1,     1, NOT_ON_TIMER,   0},
+    { PORTA, 12, TCC2_CH0,     0, TCC0_CH6,     6},
+    { PORTA, 13, TCC2_CH1,     1, TCC0_CH7,     7},
+    { PORTA, 14, TC3_CH0,     0, TCC0_CH4,     4},
+    { PORTA, 15, TC3_CH1,     1, TCC0_CH5,     5},
+    { PORTA, 16, TCC2_CH0,     0, TCC0_CH6,     6},
+    { PORTA, 17, TCC2_CH1,     1, TCC0_CH7,     7},
+    { PORTA, 18, TC3_CH0,     0, TCC0_CH2,     2},
+    { PORTA, 19, TC3_CH1,     1, TCC0_CH3,     3},
+    { PORTB, 16, TC6_CH0,     0, TCC0_CH4,     4},
+    { PORTB, 17, TC6_CH1,     1, TCC0_CH5,     5},
+    { PORTA, 20, TC7_CH0,     0, TCC0_CH6,     6},
+    { PORTA, 21, TC7_CH1,     1, TCC0_CH7,     7},
+    { PORTA, 22, TC4_CH0,     0, TCC0_CH4,     4},
+    { PORTA, 23, TC4_CH1,     1, TCC0_CH5,     5},
+    { PORTA, 24, TC5_CH0,     0, TCC1_CH2,     2},
+    { PORTA, 25, TC5_CH1,     1, TCC1_CH3,     3},
+    { PORTB, 22, TC7_CH0,     0, TCC3_CH0,     0},
+    { PORTB, 23, TC7_CH1,     1, TCC3_CH1,     1},
+    { PORTA, 27, NOT_ON_TIMER,   0, TCC3_CH6,     6},
+    { PORTA, 28, NOT_ON_TIMER,   0, TCC3_CH7,     7},
+    { PORTA, 30, TCC1_CH0,     0, TCC3_CH4,     4},
+    { PORTA, 31, TCC1_CH1,     1, TCC3_CH5,     5},
+    { PORTB, 30, TCC0_CH0,     0, TCC1_CH2,     2},
+    { PORTB, 31, TCC0_CH1,     1, TCC1_CH3,     3},
+    { PORTB,  0, TC7_CH0,     0, NOT_ON_TIMER,   0},
+    { PORTB,  1, TC7_CH1,     1, NOT_ON_TIMER,   0},
+    { PORTB,  2, TC6_CH0,     0, TCC3_CH2,     2},
+    { PORTB,  3, TC6_CH1,     1, TCC3_CH3,     3}
 };
 #define NUM_WO_ASSOCIATIONS 48
 
@@ -120,11 +120,11 @@ wo_association ASSOCIATION_NOT_FOUND = { NOT_A_PORT, 0, NOT_ON_TIMER, 0, NOT_ON_
 
 
 struct wo_association& getWOAssociation(EPortType port, uint32_t pin) {
-	for (int i=0;i<NUM_WO_ASSOCIATIONS;i++) {
-		if (WO_associations[i].port==port && WO_associations[i].pin==pin)
-			return WO_associations[i];
-	}
-	return ASSOCIATION_NOT_FOUND;
+  for (int i=0;i<NUM_WO_ASSOCIATIONS;i++) {
+    if (WO_associations[i].port==port && WO_associations[i].pin==pin)
+      return WO_associations[i];
+  }
+  return ASSOCIATION_NOT_FOUND;
 };
 
 

--- a/src/drivers/hardware_specific/samd_debug.h
+++ b/src/drivers/hardware_specific/samd_debug.h
@@ -16,91 +16,91 @@
  * saves you hours of cross-referencing with the datasheet.
  */
 void printAllPinInfos() {
-	Serial.println();
-	for (uint8_t pin=0;pin<PINS_COUNT;pin++) {
-		const PinDescription& pinDesc = g_APinDescription[pin];
-		wo_association& association = getWOAssociation(pinDesc.ulPort, pinDesc.ulPin);
-		Serial.print("Pin ");
-		if (pin<10) Serial.print("0");
-		Serial.print(pin);
-		switch (pinDesc.ulPort) {
-			case NOT_A_PORT: Serial.print("    "); break;
-			case PORTA: Serial.print("  PA"); break;
-			case PORTB: Serial.print("  PB"); break;
-			case PORTC: Serial.print("  PC"); break;
-		}
-		if (pinDesc.ulPin <10) Serial.print("0");
-		Serial.print(pinDesc.ulPin);
+  Serial.println();
+  for (uint8_t pin=0;pin<PINS_COUNT;pin++) {
+    const PinDescription& pinDesc = g_APinDescription[pin];
+    wo_association& association = getWOAssociation(pinDesc.ulPort, pinDesc.ulPin);
+    Serial.print("Pin ");
+    if (pin<10) Serial.print("0");
+    Serial.print(pin);
+    switch (pinDesc.ulPort) {
+      case NOT_A_PORT: Serial.print("    "); break;
+      case PORTA: Serial.print("  PA"); break;
+      case PORTB: Serial.print("  PB"); break;
+      case PORTC: Serial.print("  PC"); break;
+    }
+    if (pinDesc.ulPin <10) Serial.print("0");
+    Serial.print(pinDesc.ulPin);
 
-		Serial.print("  E=");
-		if (association.tccE>=0) {
-			int tcn = GetTCNumber(association.tccE);
-			if (tcn>=TCC_INST_NUM)
-				Serial.print("  TC");
-			else
-				Serial.print(" TCC");
-			Serial.print(tcn);
-			Serial.print("-");
-			Serial.print(GetTCChannelNumber(association.tccE));
-			Serial.print("[");
-			Serial.print(GetTCChannelNumber(association.woE));
-			Serial.print("]");
-		}
-		else
-			Serial.print("  None    ");
+    Serial.print("  E=");
+    if (association.tccE>=0) {
+      int tcn = GetTCNumber(association.tccE);
+      if (tcn>=TCC_INST_NUM)
+        Serial.print("  TC");
+      else
+        Serial.print(" TCC");
+      Serial.print(tcn);
+      Serial.print("-");
+      Serial.print(GetTCChannelNumber(association.tccE));
+      Serial.print("[");
+      Serial.print(GetTCChannelNumber(association.woE));
+      Serial.print("]");
+    }
+    else
+      Serial.print("  None    ");
 
-		Serial.print(" F=");
-		if (association.tccF>=0) {
-			int tcn = GetTCNumber(association.tccF);
-			if (tcn>=TCC_INST_NUM)
-				Serial.print("  TC");
-			else
-				Serial.print(" TCC");
-			Serial.print(tcn);
-			Serial.print("-");
-			Serial.print(GetTCChannelNumber(association.tccF));
-			Serial.print("[");
-			Serial.print(GetTCChannelNumber(association.woF));
-			Serial.println("]");
-		}
-		else
-			Serial.println("  None ");
+    Serial.print(" F=");
+    if (association.tccF>=0) {
+      int tcn = GetTCNumber(association.tccF);
+      if (tcn>=TCC_INST_NUM)
+        Serial.print("  TC");
+      else
+        Serial.print(" TCC");
+      Serial.print(tcn);
+      Serial.print("-");
+      Serial.print(GetTCChannelNumber(association.tccF));
+      Serial.print("[");
+      Serial.print(GetTCChannelNumber(association.woF));
+      Serial.println("]");
+    }
+    else
+      Serial.println("  None ");
 
-	}
-	Serial.println();
+  }
+  Serial.println();
 
-	//		uint32_t attr = pinDesc.ulPinAttribute;
-	//#ifdef PIN_ATTR_PWM //SAMD21
-	//		Serial.print("  PWM=");
-	//		Serial.print(((attr & PIN_ATTR_PWM) == PIN_ATTR_PWM));
-	//#endif
-	//#ifdef PIN_ATTR_PWM_E //SAMD51
-	//		Serial.print("  PWM_E=");
-	//		Serial.print(((attr & PIN_ATTR_PWM_E) == PIN_ATTR_PWM_E));
-	//		Serial.print("  PWM_F=");
-	//		Serial.print(((attr & PIN_ATTR_PWM_F) == PIN_ATTR_PWM_F));
-	//		Serial.print("  PWM_G=");
-	//		Serial.print(((attr & PIN_ATTR_PWM_G) == PIN_ATTR_PWM_G));
-	//#endif
-	//		Serial.print("  TIM=");
-	//		Serial.print(((attr & PIN_ATTR_TIMER) == PIN_ATTR_TIMER));
-	//		Serial.print("  ALT=");
-	//		Serial.print(((attr & PIN_ATTR_TIMER_ALT) == PIN_ATTR_TIMER_ALT));
+  //  uint32_t attr = pinDesc.ulPinAttribute;
+  //#ifdef PIN_ATTR_PWM //SAMD21
+  //  Serial.print("  PWM=");
+  //  Serial.print(((attr & PIN_ATTR_PWM) == PIN_ATTR_PWM));
+  //#endif
+  //#ifdef PIN_ATTR_PWM_E //SAMD51
+  //  Serial.print("  PWM_E=");
+  //  Serial.print(((attr & PIN_ATTR_PWM_E) == PIN_ATTR_PWM_E));
+  //  Serial.print("  PWM_F=");
+  //  Serial.print(((attr & PIN_ATTR_PWM_F) == PIN_ATTR_PWM_F));
+  //  Serial.print("  PWM_G=");
+  //  Serial.print(((attr & PIN_ATTR_PWM_G) == PIN_ATTR_PWM_G));
+  //#endif
+  //  Serial.print(((attr & PIN_ATTR_TIMER) == PIN_ATTR_TIMER));
+  //  Serial.print("  TIM=");
+  //  Serial.print("  ALT=");
+  //  Serial.print(((attr & PIN_ATTR_TIMER_ALT) == PIN_ATTR_TIMER_ALT));
 }
 
 void printTCCConfiguration(tccConfiguration& info) {
-	Serial.print(info.pin);
-	Serial.print((info.alternate==1)?" alternate TCC":" normal    TCC");
-	if (info.tcc.tccn>=0) {
-		Serial.print(info.tcc.tccn);
-		Serial.print("-");
-		Serial.print(info.tcc.chan);
-		Serial.print("[");
-		Serial.print(info.wo);
-		Serial.println("]");
-	}
-	else
-		Serial.println(" None");
+  Serial.print(info.pin);
+  Serial.print((info.alternate==1)?" alternate TCC":" normal    TCC");
+  if (info.tcc.tccn>=0) {
+    Serial.print(info.tcc.tccn);
+    Serial.print("-");
+    Serial.print(info.tcc.chan);
+    Serial.print("[");
+    Serial.print(info.wo);
+    Serial.println("]");
+  }
+  else
+    Serial.println(" None");
 }
 
 

--- a/src/sensors/Encoder.cpp
+++ b/src/sensors/Encoder.cpp
@@ -99,7 +99,7 @@ void Encoder::handleIndex() {
 }
 
 /*
-	Shaft angle calculation
+  Shaft angle calculation
 */
 float Encoder::getAngle(){
   return  _2PI * (pulse_counter) / ((float)cpr);

--- a/src/sensors/HallSensor.cpp
+++ b/src/sensors/HallSensor.cpp
@@ -93,7 +93,7 @@ void HallSensor::attachSectorCallback(void (*_onSectorChange)(int sector)) {
 }
 
 /*
-	Shaft angle calculation
+  Shaft angle calculation
 */
 float HallSensor::getAngle() {
   return ((electric_rotations * 6 + electric_sector) / cpr) * _2PI ;

--- a/src/sensors/MagneticSensorAnalog.cpp
+++ b/src/sensors/MagneticSensorAnalog.cpp
@@ -24,13 +24,13 @@ MagneticSensorAnalog::MagneticSensorAnalog(uint8_t _pinAnalog, int _min_raw_coun
 
 void MagneticSensorAnalog::init(){
 
-	// velocity calculation init
-	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+  // velocity calculation init
+  angle_prev = 0;
+  velocity_calc_timestamp = _micros(); 
 
-	// full rotations tracking number
-	full_rotation_offset = 0;
-	raw_count_prev = getRawCount();  
+  // full rotations tracking number
+  full_rotation_offset = 0;
+  raw_count_prev = getRawCount();  
 }
 
 //  Shaft angle calculation
@@ -68,5 +68,5 @@ float MagneticSensorAnalog::getVelocity(){
 
 // function reading the raw counter of the magnetic sensor
 int MagneticSensorAnalog::getRawCount(){
-	return analogRead(pinAnalog);
+  return analogRead(pinAnalog);
 }

--- a/src/sensors/MagneticSensorI2C.cpp
+++ b/src/sensors/MagneticSensorI2C.cpp
@@ -65,13 +65,13 @@ void MagneticSensorI2C::init(TwoWire* _wire){
   // I2C communication begin
   wire->begin();
 
-	// velocity calculation init
-	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+  // velocity calculation init
+  angle_prev = 0;
+  velocity_calc_timestamp = _micros(); 
 
-	// full rotations tracking number
-	full_rotation_offset = 0;
-	angle_data_prev = getRawCount();  
+  // full rotations tracking number
+  full_rotation_offset = 0;
+  angle_data_prev = getRawCount();  
 }
 
 //  Shaft angle calculation
@@ -116,7 +116,7 @@ float MagneticSensorI2C::getVelocity(){
 
 // function reading the raw counter of the magnetic sensor
 int MagneticSensorI2C::getRawCount(){
-	return (int)MagneticSensorI2C::read(angle_register_msb);
+  return (int)MagneticSensorI2C::read(angle_register_msb);
 }
 
 // I2C functions 
@@ -127,26 +127,26 @@ int MagneticSensorI2C::getRawCount(){
 */
 int MagneticSensorI2C::read(uint8_t angle_reg_msb) {
   // read the angle register first MSB then LSB
-	byte readArray[2];
-	uint16_t readValue = 0;
+  byte readArray[2];
+  uint16_t readValue = 0;
   // notify the device that is aboout to be read
-	wire->beginTransmission(chip_address);
-	wire->write(angle_reg_msb);
+  wire->beginTransmission(chip_address);
+  wire->write(angle_reg_msb);
   wire->endTransmission(false);
   
   // read the data msb and lsb
-	wire->requestFrom(chip_address, (uint8_t)2);
-	for (byte i=0; i < 2; i++) {
-		readArray[i] = wire->read();
-	}
+  wire->requestFrom(chip_address, (uint8_t)2);
+  for (byte i=0; i < 2; i++) {
+    readArray[i] = wire->read();
+  }
 
   // depending on the sensor architecture there are different combinations of 
   // LSB and MSB register used bits
   // AS5600 uses 0..7 LSB and 8..11 MSB
   // AS5048 uses 0..5 LSB and 6..13 MSB
   readValue = ( readArray[1] &  lsb_mask );
-	readValue += ( ( readArray[0] & msb_mask ) << lsb_used );
-	return readValue;
+  readValue += ( ( readArray[0] & msb_mask ) << lsb_used );
+  return readValue;
 }
 
 /*

--- a/src/sensors/MagneticSensorSPI.cpp
+++ b/src/sensors/MagneticSensorSPI.cpp
@@ -65,28 +65,28 @@ void MagneticSensorSPI::init(SPIClass* _spi){
 
   spi = _spi;
 
-	// 1MHz clock (AMS should be able to accept up to 10MHz)
-	settings = SPISettings(clock_speed, MSBFIRST, spi_mode);
+  // 1MHz clock (AMS should be able to accept up to 10MHz)
+  settings = SPISettings(clock_speed, MSBFIRST, spi_mode);
 
-	//setup pins
-	pinMode(chip_select_pin, OUTPUT);
+  //setup pins
+  pinMode(chip_select_pin, OUTPUT);
   
-	//SPI has an internal SPI-device counter, it is possible to call "begin()" from different devices
-	spi->begin();
+  //SPI has an internal SPI-device counter, it is possible to call "begin()" from different devices
+  spi->begin();
 #ifndef ESP_H // if not ESP32 board
-	spi->setBitOrder(MSBFIRST); // Set the SPI_1 bit order
-	spi->setDataMode(spi_mode) ;
-	spi->setClockDivider(SPI_CLOCK_DIV8);
+  spi->setBitOrder(MSBFIRST); // Set the SPI_1 bit order
+  spi->setDataMode(spi_mode) ;
+  spi->setClockDivider(SPI_CLOCK_DIV8);
 #endif
 
-	digitalWrite(chip_select_pin, HIGH);
-	// velocity calculation init
-	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+  digitalWrite(chip_select_pin, HIGH);
+  // velocity calculation init
+  angle_prev = 0;
+  velocity_calc_timestamp = _micros(); 
 
-	// full rotations tracking number
-	full_rotation_offset = 0;
-	angle_data_prev = getRawCount();  
+  // full rotations tracking number
+  full_rotation_offset = 0;
+  angle_data_prev = getRawCount();  
 }
 
 //  Shaft angle calculation
@@ -132,7 +132,7 @@ float MagneticSensorSPI::getVelocity(){
 
 // function reading the raw counter of the magnetic sensor
 int MagneticSensorSPI::getRawCount(){
-	return (int)MagneticSensorSPI::read(angle_register);
+  return (int)MagneticSensorSPI::read(angle_register);
 }
 
 // SPI functions 
@@ -140,15 +140,15 @@ int MagneticSensorSPI::getRawCount(){
  * Utility function used to calculate even parity of word
  */
 byte MagneticSensorSPI::spiCalcEvenParity(word value){
-	byte cnt = 0;
-	byte i;
+  byte cnt = 0;
+  byte i;
 
-	for (i = 0; i < 16; i++)
-	{
-		if (value & 0x1) cnt++;
-		value >>= 1;
-	}
-	return cnt & 0x1;
+  for (i = 0; i < 16; i++)
+  {
+    if (value & 0x1) cnt++;
+    value >>= 1;
+  }
+  return cnt & 0x1;
 }
 
   /*
@@ -164,8 +164,8 @@ word MagneticSensorSPI::read(word angle_register){
     command = angle_register | (1 << command_rw_bit);
   }
   if (command_parity_bit > 0) {
-   	//Add a parity bit on the the MSB
-  	command |= ((word)spiCalcEvenParity(command) << command_parity_bit);
+     //Add a parity bit on the the MSB
+    command |= ((word)spiCalcEvenParity(command) << command_parity_bit);
   }
 
 #if !defined(_STM32_DEF_) // if not stm chips
@@ -202,7 +202,7 @@ word MagneticSensorSPI::read(word angle_register){
 
   const static word data_mask = 0xFFFF >> (16 - bit_resolution);
 
-	return register_value & data_mask;  // Return the data, stripping the non data (e.g parity) bits
+  return register_value & data_mask;  // Return the data, stripping the non data (e.g parity) bits
 }
 
 /**
@@ -210,5 +210,5 @@ word MagneticSensorSPI::read(word angle_register){
  * SPI has an internal SPI-device counter, for each init()-call the close() function must be called exactly 1 time
  */
 void MagneticSensorSPI::close(){
-	spi->end();
+  spi->end();
 }

--- a/src/sensors/MagneticSensorSPI.h
+++ b/src/sensors/MagneticSensorSPI.h
@@ -58,7 +58,7 @@ class MagneticSensorSPI: public Sensor{
     // spi variables
     int angle_register; //!< SPI angle register to read
     int chip_select_pin; //!< SPI chip select pin
-	  SPISettings settings; //!< SPI settings variable
+    SPISettings settings; //!< SPI settings variable
     // spi functions
     /** Stop SPI communication */
     void close(); 


### PR DESCRIPTION
I found that the tab and space are mixed in the code, resulting in some code formats that are not very uniform. According to observations, most of the indentation is two spaces, so I replaced some tabs with two spaces.

example: [here](https://github.com/simplefoc/Arduino-FOC/blob/master/src/StepperMotor.h#L44)