### PR TITLE
Use float instead of double for constants to improve speed

### DIFF
--- a/examples/hardware_specific_examples/Bluepill_examples/encoder/bluepill_position_control/bluepill_position_control.ino
+++ b/examples/hardware_specific_examples/Bluepill_examples/encoder/bluepill_position_control/bluepill_position_control.ino
@@ -1,9 +1,9 @@
 /**
- * 
+ *
  * STM32 Bluepill position motion control example with encoder
- * 
+ *
  * The same example can be ran with any STM32 board - just make sure that put right pin numbers.
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -32,10 +32,10 @@ void doTarget(char* cmd) { command.scalar(&target_angle, cmd); }
 
 
 void setup() {
-  
+
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB, doI); 
+  encoder.enableInterrupts(doA, doB, doI);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -54,20 +54,20 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // default voltage_power_supply
   motor.voltage_limit = 6;
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
- 
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 20;
@@ -75,11 +75,11 @@ void setup() {
   motor.velocity_limit = 4;
 
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
-  
+
   // initialize motor
   motor.init();
   // align encoder and start FOC
@@ -97,7 +97,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -109,7 +109,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/hardware_specific_examples/Bluepill_examples/magnetic_sensor/bluepill_position_control/bluepill_position_control.ino
+++ b/examples/hardware_specific_examples/Bluepill_examples/magnetic_sensor/bluepill_position_control/bluepill_position_control.ino
@@ -1,9 +1,9 @@
 /**
- * 
+ *
  * STM32 Bluepill position motion control example with magnetic sensor
- * 
+ *
  * The same example can be ran with any STM32 board - just make sure that put right pin numbers.
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -47,37 +47,37 @@ void setup() {
   driver.init();
   // link the motor and the driver
   motor.linkDriver(&driver);
-  
+
   // choose FOC modulation (optional)
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // maximal voltage to be set to the motor
   motor.voltage_limit = 6;
-  
+
   // velocity low pass filtering time constant
   // the lower the less filtered
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
-  // angle P controller 
+  // angle P controller
   motor.P_angle.P = 20;
   // maximal velocity of the position control
   motor.velocity_limit = 40;
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
 
-  
+
   // initialize motor
   motor.init();
   // align sensor and start FOC
@@ -99,7 +99,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -112,7 +112,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/hardware_specific_examples/DRV8302_driver/3pwm_example/encoder/full_control_serial/full_control_serial.ino
+++ b/examples/hardware_specific_examples/DRV8302_driver/3pwm_example/encoder/full_control_serial/full_control_serial.ino
@@ -1,15 +1,15 @@
 /**
  * Comprehensive BLDC motor control example using encoder and the DRV8302 board
- * 
+ *
  * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
  * - configure PID controller constants
  * - change motion control loops
  * - monitor motor variabels
  * - set target values
- * - check all the configuration values 
- * 
+ * - check all the configuration values
+ *
  * check the https://docs.simplefoc.com for full list of motor commands
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -20,7 +20,7 @@
 #define INH_C 11
 
 #define EN_GATE 7
-#define M_PWM A1 
+#define M_PWM A1
 #define M_OC A2
 #define OC_ADJ A3
 
@@ -45,7 +45,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -76,14 +76,14 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.2;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // default voltage_power_supply
   motor.voltage_limit = 12;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -111,7 +111,7 @@ void setup() {
   Serial.println(F("Run user commands to configure and the motor (find the full command list in docs.simplefoc.com) \n "));
   Serial.println(F("Initial motion control loop is voltage loop."));
   Serial.println(F("Initial target voltage 2V."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/DRV8302_driver/6pwm_example/encoder/full_control_serial/full_control_serial.ino
+++ b/examples/hardware_specific_examples/DRV8302_driver/6pwm_example/encoder/full_control_serial/full_control_serial.ino
@@ -1,15 +1,15 @@
 /**
  * Comprehensive BLDC motor control example using encoder and the DRV8302 board
- * 
+ *
  * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
  * - configure PID controller constants
  * - change motion control loops
  * - monitor motor variabels
  * - set target values
- * - check all the configuration values 
- * 
+ * - check all the configuration values
+ *
  * check the https://docs.simplefoc.com for full list of motor commands
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -23,7 +23,7 @@
 #define INL_C 10
 
 #define EN_GATE 7
-#define M_PWM A1 
+#define M_PWM A1
 #define M_OC A2
 #define OC_ADJ A3
 
@@ -48,7 +48,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -77,14 +77,14 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.2;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // default voltage_power_supply
   motor.voltage_limit = 12;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -112,7 +112,7 @@ void setup() {
   Serial.println(F("Run user commands to configure and the motor (find the full command list in docs.simplefoc.com) \n "));
   Serial.println(F("Initial motion control loop is voltage loop."));
   Serial.println(F("Initial target voltage 2V."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/ESP32/encoder/esp32_position_control/esp32_position_control.ino
+++ b/examples/hardware_specific_examples/ESP32/encoder/esp32_position_control/esp32_position_control.ino
@@ -1,4 +1,4 @@
-/** 
+/**
  * ESP32 position motion control example with encoder
  *
  */
