### PR TITLE
Dev

### DIFF
--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -32,6 +32,10 @@ void Commander::run(){
       received_chars[0] = 0;
       rec_cnt=0;
     }
+    if (rec_cnt>=MAX_COMMAND_LENGTH) { // prevent buffer overrun if message is too long
+        received_chars[0] = 0;
+        rec_cnt=0;
+    }
   }
 }
 

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -7,6 +7,10 @@
 #include "../common/lowpass_filter.h"
 #include "commands.h"
 
+
+#define MAX_COMMAND_LENGTH 20
+
+
 // Commander verbose display to the user type
 enum VerboseMode{
   nothing = 0,   // display nothing - good for monitoring
@@ -174,7 +178,7 @@ class Commander
     int call_count = 0;//!< number callbacks that are subscribed
 
     // helping variable for serial communication reading
-    char received_chars[20] = {0}; //!< so far received user message - waiting for newline
+    char received_chars[MAX_COMMAND_LENGTH] = {0}; //!< so far received user message - waiting for newline
     int rec_cnt = 0; //!< number of characters receives
         
     // serial printing functions


### PR DESCRIPTION
Simple fix to prevent buffer overruns (and crashes) if other side sends commands which are too long.