### PR TITLE
Issue #46: motor.command() and CRLF

### DIFF
--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -1,11 +1,14 @@
 #include "Commander.h"
 
 
-Commander::Commander(Stream& serial){
+Commander::Commander(Stream& serial, char eol, bool echo){
   com_port = &serial;
+  this->eol = eol;
+  this->echo = echo;
 }
-Commander::Commander(){
-  // do nothing
+Commander::Commander(char eol, bool echo){
+  this->eol = eol;
+  this->echo = echo;
 }
 
 
@@ -19,33 +22,24 @@ void Commander::add(char id, CommandCallback onCommand, char* label ){
 
 void Commander::run(){
   if(!com_port) return;
-  // a string to hold incoming data
-  while (com_port->available()) {
-    // get the new byte:
-    received_chars[rec_cnt] = (char)com_port->read();
-    // end of user input
-    if (received_chars[rec_cnt++] == '\n') {
-      // execute the user command
-      run(received_chars);
-
-      // reset the command buffer
-      received_chars[0] = 0;
-      rec_cnt=0;
-    }
-  }
+  run(*com_port, eol);
 }
 
-void Commander::run(Stream& serial){
+void Commander::run(Stream& serial, char eol){
   Stream* tmp = com_port; // save the serial instance
-  // use the new serial instance to output if not available the one linked in constructor
-  if(!tmp) com_port = &serial;
+  char eol_tmp = this->eol;
+  this->eol = eol;
+  com_port = &serial;
 
   // a string to hold incoming data
   while (serial.available()) {
     // get the new byte:
-    received_chars[rec_cnt] = (char)serial.read();
+    int ch = serial.read();
+    received_chars[rec_cnt++] = (char)ch;
     // end of user input
-    if (received_chars[rec_cnt++] == '\n') {
+    if(echo)
+      print((char)ch);
+    if (isSentinel(ch)) {
       // execute the user command
       run(received_chars);
 
@@ -56,11 +50,15 @@ void Commander::run(Stream& serial){
   }
 
   com_port = tmp; // reset the instance to the internal value
+   this->eol = eol_tmp;
 }
 
 void Commander::run(char* user_input){
   // execute the user command
   char id = user_input[0];
+
+
+
   switch(id){
     case CMD_SCAN:
       for(int i=0; i < call_count; i++){
@@ -71,7 +69,7 @@ void Commander::run(char* user_input){
       }
       break;
     case CMD_VERBOSE:
-      if(user_input[1] != '\n') verbose = (VerboseMode)atoi(&user_input[1]);
+      if(user_input[1] != eol) verbose = (VerboseMode)atoi(&user_input[1]);
       printVerbose(F("Verb:"));
       switch (verbose){
       case VerboseMode::nothing:
@@ -84,7 +82,7 @@ void Commander::run(char* user_input){
       }
       break;
     case CMD_DECIMAL:
-      if(user_input[1] != '\n') decimal_places = atoi(&user_input[1]);
+      if(user_input[1] != eol) decimal_places = atoi(&user_input[1]);
       printVerbose(F("Decimal:"));
       println(decimal_places);
       break;
@@ -105,7 +103,7 @@ void Commander::motor(FOCMotor* motor, char* user_command) {
   char sub_cmd = user_command[1];
   int value_index = (sub_cmd >= 'A'  && sub_cmd <= 'Z') ?  2 :  1;
   // check if get command
-  bool GET = user_command[value_index] == '\n';
+  bool GET = isSentinel(user_command[value_index]);
   // parse command values
   float  value  = atof(&user_command[value_index]);
 
@@ -306,7 +304,7 @@ void Commander::motor(FOCMotor* motor, char* user_command) {
         case SCMD_SET:
           if(!GET) motor->monitor_variables = (uint8_t) 0;
           for(int i = 0; i < 7; i++){
-            if(user_command[value_index+i] == '\n') break;
+            if(isSentinel(user_command[value_index+i])) break;
             if(!GET) motor->monitor_variables |=  (user_command[value_index+i] - '0') << (6-i);
             print( (user_command[value_index+i] - '0') );
           }
@@ -326,7 +324,7 @@ void Commander::motor(FOCMotor* motor, char* user_command) {
 
 void Commander::pid(PIDController* pid, char* user_cmd){
   char cmd = user_cmd[0];
-  bool GET  = user_cmd[1] == '\n';
+  bool GET  = isSentinel(user_cmd[1]);
   float value = atof(&user_cmd[1]);
 
   switch (cmd){
@@ -363,7 +361,7 @@ void Commander::pid(PIDController* pid, char* user_cmd){
 
 void Commander::lpf(LowPassFilter* lpf, char* user_cmd){
   char cmd = user_cmd[0];
-  bool GET  = user_cmd[1] == '\n';
+  bool GET  = isSentinel(user_cmd[1]);
   float value = atof(&user_cmd[1]);
 
   switch (cmd){
@@ -379,11 +377,26 @@ void Commander::lpf(LowPassFilter* lpf, char* user_cmd){
 }
 
 void Commander::scalar(float* value,  char* user_cmd){
-  bool GET  = user_cmd[0] == '\n';
+  bool GET  = isSentinel(user_cmd[0]);
   if(!GET) *value = atof(user_cmd);
   println(*value);
 }
 
+bool Commander::isSentinel(char ch)
+{
+  if(ch == eol)
+    return true;
+  else if (ch == '\r')
+  {
+    if(verbose == VerboseMode::user_friendly)
+    {
+      print(F("Warning! \\r detected but is not configured as end of line sentinel, which is configured as ascii code '"));
+      print(int(eol));
+      print("'\n");
+    }
+  }
+  return false;
+}
 
 void Commander::print(const int number){
   if( !com_port || verbose == VerboseMode::nothing ) return;

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -69,7 +69,7 @@ void Commander::run(char* user_input){
       }
       break;
     case CMD_VERBOSE:
-      if(user_input[1] != eol) verbose = (VerboseMode)atoi(&user_input[1]);
+      if(!isSentinel(user_input[1])) verbose = (VerboseMode)atoi(&user_input[1]);
       printVerbose(F("Verb:"));
       switch (verbose){
       case VerboseMode::nothing:
@@ -82,7 +82,7 @@ void Commander::run(char* user_input){
       }
       break;
     case CMD_DECIMAL:
-      if(user_input[1] != eol) decimal_places = atoi(&user_input[1]);
+      if(!isSentinel(user_input[1])) decimal_places = atoi(&user_input[1]);
       printVerbose(F("Decimal:"));
       println(decimal_places);
       break;

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -38,9 +38,11 @@ class Commander
      * Also if the function run() is used it uses this serial instance to read the serial for user commands
      * 
      * @param serial - Serial com port instance
+     * @param eol - the end of line sentinel character
+     * @param echo - echo last typed character (for command line feedback)
      */
-    Commander(Stream &serial);
-    Commander();
+    Commander(Stream &serial, char eol = '\n', bool echo = false);
+    Commander(char eol = '\n', bool echo = false);
 
     /**
      * Function reading the serial port and firing callbacks that have been added to the commander 
@@ -61,9 +63,10 @@ class Commander
      *    '#' - Number of decimal places
      *    '?' - Scan command - displays all the labels of attached nodes
      * 
-     * @param reader - Stream to read user input
+     * @param reader - temporary stream to read user input
+     * @param eol - temporary end of line sentinel
      */ 
-    void run(Stream &reader);
+    void run(Stream &reader, char eol = '\n');
     /**
      * Function reading the string of user input and firing callbacks that have been added to the commander 
      * once the user has requested them - when he sends the command  
@@ -91,7 +94,8 @@ class Commander
 
     // monitoring functions
     Stream* com_port = nullptr; //!< Serial terminal variable if provided
-    
+    char eol = '\n'; //!< end of line sentinel character
+    bool echo = false; //!< echo last typed character (for command line feedback)
     /**
      * 
      * FOC motor (StepperMotor and BLDCMotor) command interface
@@ -194,6 +198,7 @@ class Commander
      *  @param message - number to be printed
      *  @param newline - if needs lewline (1) otherwise (0)
      */
+
     void print(const float number);
     void print(const int number);
     void print(const char* message);
@@ -206,6 +211,7 @@ class Commander
     void println(const char message);
 
     void printError();
+    bool isSentinel(char ch);
 };
 
 


### PR DESCRIPTION
The eol character is now configurable
The user can now actuvate echo feedback to see what he is typing
I also removed a duplication in two run() overload, while fixing what I think was a mistake by enforcing the use of the provided argument Stream& even if the ctor one is not null.
Lastly, I warn the user if \n is configured but \r is detected (only in user friendly mode)
All the past code should work as before (no API change required)