@@ -23,14 +23,14 @@ Commander command = Commander(Serial);
 void doTarget(char* cmd) { command.scalar(&target_angle, cmd); }
 
 void setup() {
-  
+
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
 
   // link the motor to the sensor
   motor.linkSensor(&encoder);
-  
+
   // driver config
   // power supply voltage [V]
   driver.voltage_power_supply = 12;
@@ -46,20 +46,20 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // default voltage_power_supply
   motor.voltage_limit = 6;
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
- 
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 20;
@@ -67,11 +67,11 @@ void setup() {
   motor.velocity_limit = 4;
 
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
-  
+
   // initialize motor
   motor.init();
   // align encoder and start FOC
@@ -92,7 +92,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -104,7 +104,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/hardware_specific_examples/ESP32/magnetic_sensor/esp32_position_control/esp32_position_control.ino
+++ b/examples/hardware_specific_examples/ESP32/magnetic_sensor/esp32_position_control/esp32_position_control.ino
@@ -44,37 +44,37 @@ void setup() {
   driver.init();
   // link the motor and the driver
   motor.linkDriver(&driver);
-  
+
   // choose FOC modulation (optional)
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // maximal voltage to be set to the motor
   motor.voltage_limit = 6;
-  
+
   // velocity low pass filtering time constant
   // the lower the less filtered
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
-  // angle P controller 
+  // angle P controller
   motor.P_angle.P = 20;
   // maximal velocity of the position control
   motor.velocity_limit = 40;
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
 
-  
+
   // initialize motor
   motor.init();
   // align sensor and start FOC
@@ -96,7 +96,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -109,7 +109,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/hardware_specific_examples/HMBGC_example/position_control/position_control.ino
+++ b/examples/hardware_specific_examples/HMBGC_example/position_control/position_control.ino
@@ -1,15 +1,15 @@
 /**
- * 
+ *
  * HMBGC position motion control example with encoder
- * 
+ *
  * - Motor is connected the MOT1 connector (MOT1 9,10,11; MOT2 3,5,6)
  * - Encoder is connected to A0 and A1
- * 
- * This board doesn't have any interrupt pins so we need to run all the encoder channels with the software interrupt library 
+ *
+ * This board doesn't have any interrupt pins so we need to run all the encoder channels with the software interrupt library
  * - For this example we use: PciManager library : https://github.com/prampec/arduino-pcimanager
- * 
+ *
  * See docs.simplefoc.com for more info.
- * 
+ *
  */
 #include <SimpleFOC.h>
 // software interrupt library
@@ -49,7 +49,7 @@ void setup() {
   PciManager.registerListener(&listenerB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
-  
+
   // driver config
   // power supply voltage [V]
   driver.voltage_power_supply = 12;
@@ -65,20 +65,20 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   // default voltage_power_supply
   motor.voltage_limit = 6;
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
- 
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 20;
@@ -86,11 +86,11 @@ void setup() {
   motor.velocity_limit = 4;
 
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
-  
+
   // initialize motor
   motor.init();
   // align encoder and start FOC
@@ -109,7 +109,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -121,7 +121,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/hardware_specific_examples/SAMD_examples/nano33IoT/nano33IoT_velocity_control/nano33IoT_velocity_control.ino
+++ b/examples/hardware_specific_examples/SAMD_examples/nano33IoT/nano33IoT_velocity_control/nano33IoT_velocity_control.ino
@@ -17,7 +17,7 @@ BLDCMotor motor = BLDCMotor(7);
 BLDCDriver3PWM driver =  BLDCDriver3PWM(6,5,8);
 
 // velocity set point variable
-float target_velocity = 2.0;
+float target_velocity = 2.0f;
 // instantiate the commander
 Commander command = Commander(SerialUSB);
 void doTarget(char* cmd) { command.scalar(&target_velocity, cmd); }
@@ -35,11 +35,11 @@ void setup() {
 	driver.init();
 	motor.linkDriver(&driver);
 	motor.controller = MotionControlType::velocity;
-	motor.PID_velocity.P = 0.2;
+	motor.PID_velocity.P = 0.2f;
 	motor.PID_velocity.I = 20;
-	motor.PID_velocity.D = 0.001;
+	motor.PID_velocity.D = 0.001f;
 	motor.PID_velocity.output_ramp = 1000;
-	motor.LPF_velocity.Tf = 0.01;
+	motor.LPF_velocity.Tf = 0.01f;
 	motor.voltage_limit = 9;
 	//motor.P_angle.P = 20;
 	motor.init();

--- a/examples/hardware_specific_examples/SimpleFOC-PowerShield/version_v02/single_full_control_example/single_full_control_example.ino
+++ b/examples/hardware_specific_examples/SimpleFOC-PowerShield/version_v02/single_full_control_example/single_full_control_example.ino
@@ -22,7 +22,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -38,15 +38,15 @@ void setup() {
   motor.torque_controller = TorqueControlType::foc_current;
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.05f;
   motor.PID_velocity.I = 1;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
-  
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -60,7 +60,7 @@ void setup() {
   motor.useMonitoring(Serial);
   motor.monitor_downsample = 0; // disable intially
   motor.monitor_variables = _MON_TARGET | _MON_VEL | _MON_ANGLE; // monitor target velocity and angle
-  
+
   // current sense init and linking
   current_sense.init();
   motor.linkCurrentSense(&current_sense);
@@ -68,7 +68,7 @@ void setup() {
   // initialise motor
   motor.init();
   // align encoder and start FOC
-  motor.initFOC(); 
+  motor.initFOC();
 
   // set the inital target value
   motor.target = 0;
@@ -76,9 +76,9 @@ void setup() {
   // subscribe motor to the commander
   command.add('M', doMotor, "motor");
 
-  // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)  
+  // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/current : target 0Amps."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/SimpleFOCShield/version_v1/double_full_control_example/double_full_control_example.ino
+++ b/examples/hardware_specific_examples/SimpleFOCShield/version_v1/double_full_control_example/double_full_control_example.ino
@@ -4,7 +4,7 @@
 // BLDC motor & driver instance
 BLDCMotor motor1 = BLDCMotor(11);
 BLDCDriver3PWM driver1 = BLDCDriver3PWM(9, 5, 6, 8);
-  
+
 // BLDC motor & driver instance
 BLDCMotor motor2 = BLDCMotor(11);
 BLDCDriver3PWM driver2  = BLDCDriver3PWM(3, 10, 11, 7);
@@ -30,14 +30,14 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder1.init();
-  encoder1.enableInterrupts(doA1, doB1); 
+  encoder1.enableInterrupts(doA1, doB1);
   // initialize encoder sensor hardware
   encoder2.init();
-  encoder2.enableInterrupts(doA2, doB2); 
+  encoder2.enableInterrupts(doA2, doB2);
   // link the motor to the sensor
   motor1.linkSensor(&encoder1);
   motor2.linkSensor(&encoder2);
-  
+
 
   // driver config
   // power supply voltage [V]
@@ -55,14 +55,14 @@ void setup() {
   motor1.controller = MotionControlType::torque;
   motor2.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor1.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor1.PID_velocity.P = 0.05f;
   motor1.PID_velocity.I = 1;
   motor1.PID_velocity.D = 0;
   // default voltage_power_supply
   motor1.voltage_limit = 12;
-  // contoller configuration based on the controll type 
-  motor2.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor2.PID_velocity.P = 0.05f;
   motor2.PID_velocity.I = 1;
   motor2.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -78,16 +78,16 @@ void setup() {
   // comment out if not needed
   motor1.useMonitoring(Serial);
   motor2.useMonitoring(Serial);
-  
+
   // initialise motor
   motor1.init();
   // align encoder and start FOC
-  motor1.initFOC(); 
-  
+  motor1.initFOC();
+
   // initialise motor
   motor2.init();
   // align encoder and start FOC
-  motor2.initFOC(); 
+  motor2.initFOC();
 
   // set the inital target value
   motor1.target = 2;
@@ -99,7 +99,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Double motor sketch ready."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/SimpleFOCShield/version_v1/single_full_control_example/single_full_control_example.ino
+++ b/examples/hardware_specific_examples/SimpleFOCShield/version_v1/single_full_control_example/single_full_control_example.ino
@@ -19,7 +19,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -33,15 +33,15 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.05f;
   motor.PID_velocity.I = 1;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
-  
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -55,11 +55,11 @@ void setup() {
   motor.useMonitoring(Serial);
   motor.monitor_downsample = 0; // disable intially
   motor.monitor_variables = _MON_TARGET | _MON_VEL | _MON_ANGLE; // monitor target velocity and angle
-  
+
   // initialise motor
   motor.init();
   // align encoder and start FOC
-  motor.initFOC(); 
+  motor.initFOC();
 
   // set the inital target value
   motor.target = 2;
@@ -69,7 +69,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/voltage : target 2V."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/SimpleFOCShield/version_v2/double_full_control_example/double_full_control_example.ino
+++ b/examples/hardware_specific_examples/SimpleFOCShield/version_v2/double_full_control_example/double_full_control_example.ino
@@ -4,7 +4,7 @@
 // BLDC motor & driver instance
 BLDCMotor motor1 = BLDCMotor(11);
 BLDCDriver3PWM driver1 = BLDCDriver3PWM(5, 10, 6, 8);
-  
+
 // BLDC motor & driver instance
 BLDCMotor motor2 = BLDCMotor(11);
 BLDCDriver3PWM driver2  = BLDCDriver3PWM(3, 9, 11, 7);
@@ -39,14 +39,14 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder1.init();
-  encoder1.enableInterrupts(doA1, doB1); 
+  encoder1.enableInterrupts(doA1, doB1);
   // initialize encoder sensor hardware
   encoder2.init();
-  encoder2.enableInterrupts(doA2, doB2); 
+  encoder2.enableInterrupts(doA2, doB2);
   // link the motor to the sensor
   motor1.linkSensor(&encoder1);
   motor2.linkSensor(&encoder2);
-  
+
 
   // driver config
   // power supply voltage [V]
@@ -64,14 +64,14 @@ void setup() {
   motor1.controller = MotionControlType::torque;
   motor2.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor1.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor1.PID_velocity.P = 0.05f;
   motor1.PID_velocity.I = 1;
   motor1.PID_velocity.D = 0;
   // default voltage_power_supply
   motor1.voltage_limit = 12;
-  // contoller configuration based on the controll type 
-  motor2.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor2.PID_velocity.P = 0.05f;
   motor2.PID_velocity.I = 1;
   motor2.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -87,8 +87,8 @@ void setup() {
   // comment out if not needed
   motor1.useMonitoring(Serial);
   motor2.useMonitoring(Serial);
-  
-  
+
+
   // current sense init and linking
   current_sense1.init();
   motor1.linkCurrentSense(&current_sense1);
@@ -99,12 +99,12 @@ void setup() {
   // initialise motor
   motor1.init();
   // align encoder and start FOC
-  motor1.initFOC(); 
-  
+  motor1.initFOC();
+
   // initialise motor
   motor2.init();
   // align encoder and start FOC
-  motor2.initFOC(); 
+  motor2.initFOC();
 
   // set the inital target value
   motor1.target = 2;
@@ -116,7 +116,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Double motor sketch ready."));
-  
+
   _delay(1000);
 }
 

--- a/examples/hardware_specific_examples/SimpleFOCShield/version_v2/single_full_control_example/single_full_control_example.ino
+++ b/examples/hardware_specific_examples/SimpleFOCShield/version_v2/single_full_control_example/single_full_control_example.ino
@@ -23,7 +23,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -37,15 +37,15 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.05;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.05f;
   motor.PID_velocity.I = 1;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
-  
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -59,7 +59,7 @@ void setup() {
   motor.useMonitoring(Serial);
   motor.monitor_downsample = 0; // disable intially
   motor.monitor_variables = _MON_TARGET | _MON_VEL | _MON_ANGLE; // monitor target velocity and angle
-  
+
   // current sense init and linking
   current_sense.init();
   motor.linkCurrentSense(&current_sense);
@@ -67,7 +67,7 @@ void setup() {
   // initialise motor
   motor.init();
   // align encoder and start FOC
-  motor.initFOC(); 
+  motor.initFOC();
 
   // set the inital target value
   motor.target = 2;
@@ -75,9 +75,9 @@ void setup() {
   // subscribe motor to the commander
   command.add('M', doMotor, "motor");
 
-  // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)  
+  // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/voltage : target 2V."));
-  
+
   _delay(1000);
 }
 

--- a/examples/motion_control/position_motion_control/encoder/angle_control/angle_control.ino
+++ b/examples/motion_control/position_motion_control/encoder/angle_control/angle_control.ino
@@ -1,27 +1,27 @@
 /**
- * 
+ *
  * Position/angle motion control example
  * Steps:
- * 1) Configure the motor and encoder  
+ * 1) Configure the motor and encoder
  * 2) Run the code
  * 3) Set the target angle (in radians) from serial terminal
- * 
- * 
+ *
+ *
  * NOTE :
  * > Arduino UNO example code for running velocity motion control using an encoder with index significantly
  * > Since Arduino UNO doesn't have enough interrupt pins we have to use software interrupt library PciManager.
- *  
- * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins 
+ *
+ * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins
  * > you can supply doIndex directly to the encoder.enableInterrupts(doA,doB,doIndex) and avoid using PciManger
- * 
+ *
  * > If you don't want to use index pin initialize the encoder class without index pin number:
  * > For example:
  * > - Encoder encoder = Encoder(2, 3, 8192);
  * > and initialize interrupts like this:
  * > - encoder.enableInterrupts(doA,doB)
- * 
+ *
  * Check the docs.simplefoc.com for more info about the possible encoder configuration.
- * 
+ *
  */
 #include <SimpleFOC.h>
 // software interrupt library
@@ -53,10 +53,10 @@ Commander command = Commander(Serial);
 void doTarget(char* cmd) { command.scalar(&target_angle, cmd); }
 
 void setup() {
-  
+
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // software interrupts
   PciManager.registerListener(&listenerIndex);
   // link the motor to the sensor
@@ -68,7 +68,7 @@ void setup() {
   driver.init();
   // link the motor and the driver
   motor.linkDriver(&driver);
-  
+
   // aligning voltage [V]
   motor.voltage_sensor_align = 3;
   // index search velocity [rad/s]
@@ -77,11 +77,11 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -89,9 +89,9 @@ void setup() {
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
- 
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 20;
@@ -99,11 +99,11 @@ void setup() {
   motor.velocity_limit = 4;
 
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
-  
+
   // initialize motor
   motor.init();
   // align encoder and start FOC
@@ -121,7 +121,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -133,7 +133,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motion_control/position_motion_control/hall_sensor/angle_control/angle_control.ino
+++ b/examples/motion_control/position_motion_control/hall_sensor/angle_control/angle_control.ino
@@ -1,20 +1,20 @@
 /**
- * 
+ *
  * Position/angle motion control example
  * Steps:
- * 1) Configure the motor and hall sensor  
+ * 1) Configure the motor and hall sensor
  * 2) Run the code
  * 3) Set the target angle (in radians) from serial terminal
- * 
- * 
+ *
+ *
  * NOTE :
  * > This is for Arduino UNO example code for running angle motion control specifically
  * > Since Arduino UNO doesn't have enough interrupt pins we have to use software interrupt library PciManager.
- *  
- * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins 
+ *
+ * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins
  * > you can supply doIndex directly to the sensr.enableInterrupts(doA,doB,doC) and avoid using PciManger
- * 
- * 
+ *
+ *
  */
 #include <SimpleFOC.h>
 // software interrupt library
@@ -46,10 +46,10 @@ Commander command = Commander(Serial);
 void doTarget(char* cmd) { command.scalar(&target_angle, cmd); }
 
 void setup() {
-  
+
   // initialize sensor hardware
   sensor.init();
-  sensor.enableInterrupts(doA, doB); //, doC); 
+  sensor.enableInterrupts(doA, doB); //, doC);
   // software interrupts
   PciManager.registerListener(&listenC);
   // link the motor to the sensor
@@ -71,11 +71,11 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 2;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -83,9 +83,9 @@ void setup() {
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
- 
+
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 20;
@@ -93,11 +93,11 @@ void setup() {
   motor.velocity_limit = 4;
 
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
-  
+
   // initialize motor
   motor.init();
   // align sensor and start FOC
@@ -115,7 +115,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -127,7 +127,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motion_control/position_motion_control/magnetic_sensor/angle_control/angle_control.ino
+++ b/examples/motion_control/position_motion_control/magnetic_sensor/angle_control/angle_control.ino
@@ -1,11 +1,11 @@
 /**
- * 
+ *
  * Position/angle motion control example
  * Steps:
- * 1) Configure the motor and magnetic sensor  
+ * 1) Configure the motor and magnetic sensor
  * 2) Run the code
  * 3) Set the target angle (in radians) from serial terminal
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -42,38 +42,38 @@ void setup() {
   driver.init();
   // link the motor and the driver
   motor.linkDriver(&driver);
-  
+
   // choose FOC modulation (optional)
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // set motion control loop to be used
   motor.controller = MotionControlType::angle;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // maximal voltage to be set to the motor
   motor.voltage_limit = 6;
-  
+
   // velocity low pass filtering time constant
   // the lower the less filtered
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
-  // angle P controller 
+  // angle P controller
   motor.P_angle.P = 20;
   // maximal velocity of the position control
   motor.velocity_limit = 20;
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
 
-  
+
   // initialize motor
   motor.init();
   // align sensor and start FOC
@@ -93,7 +93,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -106,7 +106,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motion_control/torque_control/encoder/current_control/current_control.ino
+++ b/examples/motion_control/torque_control/encoder/current_control/current_control.ino
@@ -1,7 +1,7 @@
 /**
- * 
+ *
  * Torque control example using current control loop.
- * 
+ *
  */
 #include <SimpleFOC.h>
 
@@ -25,11 +25,11 @@ float target_current = 0;
 Commander command = Commander(Serial);
 void doTarget(char* cmd) { command.scalar(&target_current, cmd); }
 
-void setup() { 
-  
+void setup() {
+
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -46,10 +46,10 @@ void setup() {
   motor.linkCurrentSense(&current_sense);
 
   // set torque mode:
-  // TorqueControlType::dc_current 
+  // TorqueControlType::dc_current
   // TorqueControlType::voltage
   // TorqueControlType::foc_current
-  motor.torque_controller = TorqueControlType::foc_current; 
+  motor.torque_controller = TorqueControlType::foc_current;
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;
 
@@ -58,17 +58,17 @@ void setup() {
   motor.PID_current_q.I= 300;
   motor.PID_current_d.P= 5;
   motor.PID_current_d.I = 300;
-  motor.LPF_current_q.Tf = 0.01; 
-  motor.LPF_current_d.Tf = 0.01; 
+  motor.LPF_current_q.Tf = 0.01f;
+  motor.LPF_current_d.Tf = 0.01f;
   // foc currnet control parameters (stm/esp/due/teensy)
   // motor.PID_current_q.P = 5;
   // motor.PID_current_q.I= 1000;
   // motor.PID_current_d.P= 5;
   // motor.PID_current_d.I = 1000;
-  // motor.LPF_current_q.Tf = 0.002; // 1ms default
-  // motor.LPF_current_d.Tf = 0.002; // 1ms default
+  // motor.LPF_current_q.Tf = 0.002f; // 1ms default
+  // motor.LPF_current_d.Tf = 0.002f; // 1ms default
 
-  // use monitoring with serial 
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
@@ -91,7 +91,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function

--- a/examples/motion_control/velocity_motion_control/encoder/velocity_control/velocity_control.ino
+++ b/examples/motion_control/velocity_motion_control/encoder/velocity_control/velocity_control.ino
@@ -1,28 +1,28 @@
 /**
- * 
+ *
  * Velocity motion control example
  * Steps:
- * 1) Configure the motor and encoder 
+ * 1) Configure the motor and encoder
  * 2) Run the code
  * 3) Set the target velocity (in radians per second) from serial terminal
- * 
- * 
- * 
+ *
+ *
+ *
  * NOTE :
  * > Arduino UNO example code for running velocity motion control using an encoder with index significantly
  * > Since Arduino UNO doesn't have enough interrupt pins we have to use software interrupt library PciManager.
- *  
- * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins 
+ *
+ * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins
  * > you can supply doIndex directly to the encoder.enableInterrupts(doA,doB,doIndex) and avoid using PciManger
- * 
+ *
  * > If you don't want to use index pin initialize the encoder class without index pin number:
  * > For example:
  * > - Encoder encoder = Encoder(2, 3, 8192);
  * > and initialize interrupts like this:
  * > - encoder.enableInterrupts(doA,doB)
- * 
+ *
  * Check the docs.simplefoc.com for more info about the possible encoder configuration.
- * 
+ *
  */
 #include <SimpleFOC.h>
 // software interrupt library
@@ -59,7 +59,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // software interrupts
   PciManager.registerListener(&listenerIndex);
   // link the motor to the sensor
@@ -80,11 +80,11 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -92,11 +92,11 @@ void setup() {
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
-  
-  // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
 
-  // use monitoring with serial 
+  // velocity low pass filtering time constant
+  motor.LPF_velocity.Tf = 0.01f;
+
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
@@ -119,7 +119,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -131,7 +131,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motion_control/velocity_motion_control/hall_sensor/velocity_control.ino
+++ b/examples/motion_control/velocity_motion_control/hall_sensor/velocity_control.ino
@@ -1,20 +1,20 @@
 /**
- * 
+ *
  * Velocity motion control example
  * Steps:
- * 1) Configure the motor and sensor 
+ * 1) Configure the motor and sensor
  * 2) Run the code
  * 3) Set the target velocity (in radians per second) from serial terminal
- * 
- * 
- * 
+ *
+ *
+ *
  * NOTE :
- * > Specifically for Arduino UNO example code for running velocity motion control using a hall sensor 
+ * > Specifically for Arduino UNO example code for running velocity motion control using a hall sensor
  * > Since Arduino UNO doesn't have enough interrupt pins we have to use software interrupt library PciManager.
- *  
- * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins 
+ *
+ * > If running this code with Nucleo or Bluepill or any other board which has more than 2 interrupt pins
  * > you can supply doC directly to the sensor.enableInterrupts(doA,doB,doC) and avoid using PciManger
- * 
+ *
  */
 #include <SimpleFOC.h>
 // software interrupt library
@@ -49,7 +49,7 @@ void setup() {
 
   // initialize sensor sensor hardware
   sensor.init();
-  sensor.enableInterrupts(doA, doB); //, doC); 
+  sensor.enableInterrupts(doA, doB); //, doC);
   // software interrupts
   PciManager.registerListener(&listenerIndex);
   // link the motor to the sensor
@@ -64,15 +64,15 @@ void setup() {
 
   // aligning voltage [V]
   motor.voltage_sensor_align = 3;
-  
+
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 2;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -80,11 +80,11 @@ void setup() {
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
-  
-  // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
 
-  // use monitoring with serial 
+  // velocity low pass filtering time constant
+  motor.LPF_velocity.Tf = 0.01f;
+
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
@@ -107,7 +107,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -119,7 +119,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motion_control/velocity_motion_control/magnetic_sensor/velocity_control/velocity_control.ino
+++ b/examples/motion_control/velocity_motion_control/magnetic_sensor/velocity_control/velocity_control.ino
@@ -1,12 +1,12 @@
 /**
- * 
+ *
  * Velocity motion control example
  * Steps:
- * 1) Configure the motor and magnetic sensor 
+ * 1) Configure the motor and magnetic sensor
  * 2) Run the code
  * 3) Set the target velocity (in radians per second) from serial terminal
- * 
- * 
+ *
+ *
  * By using the serial terminal set the velocity value you want to motor to obtain
  *
  */
@@ -32,7 +32,7 @@ Commander command = Commander(Serial);
 void doTarget(char* cmd) { command.scalar(&target_velocity, cmd); }
 
 void setup() {
- 
+
   // initialise magnetic sensor hardware
   sensor.init();
   // link the motor to the sensor
@@ -48,11 +48,11 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
 
-  // contoller configuration 
+  // contoller configuration
   // default parameters in defaults.h
 
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -60,13 +60,13 @@ void setup() {
   // jerk control using voltage voltage ramp
   // default value is 300 volts per sec  ~ 0.3V per millisecond
   motor.PID_velocity.output_ramp = 1000;
-  
-  // velocity low pass filtering
-  // default 5ms - try different values to see what is the best. 
-  // the lower the less filtered
-  motor.LPF_velocity.Tf = 0.01;
 
-  // use monitoring with serial 
+  // velocity low pass filtering
+  // default 5ms - try different values to see what is the best.
+  // the lower the less filtered
+  motor.LPF_velocity.Tf = 0.01f;
+
+  // use monitoring with serial
   Serial.begin(115200);
   // comment out if not needed
   motor.useMonitoring(Serial);
@@ -88,7 +88,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -100,7 +100,7 @@ void loop() {
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();
-  
+
   // user communication
   command.run();
 }

--- a/examples/motor_commands_serial_examples/encoder/full_control_serial/full_control_serial.ino
+++ b/examples/motor_commands_serial_examples/encoder/full_control_serial/full_control_serial.ino
@@ -1,13 +1,13 @@
 /**
  * Comprehensive BLDC motor control example using encoder
- * 
+ *
  * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
  * - configure PID controller constants
  * - change motion control loops
  * - monitor motor variabels
  * - set target values
- * - check all the configuration values 
- * 
+ * - check all the configuration values
+ *
  * See more info in docs.simplefoc.com/commander_interface
  */
 #include <SimpleFOC.h>
@@ -36,7 +36,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB);
   // link the motor to the sensor
   motor.linkSensor(&encoder);
 
@@ -53,15 +53,15 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.2;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -87,7 +87,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/voltage : target 2V."));
-  
+
   _delay(1000);
 }
 

--- a/examples/motor_commands_serial_examples/hall_sensor/full_control_serial/full_control_serial.ino
+++ b/examples/motor_commands_serial_examples/hall_sensor/full_control_serial/full_control_serial.ino
@@ -1,13 +1,13 @@
 /**
  * Comprehensive BLDC motor control example using Hall sensor
- * 
+ *
  * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
  * - configure PID controller constants
  * - change motion control loops
  * - monitor motor variabels
  * - set target values
- * - check all the configuration values 
- * 
+ * - check all the configuration values
+ *
  * See more info in docs.simplefoc.com/commander_interface
  */
 #include <SimpleFOC.h>
@@ -43,7 +43,7 @@ void setup() {
 
   // initialize encoder sensor hardware
   sensor.init();
-  sensor.enableInterrupts(doA, doB); //, doC); 
+  sensor.enableInterrupts(doA, doB); //, doC);
   // software interrupts
   PciManager.registerListener(&listenC);
   // link the motor to the sensor
@@ -61,15 +61,15 @@ void setup() {
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
-  // contoller configuration based on the controll type 
-  motor.PID_velocity.P = 0.2;
+  // contoller configuration based on the controll type
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -95,7 +95,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/voltage : target 2V."));
-  
+
   _delay(1000);
 }
 
@@ -112,5 +112,3 @@ void loop() {
   // user communication
   command.run();
 }
-
-

--- a/examples/motor_commands_serial_examples/magnetic_sensor/full_control_serial/full_control_serial.ino
+++ b/examples/motor_commands_serial_examples/magnetic_sensor/full_control_serial/full_control_serial.ino
@@ -1,13 +1,13 @@
 /**
  * Comprehensive BLDC motor control example using magnetic sensor
- * 
+ *
  * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
  * - configure PID controller constants
  * - change motion control loops
  * - monitor motor variabels
  * - set target values
- * - check all the configuration values 
- * 
+ * - check all the configuration values
+ *
  * See more info in docs.simplefoc.com/commander_interface
  */
 #include <SimpleFOC.h>
@@ -51,15 +51,15 @@ void setup() {
   // set control loop type to be used
   motor.controller = MotionControlType::torque;
 
-  // contoller configuration based on the control type 
-  motor.PID_velocity.P = 0.2;
+  // contoller configuration based on the control type
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
   motor.voltage_limit = 12;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle loop controller
   motor.P_angle.P = 20;
@@ -85,7 +85,7 @@ void setup() {
 
   // Run user commands to configure and the motor (find the full command list in docs.simplefoc.com)
   Serial.println(F("Motor commands sketch | Initial motion control > torque/voltage : target 2V."));
-  
+
   _delay(1000);
 }
 
@@ -98,8 +98,7 @@ void loop() {
   // velocity, position or voltage
   // if tatget not set in parameter uses motor.target variable
   motor.move();
-  
+
   // user communication
   command.run();
 }
-

--- a/examples/osc_control_examples/osc_esp32_3pwm/osc_esp32_3pwm.ino
+++ b/examples/osc_control_examples/osc_esp32_3pwm/osc_esp32_3pwm.ino
@@ -93,11 +93,11 @@ void setup() {
 	driver.init();
 	motor.linkDriver(&driver);
 	motor.controller = MotionControlType::velocity;
-	motor.PID_velocity.P = 0.2;
+	motor.PID_velocity.P = 0.2f;
 	motor.PID_velocity.I = 20;
-	motor.PID_velocity.D = 0.001;
+	motor.PID_velocity.D = 0.001f;
 	motor.PID_velocity.output_ramp = 1000;
-	motor.LPF_velocity.Tf = 0.01;
+	motor.LPF_velocity.Tf = 0.01f;
 	motor.voltage_limit = 8;
 	//motor.P_angle.P = 20;
 	motor.init();
@@ -107,9 +107,9 @@ void setup() {
 }
 
 // velocity set point variable
-float target_velocity = 2.0;
+float target_velocity = 2.0f;
 // angle set point variable
-float target_angle = 1.0;
+float target_angle = 1.0f;
 
 
 void motorControl(OSCMessage &msg){

--- a/examples/osc_control_examples/osc_esp32_fullcontrol/osc_esp32_fullcontrol.ino
+++ b/examples/osc_control_examples/osc_esp32_fullcontrol/osc_esp32_fullcontrol.ino
@@ -30,7 +30,7 @@ WiFiUDP Udp;
 IPAddress outIp(192,168,1,13);        		// remote IP (not needed for receive)
 const unsigned int outPort = 8000;          // remote port (not needed for receive)
 const unsigned int inPort = 8000;        	// local port to listen for UDP packets (here's where we send the packets)
-#define POWER_SUPPLY 7.4
+#define POWER_SUPPLY 7.4f
 
 
 
@@ -46,8 +46,8 @@ String m2Prefix("/M2");
 
 
 // we store seperate set-points for each motor, of course
-float set_point1 = 0.0;
-float set_point2 = 0.0;
+float set_point1 = 0.0f;
+float set_point2 = 0.0f;
 
 
 OSCErrorCode error;
@@ -135,11 +135,11 @@ void setup() {
 	motor1.linkDriver(&driver1);
 	motor1.foc_modulation = FOCModulationType::SpaceVectorPWM;
 	motor1.controller = MotionControlType::velocity;
-	motor1.PID_velocity.P = 0.2;
+	motor1.PID_velocity.P = 0.2f;
 	motor1.PID_velocity.I = 20;
-	motor1.PID_velocity.D = 0.001;
+	motor1.PID_velocity.D = 0.001f;
 	motor1.PID_velocity.output_ramp = 1000;
-	motor1.LPF_velocity.Tf = 0.01;
+	motor1.LPF_velocity.Tf = 0.01f;
 	motor1.voltage_limit = POWER_SUPPLY;
 	motor1.P_angle.P = 20;
 	motor1.init();
@@ -152,11 +152,11 @@ void setup() {
 	motor2.linkDriver(&driver2);
 	motor2.foc_modulation = FOCModulationType::SpaceVectorPWM;
 	motor2.controller = MotionControlType::velocity;
-	motor2.PID_velocity.P = 0.2;
+	motor2.PID_velocity.P = 0.2f;
 	motor2.PID_velocity.I = 20;
-	motor2.PID_velocity.D = 0.001;
+	motor2.PID_velocity.D = 0.001f;
 	motor2.PID_velocity.output_ramp = 1000;
-	motor2.LPF_velocity.Tf = 0.01;
+	motor2.LPF_velocity.Tf = 0.01f;
 	motor2.voltage_limit = POWER_SUPPLY;
 	motor2.P_angle.P = 20;
 	motor2.init();

--- a/examples/utils/calibration/alignment_and_cogging_test/alignment_and_cogging_test.ino
+++ b/examples/utils/calibration/alignment_and_cogging_test/alignment_and_cogging_test.ino
@@ -9,7 +9,7 @@ MagneticSensorI2C sensor = MagneticSensorI2C(0x36, 12, 0X0C, 4);
 
 
 /**
- * This measures how closely sensor and electrical angle agree and how much your motor is affected by 'cogging'.  
+ * This measures how closely sensor and electrical angle agree and how much your motor is affected by 'cogging'.
  * It can be used to investigate how much non linearity there is between what we set (electrical angle) and what we read (sensor angle)
  * This non linearity could be down to magnet placement, coil winding differences or simply that the magnetic field when travelling through a pole pair is not linear
  * An alignment error of ~10 degrees and cogging of ~4 degrees is normal for small gimbal.
@@ -28,9 +28,9 @@ void testAlignmentAndCogging(int direction) {
 
   float stDevSum = 0;
 
-  float mean = 0.0;
-  float prev_mean = 0.0;
-  
+  float mean = 0.0f;
+  float prev_mean = 0.0f;
+
 
   for (int i = 0; i < sample_count; i++) {
 
@@ -39,7 +39,7 @@ void testAlignmentAndCogging(int direction) {
     motor.move(electricAngle * PI / 180);
     _delay(5);
 
-    // measure 
+    // measure
     float sensorAngle = (sensor.getAngle() - initialAngle) * 180 / PI;
     float sensorElectricAngle = sensorAngle * motor.pole_pairs;
     float electricAngleError = electricAngle - sensorElectricAngle;
@@ -87,7 +87,7 @@ void setup() {
 
   motor.voltage_sensor_align = 3;
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
- 
+
   motor.controller = MotionControlType::angle_openloop;
   motor.voltage_limit=motor.voltage_sensor_align;
 

--- a/examples/utils/calibration/find_pole_pair_number/encoder/find_pole_pairs_number/find_pole_pairs_number.ino
+++ b/examples/utils/calibration/find_pole_pair_number/encoder/find_pole_pairs_number/find_pole_pairs_number.ino
@@ -1,17 +1,17 @@
 /**
  * Utility arduino sketch which finds pole pair number of the motor
- * 
+ *
  * To run it just set the correct pin numbers for the BLDC driver and encoder A and B channel as well as the encoder PPR value.
- * 
+ *
  * The program will rotate your motor a specific amount and check how much it moved, and by doing a simple calculation calculate your pole pair number.
- * The pole pair number will be outputted to the serial terminal. 
- * 
- * If the pole pair number is well estimated your motor will start to spin in voltage mode with 2V target. 
- * 
+ * The pole pair number will be outputted to the serial terminal.
+ *
+ * If the pole pair number is well estimated your motor will start to spin in voltage mode with 2V target.
+ *
  * If the code calculates negative pole pair number please invert your encoder A and B channel pins or motor connector.
- * 
- * Try running this code several times to avoid statistical errors. 
- * > But in general if your motor spins, you have a good pole pairs number.  
+ *
+ * Try running this code several times to avoid statistical errors.
+ * > But in general if your motor spins, you have a good pole pairs number.
  */
 #include <SimpleFOC.h>
 
@@ -31,7 +31,7 @@ void doA(){encoder.handleA();}
 void doB(){encoder.handleB();}
 
 void setup() {
-  
+
   // initialise encoder hardware
   encoder.init();
   // hardware interrupt enable
@@ -57,20 +57,20 @@ void setup() {
 
   float pp_search_voltage = 4; // maximum power_supply_voltage/2
   float pp_search_angle = 6*M_PI; // search electrical angle to turn
-  
+
   // move motor to the electrical angle 0
   motor.controller = MotionControlType::angle_openloop;
   motor.voltage_limit=pp_search_voltage;
   motor.move(0);
   _delay(1000);
-  // read the encoder angle 
+  // read the encoder angle
   float angle_begin = encoder.getAngle();
   _delay(50);
-  
+
   // move the motor slowly to the electrical angle pp_search_angle
   float motor_angle = 0;
   while(motor_angle <= pp_search_angle){
-    motor_angle += 0.01;
+    motor_angle += 0.01f;
     motor.move(motor_angle);
   }
   _delay(1000);
@@ -93,7 +93,7 @@ void setup() {
   Serial.print(" = ");
   Serial.println((pp_search_angle)/(angle_end-angle_begin));
   Serial.println();
-   
+
 
   // a bit of monitoring the result
   if(pp <= 0 ){
@@ -108,7 +108,7 @@ void setup() {
     Serial.println(F(" - You can also try to adjust the target voltage using serial terminal!"));
   }
 
-  
+
   // set FOC loop to be used
   motor.controller = MotionControlType::torque;
   // set the pole pair number to the motor
@@ -129,7 +129,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -137,7 +137,7 @@ void loop() {
   // this function can be run at much lower frequency than loopFOC() function
   // You can also use motor.move() and set the motor.target in the code
   motor.move(target_voltage);
-  
+
   // communicate with the user
   serialReceiveUserCommand();
 }
@@ -146,10 +146,10 @@ void loop() {
 // utility function enabling serial communication with the user to set the target values
 // this function can be implemented in serialEvent function as well
 void serialReceiveUserCommand() {
-  
+
   // a string to hold incoming data
   static String received_chars;
-  
+
   while (Serial.available()) {
     // get the new byte:
     char inChar = (char)Serial.read();
@@ -157,13 +157,13 @@ void serialReceiveUserCommand() {
     received_chars += inChar;
     // end of user input
     if (inChar == '\n') {
-      
+
       // change the motor target
       target_voltage = received_chars.toFloat();
       Serial.print("Target voltage: ");
       Serial.println(target_voltage);
-      
-      // reset the command buffer 
+
+      // reset the command buffer
       received_chars = "";
     }
   }

--- a/examples/utils/calibration/find_pole_pair_number/magnetic_sensor/find_pole_pairs_number/find_pole_pairs_number.ino
+++ b/examples/utils/calibration/find_pole_pair_number/magnetic_sensor/find_pole_pairs_number/find_pole_pairs_number.ino
@@ -1,17 +1,17 @@
 /**
  * Utility arduino sketch which finds pole pair number of the motor
- * 
+ *
  * To run it just set the correct pin numbers for the BLDC driver and sensor CPR value and chip select pin.
- * 
+ *
  * The program will rotate your motor a specific amount and check how much it moved, and by doing a simple calculation calculate your pole pair number.
- * The pole pair number will be outputted to the serial terminal. 
- * 
- * If the pole pair number is well estimated your motor will start to spin in voltage mode with 2V target. 
- * 
+ * The pole pair number will be outputted to the serial terminal.
+ *
+ * If the pole pair number is well estimated your motor will start to spin in voltage mode with 2V target.
+ *
  * If the code calculates negative pole pair number please invert your motor connector.
- * 
- * Try running this code several times to avoid statistical errors. 
- * > But in general if your motor spins, you have a good pole pairs number.  
+ *
+ * Try running this code several times to avoid statistical errors.
+ * > But in general if your motor spins, you have a good pole pairs number.
  */
 #include <SimpleFOC.h>
 
@@ -56,20 +56,20 @@ void setup() {
 
   float pp_search_voltage = 4; // maximum power_supply_voltage/2
   float pp_search_angle = 6*M_PI; // search electrical angle to turn
-  
+
   // move motor to the electrical angle 0
   motor.controller = MotionControlType::angle_openloop;
   motor.voltage_limit=pp_search_voltage;
   motor.move(0);
   _delay(1000);
-  // read the sensor angle 
+  // read the sensor angle
   float angle_begin = sensor.getAngle();
   _delay(50);
-  
+
   // move the motor slowly to the electrical angle pp_search_angle
   float motor_angle = 0;
   while(motor_angle <= pp_search_angle){
-    motor_angle += 0.01;
+    motor_angle += 0.01f;
     sensor.getAngle(); // keep track of the overflow
     motor.move(motor_angle);
   }
@@ -93,7 +93,7 @@ void setup() {
   Serial.print(F(" = "));
   Serial.println((pp_search_angle)/(angle_end-angle_begin));
   Serial.println();
-   
+
 
   // a bit of monitoring the result
   if(pp <= 0 ){
@@ -108,7 +108,7 @@ void setup() {
     Serial.println(F(" - You can also try to adjust the target voltage using serial terminal!"));
   }
 
-  
+
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;
   // set the pole pair number to the motor
@@ -129,7 +129,7 @@ void loop() {
   // main FOC algorithm function
   // the faster you run this function the better
   // Arduino UNO loop  ~1kHz
-  // Bluepill loop ~10kHz 
+  // Bluepill loop ~10kHz
   motor.loopFOC();
 
   // Motion control function
@@ -137,7 +137,7 @@ void loop() {
   // this function can be run at much lower frequency than loopFOC() function
   // You can also use motor.move() and set the motor.target in the code
   motor.move(target_voltage);
-  
+
   // communicate with the user
   serialReceiveUserCommand();
 }
@@ -146,10 +146,10 @@ void loop() {
 // utility function enabling serial communication with the user to set the target values
 // this function can be implemented in serialEvent function as well
 void serialReceiveUserCommand() {
-  
+
   // a string to hold incoming data
   static String received_chars;
-  
+
   while (Serial.available()) {
     // get the new byte:
     char inChar = (char)Serial.read();
@@ -157,13 +157,13 @@ void serialReceiveUserCommand() {
     received_chars += inChar;
     // end of user input
     if (inChar == '\n') {
-      
+
       // change the motor target
       target_voltage = received_chars.toFloat();
       Serial.print("Target voltage: ");
       Serial.println(target_voltage);
-      
-      // reset the command buffer 
+
+      // reset the command buffer
       received_chars = "";
     }
   }

--- a/examples/utils/communication_test/step_dir/step_dir_listener_software_interrupt/step_dir_listener_software_interrupt.ino
+++ b/examples/utils/communication_test/step_dir/step_dir_listener_software_interrupt/step_dir_listener_software_interrupt.ino
@@ -1,6 +1,6 @@
 /**
- * A simple example of reading step/dir communication 
- *  - this example uses software interrupts - this code is intended primarily 
+ * A simple example of reading step/dir communication
+ *  - this example uses software interrupts - this code is intended primarily
  *    for Arduino UNO/Mega and similar boards with very limited number of interrupt pins
 */
 
@@ -10,11 +10,11 @@
 #include <PciListenerImp.h>
 
 
-// angle 
+// angle
 float received_angle = 0;
 
 // StepDirListener( step_pin, dir_pin, counter_to_value)
-StepDirListener step_dir = StepDirListener(4, 5, 2.0*_PI/200.0); // receive the angle in radians
+StepDirListener step_dir = StepDirListener(4, 5, 2.0f*_PI/200.0); // receive the angle in radians
 void onStep() { step_dir.handle(); }
 
 // If no available hadware interrupt pins use the software interrupt
@@ -23,21 +23,21 @@ PciListenerImp listenStep(step_dir.pin_step, onStep);
 void setup() {
 
   Serial.begin(115200);
-  
+
   // init step and dir pins
   step_dir.init();
   // enable software interrupts
   PciManager.registerListener(&listenStep);
-  // attach the variable to be updated on each step (optional) 
+  // attach the variable to be updated on each step (optional)
   // the same can be done asynchronously by caling step_dir.getValue();
   step_dir.attach(&received_angle);
-    
+
   Serial.println(F("Step/Dir listenning."));
   _delay(1000);
 }
 
 void loop() {
-    Serial.print(received_angle); 
+    Serial.print(received_angle);
     Serial.print("\t");
     Serial.println(step_dir.getValue());
     _delay(500);

--- a/examples/utils/communication_test/step_dir/step_dir_motor_example/step_dir_motor_example.ino
+++ b/examples/utils/communication_test/step_dir/step_dir_motor_example/step_dir_motor_example.ino
@@ -19,7 +19,7 @@ void doA() { encoder.handleA(); }
 void doB() { encoder.handleB(); }
 
 // StepDirListener( step_pin, dir_pin, counter_to_value)
-StepDirListener step_dir = StepDirListener(A4, A5, 2.0*_PI/200.0);
+StepDirListener step_dir = StepDirListener(A4, A5, 2.0f*_PI/200.0);
 void onStep() { step_dir.handle(); }
 
 void setup() {
@@ -48,7 +48,7 @@ void setup() {
   // contoller configuration
   // default parameters in defaults.h
   // velocity PI controller parameters
-  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.P = 0.2f;
   motor.PID_velocity.I = 20;
   motor.PID_velocity.D = 0;
   // default voltage_power_supply
@@ -58,7 +58,7 @@ void setup() {
   motor.PID_velocity.output_ramp = 1000;
 
   // velocity low pass filtering time constant
-  motor.LPF_velocity.Tf = 0.01;
+  motor.LPF_velocity.Tf = 0.01f;
 
   // angle P controller
   motor.P_angle.P = 10;
@@ -77,12 +77,12 @@ void setup() {
 
   // init step and dir pins
   step_dir.init();
-  // enable interrupts 
+  // enable interrupts
   step_dir.enableInterrupt(onStep);
-  // attach the variable to be updated on each step (optional) 
+  // attach the variable to be updated on each step (optional)
   // the same can be done asynchronously by caling motor.move(step_dir.getValue());
   step_dir.attach(&motor.target);
-    
+
   Serial.println(F("Motor ready."));
   Serial.println(F("Listening to step/dir commands!"));
   _delay(1000);

--- a/examples/utils/driver_standalone_test/bldc_driver_6pwm_standalone/bldc_driver_6pwm_standalone.ino
+++ b/examples/utils/driver_standalone_test/bldc_driver_6pwm_standalone/bldc_driver_6pwm_standalone.ino
@@ -5,7 +5,7 @@
 BLDCDriver6PWM driver = BLDCDriver6PWM(5, 6, 9,10, 3, 11, 8);
 
 void setup() {
-  
+
   // pwm frequency to be used [Hz]
   // for atmega328 fixed to 32kHz
   // esp32/stm32/teensy configurable
@@ -14,8 +14,8 @@ void setup() {
   driver.voltage_power_supply = 12;
   // Max DC voltage allowed - default voltage_power_supply
   driver.voltage_limit = 12;
-  // daad_zone [0,1] - default 0.02 - 2%
-  driver.dead_zone = 0.05;
+  // daad_zone [0,1] - default 0.02f - 2%
+  driver.dead_zone = 0.05f;
 
   // driver init
   driver.init();

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -159,7 +159,7 @@ int BLDCMotor::alignSensor() {
     // find natural direction
     // move one electrical revolution forward
     for (int i = 0; i <=500; i++ ) {
-      float angle = _3PI_2 + _2PI * i / 500.0;
+      float angle = _3PI_2 + _2PI * i / 500.0f;
       setPhaseVoltage(voltage_sensor_align, 0,  angle);
       _delay(2);
     }
@@ -167,7 +167,7 @@ int BLDCMotor::alignSensor() {
     float mid_angle = sensor->getAngle();
     // move one electrical revolution backwards
     for (int i = 500; i >=0; i-- ) {
-      float angle = _3PI_2 + _2PI * i / 500.0 ;
+      float angle = _3PI_2 + _2PI * i / 500.0f ;
       setPhaseVoltage(voltage_sensor_align, 0,  angle);
       _delay(2);
     }
@@ -188,7 +188,7 @@ int BLDCMotor::alignSensor() {
     // check pole pair number
     if(monitor_port) monitor_port->print(F("MOT: PP check: "));
     float moved =  fabs(mid_angle - end_angle);
-    if( fabs(moved*pole_pairs - _2PI) > 0.5 ) { // 0.5 is arbitrary number it can be lower or higher!
+    if( fabs(moved*pole_pairs - _2PI) > 0.5f ) { // 0.5f is arbitrary number it can be lower or higher!
       if(monitor_port) monitor_port->print(F("fail - estimated pp:"));
       if(monitor_port) monitor_port->println(_2PI/moved,4);
     }else if(monitor_port) monitor_port->println(F("OK!"));
@@ -226,7 +226,7 @@ int BLDCMotor::absoluteZeroSearch() {
   voltage_limit = voltage_sensor_align;
   shaft_angle = 0;
   while(sensor->needsSearch() && shaft_angle < _2PI){
-    angleOpenloop(1.5*_2PI);
+    angleOpenloop(1.5f*_2PI);
     // call important for some sensors not to loose count
     // not needed for the search
     sensor->getAngle();
@@ -568,9 +568,9 @@ float BLDCMotor::velocityOpenloop(float target_velocity){
   // get current timestamp
   unsigned long now_us = _micros();
   // calculate the sample time from last call
-  float Ts = (now_us - open_loop_timestamp) * 1e-6;
+  float Ts = (now_us - open_loop_timestamp) * 1e-6f;
   // quick fix for strange cases (micros overflow + timestamp not defined)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3;
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // calculate the necessary angle to achieve target velocity
   shaft_angle = _normalizeAngle(shaft_angle + target_velocity*Ts);
@@ -597,9 +597,9 @@ float BLDCMotor::angleOpenloop(float target_angle){
   // get current timestamp
   unsigned long now_us = _micros();
   // calculate the sample time from last call
-  float Ts = (now_us - open_loop_timestamp) * 1e-6;
+  float Ts = (now_us - open_loop_timestamp) * 1e-6f;
   // quick fix for strange cases (micros overflow + timestamp not defined)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3;
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // calculate the necessary angle to move from current position towards target angle
   // with maximal velocity (velocity_limit)

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -11,7 +11,7 @@ StepperMotor::StepperMotor(int pp, float _R)
   // save phase resistance number
   phase_resistance = _R;
 
-  // torque control type is voltage by default 
+  // torque control type is voltage by default
   // current and foc_current not supported yet
   torque_controller = TorqueControlType::voltage;
 }
@@ -23,7 +23,7 @@ void StepperMotor::linkDriver(StepperDriver* _driver) {
   driver = _driver;
 }
 
-// init hardware pins   
+// init hardware pins
 void StepperMotor::init() {
   if(monitor_port) monitor_port->println(F("MOT: Init"));
 
@@ -37,7 +37,7 @@ void StepperMotor::init() {
   if(voltage_limit > driver->voltage_limit) voltage_limit =  driver->voltage_limit;
   // constrain voltage for sensor alignment
   if(voltage_sensor_align > voltage_limit) voltage_sensor_align = voltage_limit;
-  
+
   // update the controller limits
   if(_isset(phase_resistance)){
     // velocity control loop controls current
@@ -52,7 +52,7 @@ void StepperMotor::init() {
   if(monitor_port) monitor_port->println(F("MOT: Enable driver."));
   enable();
   _delay(500);
-  
+
 }
 
 
@@ -101,14 +101,14 @@ int  StepperMotor::initFOC( float zero_electric_offset, Direction _sensor_direct
     // added the shaft_angle update
     shaft_angle = sensor->getAngle();
   }else if(monitor_port) monitor_port->println(F("MOT: No sensor."));
-  
+
   if(exit_flag){
     if(monitor_port) monitor_port->println(F("MOT: Ready."));
   }else{
     if(monitor_port) monitor_port->println(F("MOT: Init FOC failed."));
     disable();
   }
- 
+
   return exit_flag;
 }
 
@@ -116,7 +116,7 @@ int  StepperMotor::initFOC( float zero_electric_offset, Direction _sensor_direct
 int StepperMotor::alignSensor() {
   int exit_flag = 1; //success
   if(monitor_port) monitor_port->println(F("MOT: Align sensor."));
-  
+
   // if unknown natural direction
   if(!_isset(sensor_direction)){
     // check if sensor needs zero search
@@ -127,7 +127,7 @@ int StepperMotor::alignSensor() {
     // find natural direction
     // move one electrical revolution forward
     for (int i = 0; i <=500; i++ ) {
-      float angle = _3PI_2 + _2PI * i / 500.0;
+      float angle = _3PI_2 + _2PI * i / 500.0f;
       setPhaseVoltage(voltage_sensor_align, 0,  angle);
       _delay(2);
     }
@@ -135,14 +135,14 @@ int StepperMotor::alignSensor() {
     float mid_angle = sensor->getAngle();
     // move one electrical revolution backwards
     for (int i = 500; i >=0; i-- ) {
-      float angle = _3PI_2 + _2PI * i / 500.0 ;
+      float angle = _3PI_2 + _2PI * i / 500.0f ;
       setPhaseVoltage(voltage_sensor_align, 0,  angle);
       _delay(2);
     }
     float end_angle = sensor->getAngle();
     setPhaseVoltage(0, 0, 0);
     _delay(200);
-    // determine the direction the sensor moved 
+    // determine the direction the sensor moved
     if (mid_angle == end_angle) {
       if(monitor_port) monitor_port->println(F("MOT: Failed to notice movement"));
       return 0; // failed calibration
@@ -153,10 +153,10 @@ int StepperMotor::alignSensor() {
       if(monitor_port) monitor_port->println(F("MOT: sensor_direction==CW"));
       sensor_direction = Direction::CW;
     }
-    // check pole pair number 
+    // check pole pair number
     if(monitor_port) monitor_port->print(F("MOT: PP check: "));
     float moved =  fabs(mid_angle - end_angle);
-    if( fabs(moved*pole_pairs - _2PI) > 0.5 ) { // 0.5 is arbitrary number it can be lower or higher!
+    if( fabs(moved*pole_pairs - _2PI) > 0.5f ) { // 0.5f is arbitrary number it can be lower or higher!
       if(monitor_port) monitor_port->print(F("fail - estimated pp:"));
       if(monitor_port) monitor_port->println(_2PI/moved,4);
     }else if(monitor_port) monitor_port->println(F("OK!"));
@@ -166,7 +166,7 @@ int StepperMotor::alignSensor() {
   // zero electric angle not known
   if(!_isset(zero_electric_angle)){
     // align the electrical phases of the motor and sensor
-    // set angle -90(270 = 3PI/2) degrees 
+    // set angle -90(270 = 3PI/2) degrees
     setPhaseVoltage(voltage_sensor_align, 0,  _3PI_2);
     _delay(700);
     zero_electric_angle = _normalizeAngle(_electricalAngle(sensor_direction*sensor->getAngle(), pole_pairs));
@@ -185,7 +185,7 @@ int StepperMotor::alignSensor() {
 // Encoder alignment the absolute zero angle
 // - to the index
 int StepperMotor::absoluteZeroSearch() {
-  
+
   if(monitor_port) monitor_port->println(F("MOT: Index search..."));
   // search the absolute zero with small velocity
   float limit_vel = velocity_limit;
@@ -194,7 +194,7 @@ int StepperMotor::absoluteZeroSearch() {
   voltage_limit = voltage_sensor_align;
   shaft_angle = 0;
   while(sensor->needsSearch() && shaft_angle < _2PI){
-    angleOpenloop(1.5*_2PI);
+    angleOpenloop(1.5f*_2PI);
     // call important for some sensors not to loose count
     // not needed for the search
     sensor->getAngle();
@@ -218,15 +218,15 @@ int StepperMotor::absoluteZeroSearch() {
 void StepperMotor::loopFOC() {
   // if open-loop do nothing
   if( controller==MotionControlType::angle_openloop || controller==MotionControlType::velocity_openloop ) return;
-  // shaft angle 
+  // shaft angle
   shaft_angle = shaftAngle();
-  
+
   // if disabled do nothing
-  if(!enabled) return; 
+  if(!enabled) return;
 
   electrical_angle = electricalAngle();
 
-  // set the phase voltage - FOC heart function :) 
+  // set the phase voltage - FOC heart function :)
   setPhaseVoltage(voltage.q, voltage.d, electrical_angle);
 }
 
@@ -239,7 +239,7 @@ void StepperMotor::move(float new_target) {
   // get angular velocity
   shaft_velocity = shaftVelocity();
   // if disabled do nothing
-  if(!enabled) return; 
+  if(!enabled) return;
   // downsampling (optional)
   if(motion_cnt++ < motion_downsample) return;
   motion_cnt = 0;
@@ -249,7 +249,7 @@ void StepperMotor::move(float new_target) {
   switch (controller) {
     case MotionControlType::torque:
       if(!_isset(phase_resistance))  voltage.q = target; // if voltage torque control
-      else voltage.q =  target*phase_resistance; 
+      else voltage.q =  target*phase_resistance;
       voltage.d = 0;
       break;
     case MotionControlType::angle:
@@ -259,7 +259,7 @@ void StepperMotor::move(float new_target) {
       shaft_velocity_sp = P_angle( shaft_angle_sp - shaft_angle );
       // calculate the torque command
       current_sp = PID_velocity(shaft_velocity_sp - shaft_velocity); // if voltage torque control
-      // if torque controlled through voltage  
+      // if torque controlled through voltage
       // use voltage if phase-resistance not provided
       if(!_isset(phase_resistance))  voltage.q = current_sp;
       else  voltage.q = current_sp*phase_resistance;
@@ -270,7 +270,7 @@ void StepperMotor::move(float new_target) {
       shaft_velocity_sp = target;
       // calculate the torque command
       current_sp = PID_velocity(shaft_velocity_sp - shaft_velocity); // if current/foc_current torque control
-      // if torque controlled through voltage control 
+      // if torque controlled through voltage control
       // use voltage if phase-resistance not provided
       if(!_isset(phase_resistance))  voltage.q = current_sp;
       else  voltage.q = current_sp*phase_resistance;
@@ -295,12 +295,12 @@ void StepperMotor::move(float new_target) {
 // Method using FOC to set Uq and Ud to the motor at the optimal angle
 // Function implementing Sine PWM algorithms
 // - space vector not implemented yet
-// 
+//
 // Function using sine approximation
 // regular sin + cos ~300us    (no memory usaage)
 // approx  _sin + _cos ~110us  (400Byte ~ 20% of memory)
 void StepperMotor::setPhaseVoltage(float Uq, float Ud, float angle_el) {
-  // Sinusoidal PWM modulation 
+  // Sinusoidal PWM modulation
   // Inverse Park transformation
 
   // angle normalization in between 0 and 2pi
@@ -323,18 +323,18 @@ float StepperMotor::velocityOpenloop(float target_velocity){
   // get current timestamp
   unsigned long now_us = _micros();
   // calculate the sample time from last call
-  float Ts = (now_us - open_loop_timestamp) * 1e-6;
+  float Ts = (now_us - open_loop_timestamp) * 1e-6f;
   // quick fix for strange cases (micros overflow + timestamp not defined)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // calculate the necessary angle to achieve target velocity
   shaft_angle = _normalizeAngle(shaft_angle + target_velocity*Ts);
   // for display purposes
   shaft_velocity = target_velocity;
-    
+
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) Uq =  current_limit*phase_resistance; 
+  if(_isset(phase_resistance)) Uq =  current_limit*phase_resistance;
 
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   setPhaseVoltage(Uq,  0, _electricalAngle(shaft_angle, pole_pairs));
@@ -352,9 +352,9 @@ float StepperMotor::angleOpenloop(float target_angle){
   // get current timestamp
   unsigned long now_us = _micros();
   // calculate the sample time from last call
-  float Ts = (now_us - open_loop_timestamp) * 1e-6;
+  float Ts = (now_us - open_loop_timestamp) * 1e-6f;
   // quick fix for strange cases (micros overflow + timestamp not defined)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // calculate the necessary angle to move from current position towards target angle
   // with maximal velocity (velocity_limit)
@@ -368,12 +368,12 @@ float StepperMotor::angleOpenloop(float target_angle){
 
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) Uq =  current_limit*phase_resistance; 
+  if(_isset(phase_resistance)) Uq =  current_limit*phase_resistance;
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   setPhaseVoltage(Uq,  0, _electricalAngle(shaft_angle, pole_pairs));
 
   // save timestamp for next call
   open_loop_timestamp = now_us;
-  
+
   return Uq;
 }

--- a/src/common/base_classes/BLDCDriver.h
+++ b/src/common/base_classes/BLDCDriver.h
@@ -5,7 +5,7 @@
 
 class BLDCDriver{
     public:
-        
+
         /** Initialise hardware */
         virtual int init() = 0;
         /** Enable hardware */
@@ -14,26 +14,26 @@ class BLDCDriver{
         virtual void disable() = 0;
 
         long pwm_frequency; //!< pwm frequency value in hertz
-        float voltage_power_supply; //!< power supply voltage 
+        float voltage_power_supply; //!< power supply voltage
         float voltage_limit; //!< limiting voltage set to the motor
 
-        
+
         float dc_a; //!< currently set duty cycle on phaseA
         float dc_b; //!< currently set duty cycle on phaseB
         float dc_c; //!< currently set duty cycle on phaseC
-            
-        /** 
-         * Set phase voltages to the harware 
-         * 
+
+        /**
+         * Set phase voltages to the harware
+         *
          * @param Ua - phase A voltage
          * @param Ub - phase B voltage
          * @param Uc - phase C voltage
         */
         virtual void setPwm(float Ua, float Ub, float Uc) = 0;
 
-        /** 
-         * Set phase state, enable/disable 
-         * 
+        /**
+         * Set phase state, enable/disable
+         *
          * @param sc - phase A state : active / disabled ( high impedance )
          * @param sb - phase B state : active / disabled ( high impedance )
          * @param sa - phase C state : active / disabled ( high impedance )

--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -2,7 +2,7 @@
 #include "../foc_utils.h"
 #include "../time_utils.h"
 
- /** 
+ /**
  * returns 0 if it does need search for absolute zero
  * 0 - magnetic sensor (& encoder with index which is found)
  * 1 - ecoder with index (with index not found yet)
@@ -16,15 +16,15 @@ float Sensor::getVelocity(){
 
     // calculate sample time
     unsigned long now_us = _micros();
-    float Ts = (now_us - velocity_calc_timestamp)*1e-6;
+    float Ts = (now_us - velocity_calc_timestamp)*1e-6f;
     // quick fix for strange cases (micros overflow)
-    if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+    if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
     // current angle
     float angle_c = getAngle();
     // velocity calculation
     float vel = (angle_c - angle_prev)/Ts;
-    
+
     // save variables for future pass
     angle_prev = angle_c;
     velocity_calc_timestamp = now_us;

--- a/src/common/defaults.h
+++ b/src/common/defaults.h
@@ -1,12 +1,12 @@
 // default configuration values
 // change this file to optimal values for your application
 
-#define DEF_POWER_SUPPLY 12.0 //!< default power supply voltage
+#define DEF_POWER_SUPPLY 12.0f //!< default power supply voltage
 // velocity PI controller params
-#define DEF_PID_VEL_P 0.5 //!< default PID controller P value
-#define DEF_PID_VEL_I 10.0 //!<  default PID controller I value
-#define DEF_PID_VEL_D 0.0 //!<  default PID controller D value
-#define DEF_PID_VEL_RAMP 1000.0 //!< default PID controller voltage ramp value
+#define DEF_PID_VEL_P 0.5f //!< default PID controller P value
+#define DEF_PID_VEL_I 10.0f //!<  default PID controller I value
+#define DEF_PID_VEL_D 0.0f //!<  default PID controller D value
+#define DEF_PID_VEL_RAMP 1000.0f //!< default PID controller voltage ramp value
 #define DEF_PID_VEL_LIMIT (DEF_POWER_SUPPLY) //!< default PID controller voltage limit
 
 // current sensing PID values
@@ -14,33 +14,33 @@
 // for 16Mhz controllers like Arduino uno and mega
 #define DEF_PID_CURR_P 2 //!< default PID controller P value
 #define DEF_PID_CURR_I 100 //!<  default PID controller I value
-#define DEF_PID_CURR_D 0.0 //!<  default PID controller D value
-#define DEF_PID_CURR_RAMP 1000.0 //!< default PID controller voltage ramp value
+#define DEF_PID_CURR_D 0.0f //!<  default PID controller D value
+#define DEF_PID_CURR_RAMP 1000.0f //!< default PID controller voltage ramp value
 #define DEF_PID_CURR_LIMIT (DEF_POWER_SUPPLY) //!< default PID controller voltage limit
-#define DEF_CURR_FILTER_Tf 0.01 //!< default velocity filter time constant
-#else 
+#define DEF_CURR_FILTER_Tf 0.01f //!< default velocity filter time constant
+#else
 // for stm32, due, teensy, esp32 and similar
 #define DEF_PID_CURR_P 3 //!< default PID controller P value
-#define DEF_PID_CURR_I 300.0 //!<  default PID controller I value
-#define DEF_PID_CURR_D 0.0 //!<  default PID controller D value
+#define DEF_PID_CURR_I 300.0f //!<  default PID controller I value
+#define DEF_PID_CURR_D 0.0f //!<  default PID controller D value
 #define DEF_PID_CURR_RAMP 0  //!< default PID controller voltage ramp value
 #define DEF_PID_CURR_LIMIT (DEF_POWER_SUPPLY) //!< default PID controller voltage limit
-#define DEF_CURR_FILTER_Tf 0.005 //!< default currnet filter time constant
+#define DEF_CURR_FILTER_Tf 0.005f //!< default currnet filter time constant
 #endif
 // default current limit values
-#define DEF_CURRENT_LIM 0.2 //!< 2Amps current limit by default
+#define DEF_CURRENT_LIM 0.2f //!< 2Amps current limit by default
 
 // default monitor downsample
 #define DEF_MON_DOWNSMAPLE 100 //!< default monitor downsample
-#define DEF_MOTION_DOWNSMAPLE 0 //!< default motion downsample - disable 
+#define DEF_MOTION_DOWNSMAPLE 0 //!< default motion downsample - disable
 
 // angle P params
-#define DEF_P_ANGLE_P 20.0 //!< default P controller P value
-#define DEF_VEL_LIM 20.0 //!< angle velocity limit default
+#define DEF_P_ANGLE_P 20.0f //!< default P controller P value
+#define DEF_VEL_LIM 20.0f //!< angle velocity limit default
 
-// index search 
-#define DEF_INDEX_SEARCH_TARGET_VELOCITY 1.0 //!< default index search velocity
+// index search
+#define DEF_INDEX_SEARCH_TARGET_VELOCITY 1.0f //!< default index search velocity
 // align voltage
-#define DEF_VOLTAGE_SENSOR_ALIGN 3.0 //!< default voltage for sensor and motor zero alignemt
+#define DEF_VOLTAGE_SENSOR_ALIGN 3.0f //!< default voltage for sensor and motor zero alignemt
 // low pass filter velocity
-#define DEF_VEL_FILTER_Tf 0.005 //!< default velocity filter time constant
+#define DEF_VEL_FILTER_Tf 0.005f //!< default velocity filter time constant

--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -1,6 +1,6 @@
 #include "foc_utils.h"
 
-// int array instead of float array 
+// int array instead of float array
 // 4x200 points per 360 deg
 // 2x storage save (int 2Byte float 4 Byte )
 // sin*10000
@@ -13,21 +13,21 @@ const int sine_array[200] = {0,79,158,237,316,395,473,552,631,710,789,867,946,10
 // it has to receive an angle in between 0 and 2PI
 float _sin(float a){
   if(a < _PI_2){
-    //return sine_array[(int)(199.0*( a / (_PI/2.0)))];
-    //return sine_array[(int)(126.6873* a)];           // float array optimized
-    return 0.0001*sine_array[_round(126.6873* a)];      // int array optimized
+    //return sine_array[(int)(199.0f*( a / (_PI/2.0)))];
+    //return sine_array[(int)(126.6873f* a)];           // float array optimized
+    return 0.0001f*sine_array[_round(126.6873f* a)];      // int array optimized
   }else if(a < _PI){
-    // return sine_array[(int)(199.0*(1.0 - (a-_PI/2.0) / (_PI/2.0)))];
-    //return sine_array[398 - (int)(126.6873*a)];          // float array optimized
-    return 0.0001*sine_array[398 - _round(126.6873*a)];     // int array optimized
+    // return sine_array[(int)(199.0f*(1.0f - (a-_PI/2.0) / (_PI/2.0)))];
+    //return sine_array[398 - (int)(126.6873f*a)];          // float array optimized
+    return 0.0001f*sine_array[398 - _round(126.6873f*a)];     // int array optimized
   }else if(a < _3PI_2){
-    // return -sine_array[(int)(199.0*((a - _PI) / (_PI/2.0)))];
-    //return -sine_array[-398 + (int)(126.6873*a)];           // float array optimized
-    return -0.0001*sine_array[-398 + _round(126.6873*a)];      // int array optimized
+    // return -sine_array[(int)(199.0f*((a - _PI) / (_PI/2.0)))];
+    //return -sine_array[-398 + (int)(126.6873f*a)];           // float array optimized
+    return -0.0001*sine_array[-398 + _round(126.6873f*a)];      // int array optimized
   } else {
-    // return -sine_array[(int)(199.0*(1.0 - (a - 3*_PI/2) / (_PI/2.0)))];
-    //return -sine_array[796 - (int)(126.6873*a)];           // float array optimized
-    return -0.0001*sine_array[796 - _round(126.6873*a)];      // int array optimized
+    // return -sine_array[(int)(199.0f*(1.0f - (a - 3*_PI/2) / (_PI/2.0)))];
+    //return -sine_array[796 - (int)(126.6873f*a)];           // float array optimized
+    return -0.0001*sine_array[796 - _round(126.6873f*a)];      // int array optimized
   }
 }
 
@@ -54,7 +54,7 @@ float _electricalAngle(float shaft_angle, int pole_pairs) {
   return (shaft_angle * pole_pairs);
 }
 
-// square root approximation function using 
+// square root approximation function using
 // https://reprap.org/forum/read.php?147,219210
 // https://en.wikipedia.org/wiki/Fast_inverse_square_root
 float _sqrtApprox(float number) {//low in fat
@@ -67,7 +67,7 @@ float _sqrtApprox(float number) {//low in fat
   y = number;
   i = * ( long * ) &y;
   i = 0x5f375a86 - ( i >> 1 );
-  y = * ( float * ) &i; 
+  y = * ( float * ) &i;
   // y = y * ( f - ( x * y * y ) ); // better precision
   return number * y;
 }

--- a/src/common/foc_utils.h
+++ b/src/common/foc_utils.h
@@ -12,31 +12,31 @@
 #define _UNUSED(v) (void) (v)
 
 // utility defines
-#define _2_SQRT3 1.15470053838
-#define _SQRT3 1.73205080757
-#define _1_SQRT3 0.57735026919
-#define _SQRT3_2 0.86602540378
-#define _SQRT2 1.41421356237
-#define _120_D2R 2.09439510239
-#define _PI 3.14159265359
-#define _PI_2 1.57079632679
-#define _PI_3 1.0471975512
-#define _2PI 6.28318530718
-#define _3PI_2 4.71238898038
-#define _PI_6 0.52359877559
+#define _2_SQRT3 1.15470053838f
+#define _SQRT3 1.73205080757f
+#define _1_SQRT3 0.57735026919f
+#define _SQRT3_2 0.86602540378f
+#define _SQRT2 1.41421356237f
+#define _120_D2R 2.09439510239f
+#define _PI 3.14159265359f
+#define _PI_2 1.57079632679f
+#define _PI_3 1.0471975512f
+#define _2PI 6.28318530718f
+#define _3PI_2 4.71238898038f
+#define _PI_6 0.52359877559f
 
 #define NOT_SET -12345.0
 #define _HIGH_IMPEDANCE 0
 #define _HIGH_Z _HIGH_IMPEDANCE
 #define _ACTIVE 1
 
-// dq current structure 
+// dq current structure
 struct DQCurrent_s
 {
     float d;
     float q;
 };
-// phase current structure 
+// phase current structure
 struct PhaseCurrent_s
 {
     float a;
@@ -54,27 +54,27 @@ struct DQVoltage_s
 /**
  *  Function approximating the sine calculation by using fixed size array
  * - execution time ~40us (Arduino UNO)
- * 
+ *
  * @param a angle in between 0 and 2PI
  */
 float _sin(float a);
 /**
  * Function approximating cosine calculation by using fixed size array
  * - execution time ~50us (Arduino UNO)
- * 
+ *
  * @param a angle in between 0 and 2PI
  */
 float _cos(float a);
 
-/** 
- * normalizing radian angle to [0,2PI] 
+/**
+ * normalizing radian angle to [0,2PI]
  * @param angle - angle to be normalized
- */ 
+ */
 float _normalizeAngle(float angle);
 
-    
-/** 
- * Electrical angle calculation  
+
+/**
+ * Electrical angle calculation
  *
  * @param shaft_angle - shaft angle of the motor
  * @param pole_pairs - number of pole pairs
@@ -84,7 +84,7 @@ float _electricalAngle(float shaft_angle, int pole_pairs);
 /**
  * Function approximating square root function
  *  - using fast inverse square root
- * 
+ *
  * @param value - number
  */
 float _sqrtApprox(float value);

--- a/src/common/pid.cpp
+++ b/src/common/pid.cpp
@@ -6,9 +6,9 @@ PIDController::PIDController(float P, float I, float D, float ramp, float limit)
     , D(D)
     , output_ramp(ramp)    // output derivative limit [volts/second]
     , limit(limit)         // output supply limit     [volts]
-    , integral_prev(0.0)
-    , error_prev(0.0)
-    , output_prev(0.0)
+    , integral_prev(0.0f)
+    , error_prev(0.0f)
+    , output_prev(0.0f)
 {
     timestamp_prev = _micros();
 }
@@ -17,13 +17,13 @@ PIDController::PIDController(float P, float I, float D, float ramp, float limit)
 float PIDController::operator() (float error){
     // calculate the time from the last call
     unsigned long timestamp_now = _micros();
-    float Ts = (timestamp_now - timestamp_prev) * 1e-6;
+    float Ts = (timestamp_now - timestamp_prev) * 1e-6f;
     // quick fix for strange cases (micros overflow)
-    if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+    if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
     // u(s) = (P + I/s + Ds)e(s)
     // Discrete implementations
-    // proportional part 
+    // proportional part
     // u_p  = P *e(k)
     float proportional = P * error;
     // Tustin transform of the integral part
@@ -56,4 +56,3 @@ float PIDController::operator() (float error){
     timestamp_prev = timestamp_now;
     return output;
 }
-

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -24,14 +24,14 @@ typedef void (* CommandCallback)(char*); //!< command callback function pointer
 
 /**
  * Commander class implementing string communication protocol based on IDvalue (ex AB5.321 - command id `A`, sub-command id `B`,value `5.321`)
- * 
- *  - This class can be used in combination with HardwareSerial instance which it would read and write 
+ *
+ *  - This class can be used in combination with HardwareSerial instance which it would read and write
  *    or it can be used to parse strings that have been received from the user outside this library
  *  - Commander class implements command protocol for few standard components of the SimpleFOC library
  *     - FOCMotor
  *     - PIDController
  *     - LowPassFilter
- *  - Commander also provides a very simple command > callback interface that enables user to 
+ *  - Commander also provides a very simple command > callback interface that enables user to
  *    attach a callback function to certain command id - see function add()
  */
 class Commander
@@ -40,7 +40,7 @@ class Commander
     /**
      * Default constructor receiving a serial interface that it uses to output the values to
      * Also if the function run() is used it uses this serial instance to read the serial for user commands
-     * 
+     *
      * @param serial - Serial com port instance
      * @param eol - the end of line sentinel character
      * @param echo - echo last typed character (for command line feedback)
@@ -49,45 +49,45 @@ class Commander
     Commander(char eol = '\n', bool echo = false);
 
     /**
-     * Function reading the serial port and firing callbacks that have been added to the commander 
-     * once the user has requested them - when he sends the command  
-     * 
+     * Function reading the serial port and firing callbacks that have been added to the commander
+     * once the user has requested them - when he sends the command
+     *
      *  - It has default commands (the letters can be changed in the commands.h file)
-     *    '@' - Verbose mode        
+     *    '@' - Verbose mode
      *    '#' - Number of decimal places
-     *    '?' - Scan command - displays all the labels of attached nodes 
-     */ 
+     *    '?' - Scan command - displays all the labels of attached nodes
+     */
     void run();
     /**
-     * Function reading the string of user input and firing callbacks that have been added to the commander 
-     * once the user has requested them - when he sends the command  
-     * 
+     * Function reading the string of user input and firing callbacks that have been added to the commander
+     * once the user has requested them - when he sends the command
+     *
      *  - It has default commands (the letters can be changed in the commands.h file)
-     *    '@' - Verbose mode        
+     *    '@' - Verbose mode
      *    '#' - Number of decimal places
      *    '?' - Scan command - displays all the labels of attached nodes
-     * 
+     *
      * @param reader - temporary stream to read user input
      * @param eol - temporary end of line sentinel
-     */ 
+     */
     void run(Stream &reader, char eol = '\n');
     /**
-     * Function reading the string of user input and firing callbacks that have been added to the commander 
-     * once the user has requested them - when he sends the command  
-     * 
+     * Function reading the string of user input and firing callbacks that have been added to the commander
+     * once the user has requested them - when he sends the command
+     *
      *  - It has default commands (the letters can be changed in the commands.h file)
-     *    '@' - Verbose mode        
+     *    '@' - Verbose mode
      *    '#' - Number of decimal places
      *    '?' - Scan command - displays all the labels of attached nodes
-     * 
+     *
      * @param user_input - string of user inputs
-     */ 
+     */
     void run(char* user_input);
 
     /**
      *  Function adding a callback to the coomander withe the command id
      * @param id         - char command letter
-     * @param onCommand  - function pointer void function(char*) 
+     * @param onCommand  - function pointer void function(char*)
      * @param label      - string label to be displayed when scan command sent
      */
     void add(char id , CommandCallback onCommand, char* label = nullptr);
@@ -101,48 +101,48 @@ class Commander
     char eol = '\n'; //!< end of line sentinel character
     bool echo = false; //!< echo last typed character (for command line feedback)
     /**
-     * 
+     *
      * FOC motor (StepperMotor and BLDCMotor) command interface
      *  - It has several paramters (the letters can be changed in the commands.h file)
      *    'Q' - Q current PID controller & LPF (see function pid and lpf for commands)
-     *    'D' - D current PID controller & LPF (see function pid and lpf for commands)  
-     *    'V' - Velocity PID controller & LPF  (see function pid and lpf for commands)  
-     *    'A' - Angle PID controller & LPF     (see function pid and lpf for commands) 
-     *    'L' - Limits                         
+     *    'D' - D current PID controller & LPF (see function pid and lpf for commands)
+     *    'V' - Velocity PID controller & LPF  (see function pid and lpf for commands)
+     *    'A' - Angle PID controller & LPF     (see function pid and lpf for commands)
+     *    'L' - Limits
      *           sub-commands:
-     *           'C' - Current  
-     *           'U' - Voltage   
-     *           'V' - Velocity  
-     *    'C' - Motion control type config   
+     *           'C' - Current
+     *           'U' - Voltage
+     *           'V' - Velocity
+     *    'C' - Motion control type config
      *          sub-commands:
-     *          'D' - downsample motiron loop 
-     *          '0' - torque    
-     *          '1' - velocity 
-     *          '2' - angle    
-     *    'T' - Torque control type        
+     *          'D' - downsample motiron loop
+     *          '0' - torque
+     *          '1' - velocity
+     *          '2' - angle
+     *    'T' - Torque control type
      *          sub-commands:
-     *          '0' - voltage      
-     *          '1' - current     
-     *          '2' - foc_current 
-     *    'E' - Motor status (enable/disable)  
+     *          '0' - voltage
+     *          '1' - current
+     *          '2' - foc_current
+     *    'E' - Motor status (enable/disable)
      *          sub-commands:
-     *          '0' - enable    
-     *          '1' - disable  
-     *    'R' - Motor resistance               
-     *    'S' - Sensor offsets                 
+     *          '0' - enable
+     *          '1' - disable
+     *    'R' - Motor resistance
+     *    'S' - Sensor offsets
      *          sub-commands:
-     *          'M' - sensor offset          
-     *          'E' - sensor electrical zero 
-     *    'M' - Monitoring control             
+     *          'M' - sensor offset
+     *          'E' - sensor electrical zero
+     *    'M' - Monitoring control
      *          sub-commands:
-     *          'D' - downsample monitoring     
-     *          'C' - clear monitor             
-     *          'S' - set monitoring variables  
-     *          'G' - get variable value        
-     *    '' - Target get/set                  
-     *  
+     *          'D' - downsample monitoring
+     *          'C' - clear monitor
+     *          'S' - set monitoring variables
+     *          'G' - get variable value
+     *    '' - Target get/set
+     *
      *  - Each of them can be get by sening the command letter -(ex. 'R' - to get the phase resistance)
-     *  - Each of them can be set by sending 'IdSubidValue' - (ex. SM1.5 for setting sensor zero offset to 1.5)
+     *  - Each of them can be set by sending 'IdSubidValue' - (ex. SM1.5 for setting sensor zero offset to 1.5f)
      *
      */
     void motor(FOCMotor* motor, char* user_cmd);
@@ -170,7 +170,7 @@ class Commander
      * Float variable scalar command interface
      *  - It only has one property - one float value
      *  - It can be get by sending an empty string '\n'
-     *  - It can be set by sending 'value' - (ex. 0.01 for settin *value=0.01)
+     *  - It can be set by sending 'value' - (ex. 0.01f for settin *value=0.01)
      */
     void scalar(float* value, char* user_cmd);
 
@@ -184,19 +184,19 @@ class Commander
     // helping variable for serial communication reading
     char received_chars[MAX_COMMAND_LENGTH] = {0}; //!< so far received user message - waiting for newline
     int rec_cnt = 0; //!< number of characters receives
-        
+
     // serial printing functions
     /**
      *  print the string message only if verbose mode on
      *  @param message - message to be printed
      */
-    void printVerbose(const char* message); 
+    void printVerbose(const char* message);
     /**
-     *  Print the string message only if verbose mode on 
+     *  Print the string message only if verbose mode on
      *  - Function handling the case for strings defined by F macro
      *  @param message - message to be printed
      */
-    void printVerbose(const __FlashStringHelper *message);  
+    void printVerbose(const __FlashStringHelper *message);
     /**
      *  print the numbers to the serial with desired decimal point number
      *  @param message - number to be printed

--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -12,7 +12,7 @@ InlineCurrentSense::InlineCurrentSense(float _shunt_resistor, float _gain, int _
 
     shunt_resistor = _shunt_resistor;
     amp_gain  = _gain;
-    volts_to_amps_ratio = 1.0 /_shunt_resistor / _gain; // volts to amps
+    volts_to_amps_ratio = 1.0f /_shunt_resistor / _gain; // volts to amps
     // gains for each phase
     gain_a = volts_to_amps_ratio;
     gain_b = volts_to_amps_ratio;
@@ -72,36 +72,36 @@ int InlineCurrentSense::driverSync(BLDCDriver *driver){
 int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     int exit_flag = 1;
     if(skip_align) return exit_flag;
-    
+
     // set phase A active and phases B and C down
     driver->setPwm(voltage, 0, 0);
-    _delay(200); 
+    _delay(200);
     PhaseCurrent_s c = getPhaseCurrents();
     // read the current 100 times ( arbitrary number )
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4*c1.a;
-        c.b = c.b*0.6 + 0.4*c1.b;
-        c.c = c.c*0.6 + 0.4*c1.c;
+        c.a = c.a*0.6 + 0.4f*c1.a;
+        c.b = c.b*0.6 + 0.4f*c1.b;
+        c.c = c.c*0.6 + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
     // align phase A
     float ab_ratio = fabs(c.a / c.b);
     float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
-    if( ab_ratio > 1.5 ){ // should be ~2    
+    if( ab_ratio > 1.5f ){ // should be ~2
         gain_a *= _sign(c.a);
-    }else if( ab_ratio < 0.7 ){ // should be ~0.5
+    }else if( ab_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and B
         int tmp_pinA = pinA;
-        pinA = pinB; 
+        pinA = pinB;
         pinB = tmp_pinA;
         gain_a *= _sign(c.b);
         exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) &&  ac_ratio < 0.7 ){ // should be ~0.5
+    }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and C
         int tmp_pinA = pinA;
-        pinA = pinC; 
+        pinA = pinC;
         pinC= tmp_pinA;
         gain_a *= _sign(c.c);
         exit_flag = 2;// signal that pins have been switched
@@ -109,35 +109,35 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
         // error in current sense - phase either not measured or bad connection
         return 0;
     }
-    
+
     // set phase B active and phases A and C down
     driver->setPwm(0, voltage, 0);
-    _delay(200); 
+    _delay(200);
     c = getPhaseCurrents();
     // read the current 50 times
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4*c1.a;
-        c.b = c.b*0.6 + 0.4*c1.b;
-        c.c = c.c*0.6 + 0.4*c1.c;
+        c.a = c.a*0.6 + 0.4f*c1.a;
+        c.b = c.b*0.6 + 0.4f*c1.b;
+        c.c = c.c*0.6 + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
     float ba_ratio = fabs(c.b/c.a);
     float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
-     if( ba_ratio > 1.5 ){ // should be ~2
+     if( ba_ratio > 1.5f ){ // should be ~2
         gain_b *= _sign(c.b);
-    }else if( ba_ratio < 0.7 ){ // it should be ~0.5
+    }else if( ba_ratio < 0.7f ){ // it should be ~0.5
         // switch phase A and B
         int tmp_pinB = pinB;
-        pinB = pinA; 
+        pinB = pinA;
         pinA = tmp_pinB;
         gain_b *= _sign(c.a);
         exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) && bc_ratio < 0.7 ){ // should be ~0.5
+    }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and C
         int tmp_pinB = pinB;
-        pinB = pinC; 
+        pinB = pinC;
         pinC = tmp_pinB;
         gain_b *= _sign(c.c);
         exit_flag = 2; // signal that pins have been switched
@@ -150,7 +150,7 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     if(_isset(pinC)){
         // set phase B active and phases A and C down
         driver->setPwm(0, 0, voltage);
-        _delay(200); 
+        _delay(200);
         c = getPhaseCurrents();
         // read the adc voltage 500 times ( arbitrary number )
         for (int i = 0; i < 50; i++) {
@@ -170,4 +170,3 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     // 4 - success but pins reconfigured and gains inverted
     return exit_flag;
 }
-

--- a/src/current_sense/LowsideCurrentSense.cpp
+++ b/src/current_sense/LowsideCurrentSense.cpp
@@ -12,7 +12,7 @@ LowsideCurrentSense::LowsideCurrentSense(float _shunt_resistor, float _gain, int
 
     shunt_resistor = _shunt_resistor;
     amp_gain  = _gain;
-    volts_to_amps_ratio = 1.0 /_shunt_resistor / _gain; // volts to amps
+    volts_to_amps_ratio = 1.0f /_shunt_resistor / _gain; // volts to amps
     // gains for each phase
     gain_a = volts_to_amps_ratio;
     gain_b = volts_to_amps_ratio;
@@ -41,9 +41,9 @@ void LowsideCurrentSense::calibrateOffsets(){
         _delay(1);
     }
     // calculate the mean offsets
-    offset_ia = offset_ia / 1000.0;
-    offset_ib = offset_ib / 1000.0;
-    if(_isset(pinC)) offset_ic = offset_ic / 1000.0;
+    offset_ia = offset_ia / 1000.0f;
+    offset_ib = offset_ib / 1000.0f;
+    if(_isset(pinC)) offset_ic = offset_ic / 1000.0f;
 }
 
 // read all three phase currents (if possible 2 or 3)
@@ -86,25 +86,25 @@ int LowsideCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     // read the current 100 times ( arbitrary number )
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4*c1.a;
-        c.b = c.b*0.6 + 0.4*c1.b;
-        c.c = c.c*0.6 + 0.4*c1.c;
+        c.a = c.a*0.6 + 0.4f*c1.a;
+        c.b = c.b*0.6 + 0.4f*c1.b;
+        c.c = c.c*0.6 + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
     // align phase A
     float ab_ratio = fabs(c.a / c.b);
     float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
-    if( ab_ratio > 1.5 ){ // should be ~2
+    if( ab_ratio > 1.5f ){ // should be ~2
         gain_a *= _sign(c.a);
-    }else if( ab_ratio < 0.7 ){ // should be ~0.5
+    }else if( ab_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and B
         int tmp_pinA = pinA;
         pinA = pinB;
         pinB = tmp_pinA;
         gain_a *= _sign(c.b);
         exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) &&  ac_ratio < 0.7 ){ // should be ~0.5
+    }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and C
         int tmp_pinA = pinA;
         pinA = pinC;
@@ -123,24 +123,24 @@ int LowsideCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     // read the current 50 times
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4*c1.a;
-        c.b = c.b*0.6 + 0.4*c1.b;
-        c.c = c.c*0.6 + 0.4*c1.c;
+        c.a = c.a*0.6 + 0.4f*c1.a;
+        c.b = c.b*0.6 + 0.4f*c1.b;
+        c.c = c.c*0.6 + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
     float ba_ratio = fabs(c.b/c.a);
     float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
-     if( ba_ratio > 1.5 ){ // should be ~2
+     if( ba_ratio > 1.5f ){ // should be ~2
         gain_b *= _sign(c.b);
-    }else if( ba_ratio < 0.7 ){ // it should be ~0.5
+    }else if( ba_ratio < 0.7f ){ // it should be ~0.5
         // switch phase A and B
         int tmp_pinB = pinB;
         pinB = pinA;
         pinA = tmp_pinB;
         gain_b *= _sign(c.a);
         exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) && bc_ratio < 0.7 ){ // should be ~0.5
+    }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
         // switch phase A and C
         int tmp_pinB = pinB;
         pinB = pinC;

--- a/src/current_sense/hardware_api.h
+++ b/src/current_sense/hardware_api.h
@@ -6,14 +6,14 @@
 
 /**
  *  function reading an ADC value and returning the read voltage
- * 
+ *
  * @param pinA - the arduino pin to be read (it has to be ADC pin)
  */
 float _readADCVoltageInline(const int pinA);
 
 /**
  *  function reading an ADC value and returning the read voltage
- * 
+ *
  * @param pinA - adc pin A
  * @param pinB - adc pin B
  * @param pinC - adc pin C
@@ -21,8 +21,8 @@ float _readADCVoltageInline(const int pinA);
 void _configureADCInline(const int pinA,const int pinB,const int pinC = NOT_SET);
 
 /**
- *  function reading an ADC value and returning the read voltage 
- * 
+ *  function reading an ADC value and returning the read voltage
+ *
  * @param pinA - adc pin A
  * @param pinB - adc pin B
  * @param pinC - adc pin C
@@ -33,7 +33,7 @@ void _startADC3PinConversionLowSide();
 
 /**
  *  function reading an ADC value and returning the read voltage
- * 
+ *
  * @param pinA - the arduino pin to be read (it has to be ADC pin)
  */
 float _readADCVoltageLowSide(const int pinA);

--- a/src/current_sense/hardware_specific/esp32_mcu.cpp
+++ b/src/current_sense/hardware_specific/esp32_mcu.cpp
@@ -6,8 +6,8 @@
 #include "soc/mcpwm_reg.h"
 #include "soc/mcpwm_struct.h"
 
-#define _ADC_VOLTAGE 3.3
-#define _ADC_RESOLUTION 4095.0
+#define _ADC_VOLTAGE 3.3f
+#define _ADC_RESOLUTION 4095.0f
 
 static mcpwm_dev_t *MCPWM[2] = {&MCPWM0, &MCPWM1};
 int a1, a2, a3;         //Current readings from internal current sensor amplifiers
@@ -31,7 +31,7 @@ float _readADCVoltageLowSide(const int pin){
 }
 
 void _startADC3PinConversionLowSide(){
-  
+
 }
 
 // function reading an ADC value and returning the read voltage

--- a/src/current_sense/hardware_specific/generic_mcu.cpp
+++ b/src/current_sense/hardware_specific/generic_mcu.cpp
@@ -3,8 +3,8 @@
 
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega2560__) //  if mcu is atmega328 or atmega2560
-  #define _ADC_VOLTAGE 5.0
-  #define _ADC_RESOLUTION 1024.0
+  #define _ADC_VOLTAGE 5.0f
+  #define _ADC_RESOLUTION 1024.0f
   #ifndef cbi
     #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
   #endif
@@ -12,20 +12,20 @@
     #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
   #endif
 #elif defined(__arm__) && defined(CORE_TEENSY)  // or teensy
-  #define _ADC_VOLTAGE 3.3
-  #define _ADC_RESOLUTION 1024.0
+  #define _ADC_VOLTAGE 3.3f
+  #define _ADC_RESOLUTION 1024.0f
 #elif defined(__arm__) && defined(__SAM3X8E__)  // or due
-  #define _ADC_VOLTAGE 3.3
-  #define _ADC_RESOLUTION 1024.0
+  #define _ADC_VOLTAGE 3.3f
+  #define _ADC_RESOLUTION 1024.0f
 #elif defined(ESP_H)  // or esp32
   // do nothing implemented in esp32_mcu.h
 
 #elif defined(_STM32_DEF_) // or stm32
-  #define _ADC_VOLTAGE 3.3
-  #define _ADC_RESOLUTION 1024.0
+  #define _ADC_VOLTAGE 3.3f
+  #define _ADC_RESOLUTION 1024.0f
 #else
-  #define _ADC_VOLTAGE 5.0
-  #define _ADC_RESOLUTION 1024.0
+  #define _ADC_VOLTAGE 5.0f
+  #define _ADC_RESOLUTION 1024.0f
 #endif
 
 // adc counts to voltage conversion ratio
@@ -46,9 +46,9 @@ void _configureADCInline(const int pinA,const int pinB,const int pinC){
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega2560__) //  if mcu is atmega328 or atmega2560
-    // set hight frequency adc - ADPS2,ADPS1,ADPS0 | 001 (16mhz/2) | 010 ( 16mhz/4 ) | 011 (16mhz/8) | 100(16mhz/16) | 101 (16mhz/32) | 110 (16mhz/64) | 111 (16mhz/128 default)  
-    // set divisor to 8 - adc frequency 16mhz/8 = 2 mhz 
-    // arduino takes 25 conversions per sample so - 2mhz/25 = 80k samples per second - 12.5us per sample 
+    // set hight frequency adc - ADPS2,ADPS1,ADPS0 | 001 (16mhz/2) | 010 ( 16mhz/4 ) | 011 (16mhz/8) | 100(16mhz/16) | 101 (16mhz/32) | 110 (16mhz/64) | 111 (16mhz/128 default)
+    // set divisor to 8 - adc frequency 16mhz/8 = 2 mhz
+    // arduino takes 25 conversions per sample so - 2mhz/25 = 80k samples per second - 12.5us per sample
     cbi(ADCSRA, ADPS2);
     sbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);

--- a/src/current_sense/hardware_specific/samd21_mcu.cpp
+++ b/src/current_sense/hardware_specific/samd21_mcu.cpp
@@ -9,8 +9,8 @@ static int _pinA, _pinB, _pinC;
 static uint16_t a = 0xFFFF, b = 0xFFFF, c = 0xFFFF; // updated by adcStopWithDMA when configured in freerunning mode
 static SAMDCurrentSenseADCDMA instance;
 /**
- *  function reading an ADC value and returning the read voltage 
- * 
+ *  function reading an ADC value and returning the read voltage
+ *
  * @param pinA - adc pin A
  * @param pinB - adc pin B
  * @param pinC - adc pin C
@@ -18,7 +18,7 @@ static SAMDCurrentSenseADCDMA instance;
 void _configureADCLowSide(const int pinA,const int pinB,const int pinC)
 {
   _pinA = pinA;
-  _pinB = pinB; 
+  _pinB = pinB;
   _pinC = pinC;
   freeRunning = true;
   instance.init(pinA, pinB, pinC);
@@ -30,13 +30,13 @@ void _startADC3PinConversionLowSide()
 }
 /**
  *  function reading an ADC value and returning the read voltage
- * 
+ *
  * @param pinA - the arduino pin to be read (it has to be ADC pin)
  */
 float _readADCVoltageLowSide(const int pinA)
 {
   instance.readResults(a, b, c);
-  
+
   if(pinA == _pinA)
     return instance.toVolts(a);
   if(pinA == _pinB)
@@ -72,7 +72,7 @@ static void adcStopWithDMA(void);
 static void adcStartWithDMA(void);
 
 /**
- * @brief  ADC sync wait 
+ * @brief  ADC sync wait
  * @retval void
  */
 static __inline__ void ADCsync() __attribute__((always_inline, unused));
@@ -82,9 +82,9 @@ static void   ADCsync() {
 
 //  ADC DMA sequential free running (6) with Interrupts /////////////////
 
-SAMDCurrentSenseADCDMA * SAMDCurrentSenseADCDMA::getHardwareAPIInstance() 
+SAMDCurrentSenseADCDMA * SAMDCurrentSenseADCDMA::getHardwareAPIInstance()
 {
-  
+
   return &instance;
 }
 
@@ -136,7 +136,7 @@ float SAMDCurrentSenseADCDMA::toVolts(uint16_t counts) {
 }
 
 void SAMDCurrentSenseADCDMA::initPins(){
-  
+
   pinMode(pinAREF, INPUT);
   pinMode(pinA, INPUT);
   pinMode(pinB, INPUT);
@@ -145,7 +145,7 @@ void SAMDCurrentSenseADCDMA::initPins(){
   uint32_t ainB = g_APinDescription[pinB].ulADCChannelNumber;
   firstAIN = min(ainA, ainB);
   lastAIN = max(ainA, ainB);
-  if( _isset(pinC) ) 
+  if( _isset(pinC) )
   {
     uint32_t ainC = g_APinDescription[pinC].ulADCChannelNumber;
     pinMode(pinC, INPUT);
@@ -160,13 +160,13 @@ void SAMDCurrentSenseADCDMA::initPins(){
 
 void SAMDCurrentSenseADCDMA::initADC(){
 
-  analogRead(pinA);  // do some pin init  pinPeripheral() 
-  analogRead(pinB);  // do some pin init  pinPeripheral() 
-  analogRead(pinC);  // do some pin init  pinPeripheral() 
+  analogRead(pinA);  // do some pin init  pinPeripheral()
+  analogRead(pinB);  // do some pin init  pinPeripheral()
+  analogRead(pinC);  // do some pin init  pinPeripheral()
 
   ADC->CTRLA.bit.ENABLE = 0x00; // Disable ADC
   ADCsync();
-  //ADC->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; //  2.2297 V Supply VDDANA
+  //ADC->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_INTVCC0_Val; //  2.2297f V Supply VDDANA
   ADC->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_1X_Val; // Gain select as 1X
   // ADC->INPUTCTRL.bit.GAIN = ADC_INPUTCTRL_GAIN_DIV2_Val;  // default
   ADC->REFCTRL.bit.REFSEL = ADC_REFCTRL_REFSEL_AREFA;
@@ -215,7 +215,7 @@ void SAMDCurrentSenseADCDMA::initADC(){
   */
   ADC->INPUTCTRL.bit.MUXPOS = oneBeforeFirstAIN;
   ADCsync();
-  ADC->INPUTCTRL.bit.INPUTSCAN = lastAIN; // so the adc will scan from oneBeforeFirstAIN to lastAIN (inclusive) 
+  ADC->INPUTCTRL.bit.INPUTSCAN = lastAIN; // so the adc will scan from oneBeforeFirstAIN to lastAIN (inclusive)
   ADCsync();
   ADC->INPUTCTRL.bit.INPUTOFFSET = 0; //input scan cursor
   ADCsync();
@@ -246,9 +246,9 @@ void SAMDCurrentSenseADCDMA::adcToDMATransfer(void *rxdata,  uint32_t hwords) {
   DMAC->CHCTRLA.reg &= ~DMAC_CHCTRLA_ENABLE;
   DMAC->CHCTRLA.reg = DMAC_CHCTRLA_SWRST;
   DMAC->SWTRIGCTRL.reg &= (uint32_t)(~(1 << channelDMA));
-  
-  DMAC->CHCTRLB.reg = DMAC_CHCTRLB_LVL(0) 
-  | DMAC_CHCTRLB_TRIGSRC(ADC_DMAC_ID_RESRDY) 
+
+  DMAC->CHCTRLB.reg = DMAC_CHCTRLB_LVL(0)
+  | DMAC_CHCTRLB_TRIGSRC(ADC_DMAC_ID_RESRDY)
   | DMAC_CHCTRLB_TRIGACT_BEAT;
   DMAC->CHINTENSET.reg = DMAC_CHINTENSET_MASK ; // enable all 3 interrupts
   descriptor.descaddr = 0;
@@ -289,7 +289,7 @@ void adcStartWithDMA(void){
   ADCsync();
   ADC->SWTRIG.bit.FLUSH = 1;
   ADCsync();
-  ADC->CTRLA.bit.ENABLE = 0x01; 
+  ADC->CTRLA.bit.ENABLE = 0x01;
   ADCsync();
 }
 

--- a/src/drivers/BLDCDriver3PWM.cpp
+++ b/src/drivers/BLDCDriver3PWM.cpp
@@ -39,7 +39,7 @@ void BLDCDriver3PWM::disable()
 
 }
 
-// init hardware pins   
+// init hardware pins
 int BLDCDriver3PWM::init() {
   // PWM pins
   pinMode(pwmA, OUTPUT);
@@ -62,7 +62,7 @@ int BLDCDriver3PWM::init() {
 
 
 // Set voltage to the pwm pin
-void BLDCDriver3PWM::setPhaseState(int sa, int sb, int sc) {  
+void BLDCDriver3PWM::setPhaseState(int sa, int sb, int sc) {
   // disable if needed
   if( _isset(enableA_pin) &&  _isset(enableB_pin)  && _isset(enableC_pin) ){
     digitalWrite(enableA_pin, sa == _HIGH_IMPEDANCE ? LOW : HIGH);
@@ -73,16 +73,16 @@ void BLDCDriver3PWM::setPhaseState(int sa, int sb, int sc) {
 
 // Set voltage to the pwm pin
 void BLDCDriver3PWM::setPwm(float Ua, float Ub, float Uc) {
-  
+
   // limit the voltage in driver
   Ua = _constrain(Ua, 0.0, voltage_limit);
   Ub = _constrain(Ub, 0.0, voltage_limit);
-  Uc = _constrain(Uc, 0.0, voltage_limit);    
+  Uc = _constrain(Uc, 0.0, voltage_limit);
   // calculate duty cycle
   // limited in [0,1]
-  dc_a = _constrain(Ua / voltage_power_supply, 0.0 , 1.0 );
-  dc_b = _constrain(Ub / voltage_power_supply, 0.0 , 1.0 );
-  dc_c = _constrain(Uc / voltage_power_supply, 0.0 , 1.0 );
+  dc_a = _constrain(Ua / voltage_power_supply, 0.0f , 1.0f );
+  dc_b = _constrain(Ub / voltage_power_supply, 0.0f , 1.0f );
+  dc_c = _constrain(Uc / voltage_power_supply, 0.0f , 1.0f );
 
   // hardware specific writing
   // hardware specific function - depending on driver and mcu

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -15,9 +15,9 @@ BLDCDriver6PWM::BLDCDriver6PWM(int phA_h,int phA_l,int phB_h,int phB_l,int phC_h
   // default power-supply value
   voltage_power_supply = DEF_POWER_SUPPLY;
   voltage_limit = NOT_SET;
- 
+
   // dead zone initial - 2%
-  dead_zone = 0.02;
+  dead_zone = 0.02f;
 
 }
 
@@ -39,9 +39,9 @@ void BLDCDriver6PWM::disable()
 
 }
 
-// init hardware pins   
+// init hardware pins
 int BLDCDriver6PWM::init() {
-  
+
   // PWM pins
   pinMode(pwmA_h, OUTPUT);
   pinMode(pwmB_h, OUTPUT);
@@ -55,22 +55,22 @@ int BLDCDriver6PWM::init() {
   // sanity check for the voltage limit configuration
   if( !_isset(voltage_limit) || voltage_limit > voltage_power_supply) voltage_limit =  voltage_power_supply;
 
-  // configure 6pwm 
+  // configure 6pwm
   // hardware specific function - depending on driver and mcu
   return _configure6PWM(pwm_frequency, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
 }
 
 // Set voltage to the pwm pin
-void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {  
+void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
   // limit the voltage in driver
   Ua = _constrain(Ua, 0, voltage_limit);
   Ub = _constrain(Ub, 0, voltage_limit);
-  Uc = _constrain(Uc, 0, voltage_limit);    
+  Uc = _constrain(Uc, 0, voltage_limit);
   // calculate duty cycle
   // limited in [0,1]
-  dc_a = _constrain(Ua / voltage_power_supply, 0.0 , 1.0 );
-  dc_b = _constrain(Ub / voltage_power_supply, 0.0 , 1.0 );
-  dc_c = _constrain(Uc / voltage_power_supply, 0.0 , 1.0 );
+  dc_a = _constrain(Ua / voltage_power_supply, 0.0f , 1.0f );
+  dc_b = _constrain(Ub / voltage_power_supply, 0.0f , 1.0f );
+  dc_c = _constrain(Uc / voltage_power_supply, 0.0f , 1.0f );
   // hardware specific writing
   // hardware specific function - depending on driver and mcu
   _writeDutyCycle6PWM(dc_a, dc_b, dc_c, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
@@ -78,6 +78,6 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
 
 
 // Set voltage to the pwm pin
-void BLDCDriver6PWM::setPhaseState(int sa, int sb, int sc) {  
+void BLDCDriver6PWM::setPhaseState(int sa, int sb, int sc) {
   // TODO implement disabling
 }

--- a/src/drivers/StepperDriver2PWM.cpp
+++ b/src/drivers/StepperDriver2PWM.cpp
@@ -27,7 +27,7 @@ StepperDriver2PWM::StepperDriver2PWM(int _pwm1, int _dir1, int _pwm2, int _dir2,
   dir2a = _dir2; // phase 2 direction pin
   // these pins are not used
   dir1b = NOT_SET;
-  dir2b = NOT_SET; 
+  dir2b = NOT_SET;
 
   // enable_pin pin
   enable_pin1 = en1;
@@ -59,7 +59,7 @@ void StepperDriver2PWM::disable()
 
 }
 
-// init hardware pins   
+// init hardware pins
 int StepperDriver2PWM::init() {
   // PWM pins
   pinMode(pwm1, OUTPUT);
@@ -83,22 +83,22 @@ int StepperDriver2PWM::init() {
 
 
 // Set voltage to the pwm pin
-void StepperDriver2PWM::setPwm(float Ua, float Ub) {  
-  float duty_cycle1(0.0),duty_cycle2(0.0);
+void StepperDriver2PWM::setPwm(float Ua, float Ub) {
+  float duty_cycle1(0.0f),duty_cycle2(0.0f);
   // limit the voltage in driver
   Ua = _constrain(Ua, -voltage_limit, voltage_limit);
   Ub = _constrain(Ub, -voltage_limit, voltage_limit);
   // hardware specific writing
   duty_cycle1 = _constrain(abs(Ua)/voltage_power_supply,0.0,1.0);
   duty_cycle2 = _constrain(abs(Ub)/voltage_power_supply,0.0,1.0);
-  
+
   // phase 1 direction
   digitalWrite(dir1a, Ua >= 0 ? LOW : HIGH);
   if( _isset(dir1b) ) digitalWrite(dir1b, Ua <= 0 ? LOW : HIGH);
   // phase 2 direction
   digitalWrite(dir2a, Ub >= 0 ? LOW : HIGH);
   if( _isset(dir2b) ) digitalWrite(dir2b, Ub <= 0 ? LOW : HIGH);
-  
+
   // write to hardware
   _writeDutyCycle2PWM(duty_cycle1, duty_cycle2, pwm1, pwm2);
 }

--- a/src/drivers/StepperDriver4PWM.cpp
+++ b/src/drivers/StepperDriver4PWM.cpp
@@ -37,7 +37,7 @@ void StepperDriver4PWM::disable()
 
 }
 
-// init hardware pins   
+// init hardware pins
 int StepperDriver4PWM::init() {
 
   // PWM pins
@@ -59,17 +59,17 @@ int StepperDriver4PWM::init() {
 
 
 // Set voltage to the pwm pin
-void StepperDriver4PWM::setPwm(float Ualpha, float Ubeta) {  
-  float duty_cycle1A(0.0),duty_cycle1B(0.0),duty_cycle2A(0.0),duty_cycle2B(0.0);
+void StepperDriver4PWM::setPwm(float Ualpha, float Ubeta) {
+  float duty_cycle1A(0.0f),duty_cycle1B(0.0f),duty_cycle2A(0.0f),duty_cycle2B(0.0f);
   // limit the voltage in driver
   Ualpha = _constrain(Ualpha, -voltage_limit, voltage_limit);
   Ubeta = _constrain(Ubeta, -voltage_limit, voltage_limit);
   // hardware specific writing
   if( Ualpha > 0 )
     duty_cycle1B = _constrain(abs(Ualpha)/voltage_power_supply,0.0,1.0);
-  else 
+  else
     duty_cycle1A = _constrain(abs(Ualpha)/voltage_power_supply,0.0,1.0);
-    
+
   if( Ubeta > 0 )
     duty_cycle2B = _constrain(abs(Ubeta)/voltage_power_supply,0.0,1.0);
   else

--- a/src/drivers/hardware_specific/atmega2560_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega2560_mcu.cpp
@@ -15,13 +15,13 @@ void _pinHighFrequency(const int pin){
       TCCR1B = ((TCCR1B & 0b11111000) | 0x01);     // set prescaler to 1
   else if (pin == 10 || pin == 9 )
       TCCR2B = ((TCCR2B & 0b11111000) | 0x01);     // set prescaler to 1
-  else if (pin == 5 || pin == 3 || pin == 2) 
+  else if (pin == 5 || pin == 3 || pin == 2)
       TCCR3B = ((TCCR2B & 0b11111000) | 0x01);    // set prescaler to 1
   else if (pin == 8 || pin == 7 || pin == 6)
       TCCR4B = ((TCCR4B & 0b11111000) | 0x01);    // set prescaler to 1
   else if (pin == 44 || pin == 45 || pin == 46)
       TCCR5B = ((TCCR5B & 0b11111000) | 0x01);    // set prescaler to 1
-  
+
 }
 
 
@@ -46,23 +46,23 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
   _pinHighFrequency(pinC);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
-  analogWrite(pinC, 255.0*dc_c);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(pinC, 255.0f*dc_c);
 }
 
 // function setting the high pwm frequency to the supplied pins
@@ -74,25 +74,25 @@ void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const i
   _pinHighFrequency(pin1A);
   _pinHighFrequency(pin1B);
   _pinHighFrequency(pin2A);
-  _pinHighFrequency(pin2B); 
+  _pinHighFrequency(pin2B);
 }
 
-// function setting the pwm duty cycle to the hardware  
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0*dc_1a);
-  analogWrite(pin1B, 255.0*dc_1b);
-  analogWrite(pin2A, 255.0*dc_2a);
-  analogWrite(pin2B, 255.0*dc_2b);
+  analogWrite(pin1A, 255.0f*dc_1a);
+  analogWrite(pin1B, 255.0f*dc_1b);
+  analogWrite(pin2A, 255.0f*dc_2a);
+  analogWrite(pin2B, 255.0f*dc_2b);
 }
 
 
 // function configuring pair of high-low side pwm channels, 32khz frequency and center aligned pwm
 // supports Arudino/ATmega2560
 int _configureComplementaryPair(int pinH, int pinL) {
-  if( (pinH == 4 && pinL == 13 ) || (pinH == 13 && pinL == 4 ) ){ 
+  if( (pinH == 4 && pinL == 13 ) || (pinH == 13 && pinL == 4 ) ){
     // configure the pwm phase-corrected mode
     TCCR0A = ((TCCR0A & 0b11111100) | 0x01);
     // configure complementary pwm on low side
@@ -121,7 +121,7 @@ int _configureComplementaryPair(int pinH, int pinL) {
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-// supports Arudino/ATmega328 
+// supports Arudino/ATmega328
 int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
   //  High PWM frequency
   // - always max 32kHz
@@ -132,12 +132,12 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   return ret_flag; // returns -1 if not well configured
 }
 
-// function setting the 
+// function setting the
 void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 {
   int pwm_h = _constrain(val-dead_time/2,0,255);
   int pwm_l = _constrain(val+dead_time/2,0,255);
-  
+
   analogWrite(pinH, pwm_h);
   if(pwm_l == 255 || pwm_l == 0)
     digitalWrite(pinL, pwm_l ? LOW : HIGH);
@@ -148,7 +148,7 @@ void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
-// supports Arudino/ATmega328 
+// supports Arudino/ATmega328
 void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
   _setPwmPair(pinA_h, pinA_l, dc_a*255.0, dead_zone*255.0);
   _setPwmPair(pinB_h, pinB_l, dc_b*255.0, dead_zone*255.0);

--- a/src/drivers/hardware_specific/atmega328_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega328_mcu.cpp
@@ -1,6 +1,6 @@
 #include "../hardware_api.h"
 
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328PB__) 
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328PB__)
 
 // set pwm frequency to 32KHz
 void _pinHighFrequency(const int pin){
@@ -12,9 +12,9 @@ void _pinHighFrequency(const int pin){
   }
   if (pin == 9 || pin == 10 )
       TCCR1B = ((TCCR1B & 0b11111000) | 0x01);     // set prescaler to 1
-  if (pin == 3 || pin == 11) 
+  if (pin == 3 || pin == 11)
       TCCR2B = ((TCCR2B & 0b11111000) | 0x01);// set prescaler to 1
-  
+
 }
 
 // function setting the high pwm frequency to the supplied pins
@@ -42,47 +42,47 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
   _pinHighFrequency(pinC);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
-  analogWrite(pinC, 255.0*dc_c);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(pinC, 255.0f*dc_c);
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-// supports Arudino/ATmega328 
+// supports Arudino/ATmega328
 void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pin1A);
   _pinHighFrequency(pin1B);
   _pinHighFrequency(pin2A);
-  _pinHighFrequency(pin2B); 
+  _pinHighFrequency(pin2B);
 }
 
-// function setting the pwm duty cycle to the hardware  
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0*dc_1a);
-  analogWrite(pin1B, 255.0*dc_1b);
-  analogWrite(pin2A, 255.0*dc_2a);
-  analogWrite(pin2B, 255.0*dc_2b);
+  analogWrite(pin1A, 255.0f*dc_1a);
+  analogWrite(pin1B, 255.0f*dc_1b);
+  analogWrite(pin2A, 255.0f*dc_2a);
+  analogWrite(pin2B, 255.0f*dc_2b);
 }
 
 
@@ -117,7 +117,7 @@ int _configureComplementaryPair(int pinH, int pinL) {
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-// supports Arudino/ATmega328 
+// supports Arudino/ATmega328
 int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
   _UNUSED(pwm_frequency);
   _UNUSED(dead_zone);
@@ -130,12 +130,12 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   return ret_flag; // returns -1 if not well configured
 }
 
-// function setting the 
+// function setting the
 void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 {
   int pwm_h = _constrain(val-dead_time/2,0,255);
   int pwm_l = _constrain(val+dead_time/2,0,255);
-  
+
   analogWrite(pinH, pwm_h);
   if(pwm_l == 255 || pwm_l == 0)
     digitalWrite(pinL, pwm_l ? LOW : HIGH);
@@ -146,7 +146,7 @@ void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
-// supports Arudino/ATmega328 
+// supports Arudino/ATmega328
 void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
   _setPwmPair(pinA_h, pinA_l, dc_a*255.0, dead_zone*255.0);
   _setPwmPair(pinB_h, pinB_l, dc_b*255.0, dead_zone*255.0);

--- a/src/drivers/hardware_specific/esp32_mcu.cpp
+++ b/src/drivers/hardware_specific/esp32_mcu.cpp
@@ -6,13 +6,13 @@
 #include "soc/mcpwm_reg.h"
 #include "soc/mcpwm_struct.h"
 
-// empty motor slot 
+// empty motor slot
 #define _EMPTY_SLOT -20
 #define _TAKEN_SLOT -21
 
 // ABI bus frequency - would be better to take it from somewhere
 // but I did nto find a good exposed variable
-#define _MCPWM_FREQ 160e6
+#define _MCPWM_FREQ 160e6f
 
 // preferred pwm resolution default
 #define _PWM_RES_DEF 2048
@@ -70,7 +70,7 @@ typedef struct {
 } bldc_6pwm_motor_slots_t;
 
 // define bldc motor slots array
-bldc_3pwm_motor_slots_t esp32_bldc_3pwm_motor_slots[4] =  { 
+bldc_3pwm_motor_slots_t esp32_bldc_3pwm_motor_slots[4] =  {
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_A, MCPWM0A, MCPWM1A, MCPWM2A}, // 1st motor will be MCPWM0 channel A
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_B, MCPWM0B, MCPWM1B, MCPWM2B}, // 2nd motor will be MCPWM0 channel B
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_A, MCPWM0A, MCPWM1A, MCPWM2A}, // 3rd motor will be MCPWM1 channel A
@@ -78,19 +78,19 @@ bldc_3pwm_motor_slots_t esp32_bldc_3pwm_motor_slots[4] =  {
   };
 
 // define stepper motor slots array
-bldc_6pwm_motor_slots_t esp32_bldc_6pwm_motor_slots[2] =  { 
+bldc_6pwm_motor_slots_t esp32_bldc_6pwm_motor_slots[2] =  {
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_A, MCPWM_OPR_B, MCPWM0A, MCPWM1A, MCPWM2A, MCPWM0B, MCPWM1B, MCPWM2B}, // 1st motor will be on MCPWM0
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_A, MCPWM_OPR_B, MCPWM0A, MCPWM1A, MCPWM2A, MCPWM0B, MCPWM1B, MCPWM2B}, // 1st motor will be on MCPWM0
-  };  
+  };
 
 // define 4pwm stepper motor slots array
-stepper_4pwm_motor_slots_t esp32_stepper_4pwm_motor_slots[2] =  { 
+stepper_4pwm_motor_slots_t esp32_stepper_4pwm_motor_slots[2] =  {
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_A, MCPWM_OPR_B, MCPWM0A, MCPWM1A, MCPWM0B, MCPWM1B}, // 1st motor will be on MCPWM0
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_A, MCPWM_OPR_B, MCPWM0A, MCPWM1A, MCPWM0B, MCPWM1B}, // 1st motor will be on MCPWM1
-  };  
+  };
 
 // define 2pwm stepper motor slots array
-stepper_2pwm_motor_slots_t esp32_stepper_2pwm_motor_slots[4] =  { 
+stepper_2pwm_motor_slots_t esp32_stepper_2pwm_motor_slots[4] =  {
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_A, MCPWM0A, MCPWM1A}, // 1st motor will be MCPWM0 channel A
   {_EMPTY_SLOT, &MCPWM0, MCPWM_UNIT_0, MCPWM_OPR_B, MCPWM0B, MCPWM1B}, // 2nd motor will be MCPWM0 channel B
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_A, MCPWM0A, MCPWM1A}, // 3rd motor will be MCPWM1 channel A
@@ -109,12 +109,12 @@ void _configureTimerFrequency(long pwm_frequency, mcpwm_dev_t* mcpwm_num,  mcpwm
   mcpwm_init(mcpwm_unit, MCPWM_TIMER_0, &pwm_config);    //Configure PWM0A & PWM0B with above settings
   mcpwm_init(mcpwm_unit, MCPWM_TIMER_1, &pwm_config);    //Configure PWM1A & PWM1B with above settings
   mcpwm_init(mcpwm_unit, MCPWM_TIMER_2, &pwm_config);    //Configure PWM2A & PWM2B with above settings
-  
+
   if (_isset(dead_zone)){
-    // dead zone is configured  
-    float dead_time = (float)(_MCPWM_FREQ / (pwm_frequency)) * dead_zone;  
-    mcpwm_deadtime_enable(mcpwm_unit, MCPWM_TIMER_0, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, dead_time/2.0, dead_time/2.0); 
-    mcpwm_deadtime_enable(mcpwm_unit, MCPWM_TIMER_1, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, dead_time/2.0, dead_time/2.0);     
+    // dead zone is configured
+    float dead_time = (float)(_MCPWM_FREQ / (pwm_frequency)) * dead_zone;
+    mcpwm_deadtime_enable(mcpwm_unit, MCPWM_TIMER_0, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, dead_time/2.0, dead_time/2.0);
+    mcpwm_deadtime_enable(mcpwm_unit, MCPWM_TIMER_1, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, dead_time/2.0, dead_time/2.0);
     mcpwm_deadtime_enable(mcpwm_unit, MCPWM_TIMER_2, MCPWM_ACTIVE_HIGH_COMPLIMENT_MODE, dead_time/2.0, dead_time/2.0);
   }
   _delay(100);
@@ -128,21 +128,21 @@ void _configureTimerFrequency(long pwm_frequency, mcpwm_dev_t* mcpwm_num,  mcpwm
   // calculate prescaler and period
   // step 1: calculate the prescaler using the default pwm resolution
   // prescaler = bus_freq / (pwm_freq * default_pwm_res) - 1
-  int prescaler = ceil((double)_MCPWM_FREQ / (double)_PWM_RES_DEF / 2.0 / (double)pwm_frequency) - 1;
+  int prescaler = ceil((double)_MCPWM_FREQ / (double)_PWM_RES_DEF / 2.0f / (double)pwm_frequency) - 1;
   // constrain prescaler
-  prescaler = _constrain(prescaler, 0, 128); 
+  prescaler = _constrain(prescaler, 0, 128);
   // now calculate the real resolution timer period necessary (pwm resolution)
   // pwm_res = bus_freq / (pwm_freq * (prescaler + 1))
-  int resolution_corrected = (double)_MCPWM_FREQ / 2.0 / (double)pwm_frequency / (double)(prescaler + 1);
+  int resolution_corrected = (double)_MCPWM_FREQ / 2.0f / (double)pwm_frequency / (double)(prescaler + 1);
   // if pwm resolution too low lower the prescaler
-  if(resolution_corrected < _PWM_RES_MIN && prescaler > 0 ) 
-    resolution_corrected = (double)_MCPWM_FREQ / 2.0 / (double)pwm_frequency / (double)(--prescaler + 1); 
+  if(resolution_corrected < _PWM_RES_MIN && prescaler > 0 )
+    resolution_corrected = (double)_MCPWM_FREQ / 2.0f / (double)pwm_frequency / (double)(--prescaler + 1);
   resolution_corrected = _constrain(resolution_corrected, _PWM_RES_MIN, _PWM_RES_MAX);
 
   // set prescaler
   mcpwm_num->timer[0].period.prescale = prescaler;
   mcpwm_num->timer[1].period.prescale = prescaler;
-  mcpwm_num->timer[2].period.prescale = prescaler;    
+  mcpwm_num->timer[2].period.prescale = prescaler;
   _delay(1);
   //set period
   mcpwm_num->timer[0].period.period = resolution_corrected;
@@ -152,13 +152,13 @@ void _configureTimerFrequency(long pwm_frequency, mcpwm_dev_t* mcpwm_num,  mcpwm
   mcpwm_num->timer[0].period.upmethod = 0;
   mcpwm_num->timer[1].period.upmethod = 0;
   mcpwm_num->timer[2].period.upmethod = 0;
-  _delay(1); 
-  // _delay(1); 
+  _delay(1);
+  // _delay(1);
   //restart the timers
   mcpwm_start(mcpwm_unit, MCPWM_TIMER_0);
   mcpwm_start(mcpwm_unit, MCPWM_TIMER_1);
   mcpwm_start(mcpwm_unit, MCPWM_TIMER_2);
-  _delay(1); 
+  _delay(1);
   // Cast here because MCPWM_SELECT_SYNC_INT0 (1) is not defined
   // in the default Espressif MCPWM headers. The correct const may be used
   // when https://github.com/espressif/esp-idf/issues/5429 is resolved.
@@ -174,15 +174,15 @@ void _configureTimerFrequency(long pwm_frequency, mcpwm_dev_t* mcpwm_num,  mcpwm
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-// supports Arudino/ATmega328, STM32 and ESP32 
+// supports Arudino/ATmega328, STM32 and ESP32
 void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
-  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max 
+  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
 
   stepper_2pwm_motor_slots_t m_slot = {};
 
   // determine which motor are we connecting
-  // and set the appropriate configuration parameters 
+  // and set the appropriate configuration parameters
   int slot_num;
   for(slot_num = 0; slot_num < 4; slot_num++){
     if(esp32_stepper_2pwm_motor_slots[slot_num].pin1pwm == _EMPTY_SLOT){ // put the new motor in the first empty slot
@@ -191,8 +191,8 @@ void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
       break;
     }
   }
-  
-  // disable all the slots with the same MCPWM 
+
+  // disable all the slots with the same MCPWM
   // disable 3pwm bldc motor which would go in the same slot
   esp32_bldc_3pwm_motor_slots[slot_num].pinA = _TAKEN_SLOT;
   if( slot_num < 2 ){
@@ -219,15 +219,15 @@ void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-// supports Arudino/ATmega328, STM32 and ESP32 
+// supports Arudino/ATmega328, STM32 and ESP32
 void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
-  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max 
+  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
 
   bldc_3pwm_motor_slots_t m_slot = {};
 
   // determine which motor are we connecting
-  // and set the appropriate configuration parameters 
+  // and set the appropriate configuration parameters
   int slot_num;
   for(slot_num = 0; slot_num < 4; slot_num++){
     if(esp32_bldc_3pwm_motor_slots[slot_num].pinA == _EMPTY_SLOT){ // put the new motor in the first empty slot
@@ -236,7 +236,7 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
       break;
     }
   }
-  // disable all the slots with the same MCPWM 
+  // disable all the slots with the same MCPWM
   // disable 2pwm steppr motor which would go in the same slot
   esp32_stepper_2pwm_motor_slots[slot_num].pin1pwm = _TAKEN_SLOT;
   if( slot_num < 2 ){
@@ -266,10 +266,10 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
 // - hardware speciffic
 void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
-  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max 
+  else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
   stepper_4pwm_motor_slots_t m_slot = {};
   // determine which motor are we connecting
-  // and set the appropriate configuration parameters 
+  // and set the appropriate configuration parameters
   int slot_num;
   for(slot_num = 0; slot_num < 2; slot_num++){
     if(esp32_stepper_4pwm_motor_slots[slot_num].pin1A == _EMPTY_SLOT){ // put the new motor in the first empty slot
@@ -278,7 +278,7 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
       break;
     }
   }
-  // disable all the slots with the same MCPWM 
+  // disable all the slots with the same MCPWM
   if( slot_num == 0 ){
     // slots 0 and 1 of the 3pwm bldc
     esp32_bldc_3pwm_motor_slots[0].pinA = _TAKEN_SLOT;
@@ -297,7 +297,7 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
     esp32_stepper_2pwm_motor_slots[3].pin1pwm = _TAKEN_SLOT;
     // slot 1 of the 6pwm bldc
     esp32_bldc_6pwm_motor_slots[1].pinAH = _TAKEN_SLOT;
-  } 
+  }
 
   // configure pins
   mcpwm_gpio_init(m_slot.mcpwm_unit, m_slot.mcpwm_1a, pinA);
@@ -314,7 +314,7 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
 // - hardware speciffic
 //  ESP32 uses MCPWM
 void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
-  // determine which motor slot is the motor connected to 
+  // determine which motor slot is the motor connected to
   for(int i = 0; i < 4; i++){
     if(esp32_stepper_2pwm_motor_slots[i].pin1pwm == pinA){ // if motor slot found
       // se the PWM on the slot timers
@@ -331,7 +331,7 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
 // - hardware speciffic
 //  ESP32 uses MCPWM
 void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
-  // determine which motor slot is the motor connected to 
+  // determine which motor slot is the motor connected to
   for(int i = 0; i < 4; i++){
     if(esp32_bldc_3pwm_motor_slots[i].pinA == pinA){ // if motor slot found
       // se the PWM on the slot timers
@@ -349,7 +349,7 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
 // - hardware speciffic
 //  ESP32 uses MCPWM
 void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
-  // determine which motor slot is the motor connected to 
+  // determine which motor slot is the motor connected to
   for(int i = 0; i < 2; i++){
     if(esp32_stepper_4pwm_motor_slots[i].pin1A == pin1A){ // if motor slot found
       // se the PWM on the slot timers
@@ -367,12 +367,12 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
 // - BLDC driver - 6PWM setting
 // - hardware specific
 int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
-  
+
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = 20000; // default frequency 20khz - centered pwm has twice lower frequency
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max - centered pwm has twice lower frequency
   bldc_6pwm_motor_slots_t m_slot = {};
   // determine which motor are we connecting
-  // and set the appropriate configuration parameters 
+  // and set the appropriate configuration parameters
   int slot_num;
   for(slot_num = 0; slot_num < 2; slot_num++){
     if(esp32_bldc_6pwm_motor_slots[slot_num].pinAH == _EMPTY_SLOT){ // put the new motor in the first empty slot
@@ -384,7 +384,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   // if no slots available
   if(slot_num >= 2) return -1;
 
-  // disable all the slots with the same MCPWM 
+  // disable all the slots with the same MCPWM
   if( slot_num == 0 ){
     // slots 0 and 1 of the 3pwm bldc
     esp32_bldc_3pwm_motor_slots[0].pinA = _TAKEN_SLOT;
@@ -397,7 +397,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
     esp32_bldc_3pwm_motor_slots[3].pinA = _TAKEN_SLOT;
     // slot 1 of the 6pwm bldc
     esp32_stepper_4pwm_motor_slots[1].pin1A = _TAKEN_SLOT;
-  } 
+  }
 
   // configure pins
   mcpwm_gpio_init(m_slot.mcpwm_unit, m_slot.mcpwm_ah, pinA_h);
@@ -409,7 +409,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
 
   // configure the timer
   _configureTimerFrequency(pwm_frequency, m_slot.mcpwm_num,  m_slot.mcpwm_unit, dead_zone);
-  // return 
+  // return
   return 0;
 }
 
@@ -417,7 +417,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
 // - BLDC driver - 6PWM setting
 // - hardware specific
 void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  // determine which motor slot is the motor connected to 
+  // determine which motor slot is the motor connected to
   for(int i = 0; i < 2; i++){
     if(esp32_bldc_6pwm_motor_slots[i].pinAH == pinA_h){ // if motor slot found
       // se the PWM on the slot timers

--- a/src/drivers/hardware_specific/generic_mcu.cpp
+++ b/src/drivers/hardware_specific/generic_mcu.cpp
@@ -53,34 +53,34 @@ __attribute__((weak)) int _configure6PWM(long pwm_frequency, float dead_zone, co
 }
 
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 __attribute__((weak)) void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 __attribute__((weak)) void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
-  analogWrite(pinC, 255.0*dc_c);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(pinC, 255.0f*dc_c);
 }
 
-// function setting the pwm duty cycle to the hardware  
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 __attribute__((weak)) void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0*dc_1a);
-  analogWrite(pin1B, 255.0*dc_1b);
-  analogWrite(pin2A, 255.0*dc_2a);
-  analogWrite(pin2B, 255.0*dc_2b);
+  analogWrite(pin1A, 255.0f*dc_1a);
+  analogWrite(pin1B, 255.0f*dc_1b);
+  analogWrite(pin2A, 255.0f*dc_2a);
+  analogWrite(pin2B, 255.0f*dc_2b);
 }
 
 
@@ -100,4 +100,3 @@ __attribute__((weak)) void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc
   _UNUSED(pinC_l);
   return;
 }
-

--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -147,7 +147,7 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
 
 inline float swDti(float val, float dt) {
 	float ret = dt+val;
-	if (ret>1.0) ret = 1.0;
+	if (ret>1.0) ret = 1.0f;
 	return ret;
 }
 

--- a/src/drivers/hardware_specific/samd_mcu.cpp
+++ b/src/drivers/hardware_specific/samd_mcu.cpp
@@ -704,7 +704,7 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, i
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
 		// low-side on a different pin of same TCC - do dead-time in software...
 		float ls = dc_a+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_a);
 		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
 	}
@@ -715,7 +715,7 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, i
 	tcc2 = getTccPinConfiguration(pinB_l);
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
 		float ls = dc_b+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_b);
 		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
 	}
@@ -726,7 +726,7 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, i
 	tcc2 = getTccPinConfiguration(pinC_l);
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
 		float ls = dc_c+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
-		if (ls>1.0) ls = 1.0; // no off-time is better than too-short dead-time
+		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1->tcc.chaninfo, dc_c);
 		writeSAMDDutyCycle(tcc2->tcc.chaninfo, ls);
 	}
@@ -866,5 +866,3 @@ void printTCCConfiguration(tccConfiguration& info) {
 #endif
 
 #endif
-
-

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -27,12 +27,12 @@ void _setPwm(int ulPin, uint32_t value, int resolution)
 }
 
 
-// init pin pwm 
+// init pin pwm
 HardwareTimer* _initPinPWM(uint32_t PWM_freq, int ulPin)
 {
   PinName pin = digitalPinToPinName(ulPin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM);
-  
+
   uint32_t index = get_timer_index(Instance);
   if (HardwareTimer_Handle[index] == NULL) {
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM));
@@ -61,7 +61,7 @@ HardwareTimer* _initPinPWMLow(uint32_t PWM_freq, int ulPin)
   PinName pin = digitalPinToPinName(ulPin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM);
   uint32_t index = get_timer_index(Instance);
-    
+
   if (HardwareTimer_Handle[index] == NULL) {
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM));
     HardwareTimer_Handle[index]->handle.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED3;
@@ -129,17 +129,17 @@ HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, in
   PinName wlPinName = digitalPinToPinName(pinC_l);
 
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(uhPinName, PinMap_PWM);
- 
+
   uint32_t index = get_timer_index(Instance);
-  
+
   if (HardwareTimer_Handle[index] == NULL) {
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(uhPinName, PinMap_PWM));
     HardwareTimer_Handle[index]->handle.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED3;
     HAL_TIM_Base_Init(&(HardwareTimer_Handle[index]->handle));
-    ((HardwareTimer *)HardwareTimer_Handle[index]->__this)->setOverflow(PWM_freq, HERTZ_FORMAT);  
+    ((HardwareTimer *)HardwareTimer_Handle[index]->__this)->setOverflow(PWM_freq, HERTZ_FORMAT);
   }
   HardwareTimer *HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
-     
+
   HT->setMode(STM_PIN_CHANNEL(pinmap_function(uhPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, uhPinName);
   HT->setMode(STM_PIN_CHANNEL(pinmap_function(ulPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, ulPinName);
   HT->setMode(STM_PIN_CHANNEL(pinmap_function(vhPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, vhPinName);
@@ -148,20 +148,20 @@ HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, in
   HT->setMode(STM_PIN_CHANNEL(pinmap_function(wlPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, wlPinName);
 
   // dead time is set in nanoseconds
-  uint32_t dead_time_ns = (float)(1e9/PWM_freq)*dead_zone;
+  uint32_t dead_time_ns = (float)(1e9f/PWM_freq)*dead_zone;
   uint32_t dead_time = __LL_TIM_CALC_DEADTIME(SystemCoreClock, LL_TIM_GetClockDivision(HT->getHandle()->Instance), dead_time_ns);
   LL_TIM_OC_SetDeadTime(HT->getHandle()->Instance, dead_time); // deadtime is non linear!
   LL_TIM_CC_EnableChannel(HT->getHandle()->Instance, LL_TIM_CHANNEL_CH1 | LL_TIM_CHANNEL_CH1N | LL_TIM_CHANNEL_CH2 | LL_TIM_CHANNEL_CH2N | LL_TIM_CHANNEL_CH3 | LL_TIM_CHANNEL_CH3N);
 
   HT->pause();
   HT->refresh();
-  HT->resume();  
+  HT->resume();
   return HT;
 }
 
 
 // returns 0 if each pair of pwm channels has same channel
-// returns 1 all the channels belong to the same timer - hardware inverted channels 
+// returns 1 all the channels belong to the same timer - hardware inverted channels
 // returns -1 if neither - avoid configuring - error!!!
 int _interfaceType(const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
   PinName nameAH = digitalPinToPinName(pinA_h);
@@ -177,7 +177,7 @@ int _interfaceType(const int pinA_h, const int pinA_l,  const int pinB_h, const 
   int tim5 = get_timer_index((TIM_TypeDef *)pinmap_peripheral(nameCH, PinMap_PWM));
   int tim6 = get_timer_index((TIM_TypeDef *)pinmap_peripheral(nameCL, PinMap_PWM));
   if(tim1 == tim2 && tim2==tim3 && tim3==tim4  && tim4==tim5 && tim5==tim6)
-    return _HARDWARE_6PWM; // hardware 6pwm interface - only on timer 
+    return _HARDWARE_6PWM; // hardware 6pwm interface - only on timer
   else if(tim1 == tim2 && tim3==tim4  && tim5==tim6)
     return _SOFTWARE_6PWM; // software 6pwm interface - each pair of high-low side same timer
   else
@@ -230,7 +230,7 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
   HardwareTimer* HT1 = _initPinPWM(pwm_frequency, pinA);
   HardwareTimer* HT2 = _initPinPWM(pwm_frequency, pinB);
   HardwareTimer* HT3 = _initPinPWM(pwm_frequency, pinC);
-  HardwareTimer* HT4 = _initPinPWM(pwm_frequency, pinD); 
+  HardwareTimer* HT4 = _initPinPWM(pwm_frequency, pinD);
   // allign the timers
   _alignPWMTimers(HT1, HT2, HT3, HT4);
 }
@@ -315,11 +315,11 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, i
       _setPwm(pinC_h, _PWM_RANGE*dc_c, _PWM_RESOLUTION);
       break;
     case _SOFTWARE_6PWM:
-      _setPwm(pinA_l, _constrain(dc_a + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION); 
+      _setPwm(pinA_l, _constrain(dc_a + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
       _setPwm(pinA_h, _constrain(dc_a - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinB_l, _constrain(dc_b + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION); 
+      _setPwm(pinB_l, _constrain(dc_b + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
       _setPwm(pinB_h, _constrain(dc_b - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinC_l, _constrain(dc_c + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION); 
+      _setPwm(pinC_l, _constrain(dc_c + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
       _setPwm(pinC_h, _constrain(dc_c - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
       break;
   }

--- a/src/drivers/hardware_specific/teensy_mcu.cpp
+++ b/src/drivers/hardware_specific/teensy_mcu.cpp
@@ -1,4 +1,4 @@
-#include "../hardware_api.h" 
+#include "../hardware_api.h"
 
 #if defined(__arm__) && defined(CORE_TEENSY)
 
@@ -8,7 +8,7 @@
 //  configure High PWM frequency
 void _setHighFrequency(const long freq, const int pin){
   analogWrite(pin, 0);
-  analogWriteFrequency(pin, freq); 
+  analogWriteFrequency(pin, freq);
 }
 
 
@@ -42,25 +42,25 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
   _setHighFrequency(pwm_frequency, pinC);
-  _setHighFrequency(pwm_frequency, pinD); 
+  _setHighFrequency(pwm_frequency, pinD);
 }
 
-// function setting the pwm duty cycle to the hardware 
+// function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
 }
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
-  analogWrite(pinC, 255.0*dc_c);
+  analogWrite(pinA, 255.0f*dc_a);
+  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(pinC, 255.0f*dc_c);
 }
 
 // function setting the pwm duty cycle to the hardware
@@ -68,10 +68,10 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
 // - hardware speciffic
 void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0*dc_1a);
-  analogWrite(pin1B, 255.0*dc_1b);
-  analogWrite(pin2A, 255.0*dc_2a);
-  analogWrite(pin2B, 255.0*dc_2b);
+  analogWrite(pin1A, 255.0f*dc_1a);
+  analogWrite(pin1B, 255.0f*dc_1b);
+  analogWrite(pin2A, 255.0f*dc_2a);
+  analogWrite(pin2B, 255.0f*dc_2b);
 }
 
 #endif

--- a/src/sensors/Encoder.cpp
+++ b/src/sensors/Encoder.cpp
@@ -112,12 +112,12 @@ float Encoder::getVelocity(){
   // timestamp
   long timestamp_us = _micros();
   // sampling time calculation
-  float Ts = (timestamp_us - prev_timestamp_us) * 1e-6;
+  float Ts = (timestamp_us - prev_timestamp_us) * 1e-6f;
   // quick fix for strange cases (micros overflow)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3;
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // time from last impulse
-  float Th = (timestamp_us - pulse_timestamp) * 1e-6;
+  float Th = (timestamp_us - pulse_timestamp) * 1e-6f;
   long dN = pulse_counter - prev_pulse_counter;
 
   // Pulse per second calculation (Eq.3.)
@@ -129,8 +129,8 @@ float Encoder::getVelocity(){
   float dt = Ts + prev_Th - Th;
   pulse_per_second = (dN != 0 && dt > Ts/2) ? dN / dt : pulse_per_second;
 
-  // if more than 0.05 passed in between impulses
-  if ( Th > 0.1) pulse_per_second = 0;
+  // if more than 0.05f passed in between impulses
+  if ( Th > 0.1f) pulse_per_second = 0;
 
   // velocity calculation
   float velocity = pulse_per_second / ((float)cpr) * (_2PI);

--- a/src/sensors/HallSensor.cpp
+++ b/src/sensors/HallSensor.cpp
@@ -7,14 +7,14 @@
   - pp           - pole pairs
 */
 HallSensor::HallSensor(int _hallA, int _hallB, int _hallC, int _pp){
-  
+
   // hardware pins
   pinA = _hallA;
   pinB = _hallB;
   pinC = _hallC;
 
   // hall has 6 segments per electrical revolution
-  cpr = _pp * 6; 
+  cpr = _pp * 6;
 
   // extern pullup as default
   pullup = Pullup::USE_EXTERN;
@@ -40,12 +40,12 @@ void HallSensor::handleC() {
 
 /**
  * Updates the state and sector following an interrupt
- */ 
+ */
 void HallSensor::updateState() {
   long new_pulse_timestamp = _micros();
 
   int8_t new_hall_state = C_active + (B_active << 1) + (A_active << 2);
-  
+
   // glitch avoidance #1 - sometimes we get an interrupt but pins haven't changed
   if (new_hall_state == hall_state) {
     return;
@@ -74,7 +74,7 @@ void HallSensor::updateState() {
   } else {
     pulse_diff = 0;
   }
-  
+
   pulse_timestamp = new_pulse_timestamp;
   total_interrupts++;
   old_direction = direction;
@@ -87,7 +87,7 @@ void HallSensor::updateState() {
  *  ... // for debug or call driver directly?
  * }
  * sensor.attachSectorCallback(onSectorChange);
- */ 
+ */
 void HallSensor::attachSectorCallback(void (*_onSectorChange)(int sector)) {
   onSectorChange = _onSectorChange;
 }
@@ -107,12 +107,12 @@ float HallSensor::getVelocity(){
   if (pulse_diff == 0 || ((_micros() - pulse_timestamp) > pulse_diff) ) { // last velocity isn't accurate if too old
     return 0;
   } else {
-    return direction * (_2PI / cpr) / (pulse_diff / 1000000.0);
+    return direction * (_2PI / cpr) / (pulse_diff / 1000000.0f);
   }
 
 }
 
-// HallSensor initialisation of the hardware pins 
+// HallSensor initialisation of the hardware pins
 // and calculation variables
 void HallSensor::init(){
   // initialise the electrical rotations to 0
@@ -134,7 +134,7 @@ void HallSensor::init(){
   B_active = digitalRead(pinB);
   C_active = digitalRead(pinC);
   updateState();
-  
+
   pulse_timestamp = _micros();
 
 }
@@ -149,4 +149,3 @@ void HallSensor::enableInterrupts(void (*doA)(), void(*doB)(), void(*doC)()){
   if(doB != nullptr) attachInterrupt(digitalPinToInterrupt(pinB), doB, CHANGE);
   if(doC != nullptr) attachInterrupt(digitalPinToInterrupt(pinC), doC, CHANGE);
 }
-

--- a/src/sensors/MagneticSensorAnalog.cpp
+++ b/src/sensors/MagneticSensorAnalog.cpp
@@ -6,7 +6,7 @@
  * @param _max_raw_count  the largest value read.  whilst you might expect it to be 2^10 = 1023 it is often ~ 1020. Note: For ESP32 (with 12bit ADC the value will be nearer 4096)
  */
 MagneticSensorAnalog::MagneticSensorAnalog(uint8_t _pinAnalog, int _min_raw_count, int _max_raw_count){
-  
+
   pinAnalog = _pinAnalog;
 
   cpr = _max_raw_count - _min_raw_count;
@@ -26,30 +26,30 @@ void MagneticSensorAnalog::init(){
 
 	// velocity calculation init
 	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+	velocity_calc_timestamp = _micros();
 
 	// full rotations tracking number
 	full_rotation_offset = 0;
-	raw_count_prev = getRawCount();  
+	raw_count_prev = getRawCount();
 }
 
 //  Shaft angle calculation
 //  angle is in radians [rad]
 float MagneticSensorAnalog::getAngle(){
   // raw data from the sensor
-  raw_count = getRawCount(); 
+  raw_count = getRawCount();
 
   int delta = raw_count - raw_count_prev;
   // if overflow happened track it as full rotation
-  if(abs(delta) > (0.8*cpr) ) full_rotation_offset += delta > 0 ? -_2PI : _2PI; 
-  
+  if(abs(delta) > (0.8f*cpr) ) full_rotation_offset += delta > 0 ? -_2PI : _2PI;
+
   float angle = full_rotation_offset + ( (float) (raw_count) / (float)cpr) * _2PI;
 
-  // calculate velocity here 
+  // calculate velocity here
   long now = _micros();
-  float Ts = ( now - velocity_calc_timestamp)*1e-6;
+  float Ts = ( now - velocity_calc_timestamp)*1e-6f;
   // quick fix for strange cases (micros overflow)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
   velocity = (angle - angle_prev)/Ts;
 
   // save variables for future pass

--- a/src/sensors/MagneticSensorI2C.cpp
+++ b/src/sensors/MagneticSensorI2C.cpp
@@ -19,21 +19,21 @@ MagneticSensorI2CConfig_s AS5048_I2C = {
 
 // MagneticSensorI2C(uint8_t _chip_address, float _cpr, uint8_t _angle_register_msb)
 //  @param _chip_address  I2C chip address
-//  @param _bit_resolution  bit resolution of the sensor  
+//  @param _bit_resolution  bit resolution of the sensor
 //  @param _angle_register_msb  angle read register
 //  @param _bits_used_msb number of used bits in msb
 MagneticSensorI2C::MagneticSensorI2C(uint8_t _chip_address, int _bit_resolution, uint8_t _angle_register_msb, int _bits_used_msb){
   // chip I2C address
-  chip_address = _chip_address; 
+  chip_address = _chip_address;
   // angle read register of the magnetic sensor
   angle_register_msb = _angle_register_msb;
   // register maximum value (counts per revolution)
   cpr = pow(2, _bit_resolution);
-  
+
   // depending on the sensor architecture there are different combinations of
   // LSB and MSB register used bits
   // AS5600 uses 0..7 LSB and 8..11 MSB
-  // AS5048 uses 0..5 LSB and 6..13 MSB 
+  // AS5048 uses 0..5 LSB and 6..13 MSB
   // used bits in LSB
   lsb_used = _bit_resolution - _bits_used_msb;
   // extraction masks
@@ -43,13 +43,13 @@ MagneticSensorI2C::MagneticSensorI2C(uint8_t _chip_address, int _bit_resolution,
 }
 
 MagneticSensorI2C::MagneticSensorI2C(MagneticSensorI2CConfig_s config){
-  chip_address = config.chip_address; 
+  chip_address = config.chip_address;
 
   // angle read register of the magnetic sensor
   angle_register_msb = config.angle_register;
   // register maximum value (counts per revolution)
   cpr = pow(2, config.bit_resolution);
-  
+
   int bits_used_msb = config.data_start_bit - 7;
   lsb_used = config.bit_resolution - bits_used_msb;
   // extraction masks
@@ -61,36 +61,36 @@ MagneticSensorI2C::MagneticSensorI2C(MagneticSensorI2CConfig_s config){
 void MagneticSensorI2C::init(TwoWire* _wire){
 
   wire = _wire;
-  
+
   // I2C communication begin
   wire->begin();
 
 	// velocity calculation init
 	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+	velocity_calc_timestamp = _micros();
 
 	// full rotations tracking number
 	full_rotation_offset = 0;
-	angle_data_prev = getRawCount();  
+	angle_data_prev = getRawCount();
 }
 
 //  Shaft angle calculation
 //  angle is in radians [rad]
 float MagneticSensorI2C::getAngle(){
   // raw data from the sensor
-  float angle_data = getRawCount(); 
+  float angle_data = getRawCount();
 
-  // tracking the number of rotations 
-  // in order to expand angle range form [0,2PI] 
+  // tracking the number of rotations
+  // in order to expand angle range form [0,2PI]
   // to basically infinity
   float d_angle = angle_data - angle_data_prev;
   // if overflow happened track it as full rotation
-  if(abs(d_angle) > (0.8*cpr) ) full_rotation_offset += d_angle > 0 ? -_2PI : _2PI; 
+  if(abs(d_angle) > (0.8f*cpr) ) full_rotation_offset += d_angle > 0 ? -_2PI : _2PI;
   // save the current angle value for the next steps
   // in order to know if overflow happened
   angle_data_prev = angle_data;
-  // return the full angle 
-  // (number of full rotations)*2PI + current sensor angle 
+  // return the full angle
+  // (number of full rotations)*2PI + current sensor angle
   return  (full_rotation_offset + ( angle_data / (float)cpr) * _2PI) ;
 }
 
@@ -98,15 +98,15 @@ float MagneticSensorI2C::getAngle(){
 float MagneticSensorI2C::getVelocity(){
   // calculate sample time
   unsigned long now_us = _micros();
-  float Ts = (now_us - velocity_calc_timestamp)*1e-6;
+  float Ts = (now_us - velocity_calc_timestamp)*1e-6f;
   // quick fix for strange cases (micros overflow)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // current angle
   float angle_c = getAngle();
   // velocity calculation
   float vel = (angle_c - angle_prev)/Ts;
-  
+
   // save variables for future pass
   angle_prev = angle_c;
   velocity_calc_timestamp = now_us;
@@ -119,7 +119,7 @@ int MagneticSensorI2C::getRawCount(){
 	return (int)MagneticSensorI2C::read(angle_register_msb);
 }
 
-// I2C functions 
+// I2C functions
 /*
 * Read a register from the sensor
 * Takes the address of the register as a uint8_t
@@ -133,14 +133,14 @@ int MagneticSensorI2C::read(uint8_t angle_reg_msb) {
 	wire->beginTransmission(chip_address);
 	wire->write(angle_reg_msb);
   wire->endTransmission(false);
-  
+
   // read the data msb and lsb
 	wire->requestFrom(chip_address, (uint8_t)2);
 	for (byte i=0; i < 2; i++) {
 		readArray[i] = wire->read();
 	}
 
-  // depending on the sensor architecture there are different combinations of 
+  // depending on the sensor architecture there are different combinations of
   // LSB and MSB register used bits
   // AS5600 uses 0..7 LSB and 8..11 MSB
   // AS5048 uses 0..5 LSB and 6..13 MSB
@@ -151,7 +151,7 @@ int MagneticSensorI2C::read(uint8_t angle_reg_msb) {
 
 /*
 * Checks whether other devices have locked the bus. Can clear SDA locks.
-* This should be called before sensor.init() on devices that suffer i2c slaves locking sda 
+* This should be called before sensor.init() on devices that suffer i2c slaves locking sda
 * e.g some stm32 boards with AS5600 chips
 * Takes the sda_pin and scl_pin
 * Returns 0 for OK, 1 for other master and 2 for unfixable sda locked LOW
@@ -160,7 +160,7 @@ int MagneticSensorI2C::checkBus(byte sda_pin, byte scl_pin) {
 
   pinMode(scl_pin, INPUT_PULLUP);
   pinMode(sda_pin, INPUT_PULLUP);
-  delay(250);  
+  delay(250);
 
   if (digitalRead(scl_pin) == LOW) {
     // Someone else has claimed master!");
@@ -179,15 +179,15 @@ int MagneticSensorI2C::checkBus(byte sda_pin, byte scl_pin) {
     }
     pinMode(sda_pin, INPUT);
     delayMicroseconds(20);
-    if (digitalRead(sda_pin) == LOW) { 
+    if (digitalRead(sda_pin) == LOW) {
       // SDA still blocked
-      return 2; 
-    } 
+      return 2;
+    }
     _delay(1000);
   }
   // SDA is clear (HIGH)
   pinMode(sda_pin, INPUT);
   pinMode(scl_pin, INPUT);
-  
-  return 0; 
+
+  return 0;
 }

--- a/src/sensors/MagneticSensorPWM.cpp
+++ b/src/sensors/MagneticSensorPWM.cpp
@@ -13,7 +13,7 @@ MagneticSensorPWM::MagneticSensorPWM(uint8_t _pinPWM, int _min_raw_count, int _m
     cpr = _max_raw_count - _min_raw_count;
     min_raw_count = _min_raw_count;
     max_raw_count = _max_raw_count;
-    
+
     // define if the sensor uses interrupts
     is_interrupt_based = false;
 
@@ -23,7 +23,7 @@ MagneticSensorPWM::MagneticSensorPWM(uint8_t _pinPWM, int _min_raw_count, int _m
 
 
 void MagneticSensorPWM::init(){
-    
+
     // initial hardware
     pinMode(pinPWM, INPUT);
 
@@ -36,23 +36,23 @@ void MagneticSensorPWM::init(){
     raw_count_prev = getRawCount();
 }
 
-// get current angle (rad) 
+// get current angle (rad)
 float MagneticSensorPWM::getAngle(){
 
     // raw data from sensor
     raw_count = getRawCount();
-    
+
     int delta = raw_count - raw_count_prev;
     // if overflow happened track it as full rotation
-    if(abs(delta) > (0.8*cpr) ) full_rotation_offset += delta > 0 ? -_2PI : _2PI;
+    if(abs(delta) > (0.8f*cpr) ) full_rotation_offset += delta > 0 ? -_2PI : _2PI;
 
     float angle = full_rotation_offset + ( (float) (raw_count) / (float)cpr) * _2PI;
 
     // calculate velocity here
     long now = _micros();
-    float Ts = (now - velocity_calc_timestamp)*1e-6;
+    float Ts = (now - velocity_calc_timestamp)*1e-6f;
     // quick fix for strange cases (micros overflow)
-    if(Ts <= 0 || Ts > 0.5) Ts = 1e-3;
+    if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
     velocity = (angle - angle_prev)/Ts;
 
     // save variables for future pass
@@ -80,7 +80,7 @@ int MagneticSensorPWM::getRawCount(){
 void MagneticSensorPWM::handlePWM() {
     //  unsigned long now_us = ticks();
     unsigned long now_us = _micros();
-    
+
     // if falling edge, calculate the pulse length
     if (!digitalRead(pinPWM)) pulse_length_us = now_us - last_call_us;
 

--- a/src/sensors/MagneticSensorSPI.cpp
+++ b/src/sensors/MagneticSensorSPI.cpp
@@ -8,7 +8,7 @@ MagneticSensorSPIConfig_s AS5147_SPI = {
   .clock_speed = 1000000,
   .bit_resolution = 14,
   .angle_register = 0x3FFF,
-  .data_start_bit = 13, 
+  .data_start_bit = 13,
   .command_rw_bit = 14,
   .command_parity_bit = 15
 };
@@ -22,19 +22,19 @@ MagneticSensorSPIConfig_s MA730_SPI = {
   .clock_speed = 1000000,
   .bit_resolution = 14,
   .angle_register = 0x0000,
-  .data_start_bit = 15, 
+  .data_start_bit = 15,
   .command_rw_bit = 0,  // not required
   .command_parity_bit = 0 // parity not implemented
 };
 
 
 // MagneticSensorSPI(int cs, float _bit_resolution, int _angle_register)
-//  cs              - SPI chip select pin 
+//  cs              - SPI chip select pin
 //  _bit_resolution   sensor resolution bit number
 // _angle_register  - (optional) angle read register - default 0x3FFF
 MagneticSensorSPI::MagneticSensorSPI(int cs, float _bit_resolution, int _angle_register){
-  
-  chip_select_pin = cs; 
+
+  chip_select_pin = cs;
   // angle read register of the magnetic sensor
   angle_register = _angle_register ? _angle_register : DEF_ANGLE_REGISTER;
   // register maximum value (counts per revolution)
@@ -42,14 +42,14 @@ MagneticSensorSPI::MagneticSensorSPI(int cs, float _bit_resolution, int _angle_r
   spi_mode = SPI_MODE1;
   clock_speed = 1000000;
   bit_resolution = _bit_resolution;
-  
+
   command_parity_bit = 15; // for backwards compatibilty
   command_rw_bit = 14; // for backwards compatibilty
   data_start_bit = 13; // for backwards compatibilty
 }
 
 MagneticSensorSPI::MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs){
-  chip_select_pin = cs; 
+  chip_select_pin = cs;
   // angle read register of the magnetic sensor
   angle_register = config.angle_register ? config.angle_register : DEF_ANGLE_REGISTER;
   // register maximum value (counts per revolution)
@@ -57,7 +57,7 @@ MagneticSensorSPI::MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs){
   spi_mode = config.spi_mode;
   clock_speed = config.clock_speed;
   bit_resolution = config.bit_resolution;
-  
+
   command_parity_bit = config.command_parity_bit; // for backwards compatibilty
   command_rw_bit = config.command_rw_bit; // for backwards compatibilty
   data_start_bit = config.data_start_bit; // for backwards compatibilty
@@ -72,7 +72,7 @@ void MagneticSensorSPI::init(SPIClass* _spi){
 
 	//setup pins
 	pinMode(chip_select_pin, OUTPUT);
-  
+
 	//SPI has an internal SPI-device counter, it is possible to call "begin()" from different devices
 	spi->begin();
 	// do any architectures need to set the clock divider for SPI? Why was this in the code?
@@ -81,31 +81,31 @@ void MagneticSensorSPI::init(SPIClass* _spi){
 	digitalWrite(chip_select_pin, HIGH);
 	// velocity calculation init
 	angle_prev = 0;
-	velocity_calc_timestamp = _micros(); 
+	velocity_calc_timestamp = _micros();
 
 	// full rotations tracking number
 	full_rotation_offset = 0;
-	angle_data_prev = getRawCount();  
+	angle_data_prev = getRawCount();
 }
 
 //  Shaft angle calculation
 //  angle is in radians [rad]
 float MagneticSensorSPI::getAngle(){
   // raw data from the sensor
-  float angle_data = getRawCount(); 
+  float angle_data = getRawCount();
 
-  // tracking the number of rotations 
-  // in order to expand angle range form [0,2PI] 
+  // tracking the number of rotations
+  // in order to expand angle range form [0,2PI]
   // to basically infinity
   float d_angle = angle_data - angle_data_prev;
   // if overflow happened track it as full rotation
-  if(abs(d_angle) > (0.8*cpr) ) full_rotation_offset += d_angle > 0 ? -_2PI : _2PI; 
+  if(abs(d_angle) > (0.8f*cpr) ) full_rotation_offset += d_angle > 0 ? -_2PI : _2PI;
   // save the current angle value for the next steps
   // in order to know if overflow happened
   angle_data_prev = angle_data;
 
-  // return the full angle 
-  // (number of full rotations)*2PI + current sensor angle 
+  // return the full angle
+  // (number of full rotations)*2PI + current sensor angle
   return full_rotation_offset + ( angle_data / (float)cpr) * _2PI;
 }
 
@@ -113,9 +113,9 @@ float MagneticSensorSPI::getAngle(){
 float MagneticSensorSPI::getVelocity(){
   // calculate sample time
   unsigned long now_us = _micros();
-  float Ts = (now_us - velocity_calc_timestamp)*1e-6;
+  float Ts = (now_us - velocity_calc_timestamp)*1e-6f;
   // quick fix for strange cases (micros overflow)
-  if(Ts <= 0 || Ts > 0.5) Ts = 1e-3; 
+  if(Ts <= 0 || Ts > 0.5f) Ts = 1e-3f;
 
   // current angle
   float angle_c = getAngle();
@@ -134,7 +134,7 @@ int MagneticSensorSPI::getRawCount(){
 	return (int)MagneticSensorSPI::read(angle_register);
 }
 
-// SPI functions 
+// SPI functions
 /**
  * Utility function used to calculate even parity of word
  */
@@ -174,13 +174,13 @@ word MagneticSensorSPI::read(word angle_register){
   digitalWrite(chip_select_pin, LOW);
   spi->transfer16(command);
   digitalWrite(chip_select_pin,HIGH);
-  
+
 #if defined( ESP_H ) // if ESP32 board
   delayMicroseconds(50); // why do we need to delay 50us on ESP32? In my experience no extra delays are needed, on any of the architectures I've tested...
 #else
   delayMicroseconds(1); // delay 1us, the minimum time possible in plain arduino. 350ns is the required time for AMS sensors, 80ns for MA730, MA702
 #endif
-  
+
   //Now read the response
   digitalWrite(chip_select_pin, LOW);
   word register_value = spi->transfer16(0x00);
@@ -188,7 +188,7 @@ word MagneticSensorSPI::read(word angle_register){
 
   //SPI - end transaction
   spi->endTransaction();
-  
+
   register_value = register_value >> (1 + data_start_bit - bit_resolution);  //this should shift data to the rightmost bits of the word
 
   const static word data_mask = 0xFFFF >> (16 - bit_resolution);


### PR DESCRIPTION
We should use float constants instead of double (like `0.0123f`) to improve claculation speed. If we have double constant all expression will be calculated as double just to convert it to float at the end.

I have created a simple benchmark:
```c++
#include <SimpleFOC.h>

#define N 5000UL
#define BENCH(foo, real_foo, n) bench(foo, real_foo, n, #foo)

static float bench_calibration = 0.0f;

float empty(float x)
{
    return 0.0f;
}

float bench_time(float (*foo)(float), size_t n)
{
    uint32_t begin = micros();

    for (size_t i = 0; i < n; i++)
    {
        foo((float)i / n * _2PI);
    }

    uint32_t end = micros();

    return (float)(end - begin) / n - bench_calibration;
}

float bench_error(float (*foo)(float), float (*real_foo)(float), size_t n)
{
    float sum_rms = 0.0f;
    
    for(size_t i = 0; i < n; i++)
    {
        float angle = (float)i / n * _2PI;
        float real = real_foo(angle);
        float calc = foo(angle);
        float diff = calc - real;
        sum_rms += diff * diff;
    }

    return sqrtf(sum_rms / n);
}

void bench(float (*foo)(float), float (*real_foo)(float), size_t n, const char * name)
{

    Serial.print("Testing ");
    Serial.print(name);
    Serial.print(" ");
    Serial.print(n);
    Serial.println(" times");

    float time_spent_us = bench_time(foo, n);
    float rms = bench_error(foo, real_foo, n);

    Serial.print("Time: ");
    Serial.print(time_spent_us, 3);
    Serial.print("us, RMS error: ");
    Serial.println(rms, 6);
}

void bench_calibrate(size_t n)
{
    bench_calibration = 0.0f;
    bench_calibration = bench_time(empty, n);
}

void setup() {
    Serial.begin(115200);

    bench_calibrate(N);

    BENCH(_sin, sinf, N);
    BENCH(_cos, cosf, N);
}

void loop() {

}
```

On STM32F0 running at 48MHz it gave me results presented below.
Before change to floats, using doubles as constants:
```bash
Testing _sin 5000 times
Time: 34.277us, RMS error: 0.001612
Testing _cos 5000 times
Time: 46.258us, RMS error: 0.001612
```

After change to floats:
```bash
Testing _sin 5000 times
Time: 18.794us, RMS error: 0.001612
Testing _cos 5000 times
Time: 24.926us, RMS error: 0.001612
```

As you can see it's almost two times faster and we are talking about 32bit MCU, on 8bit Arduino it should improve even more.

I haven't touched MCU specific files but I can see some double constants here as well.