### PR TITLE
mask out SAMD21 current sensing when compiling on other platforms

### DIFF
--- a/src/current_sense/hardware_specific/samd21_mcu.cpp
+++ b/src/current_sense/hardware_specific/samd21_mcu.cpp
@@ -1,3 +1,4 @@
+#ifdef _SAMD21_
 
 #include "samd21_mcu.h"
 #include "../hardware_api.h"
@@ -302,3 +303,6 @@ void DMAC_Handler() {
   DMAC->CHINTFLAG.reg = DMAC_CHINTENCLR_SUSP;
 
 }
+
+
+#endif

--- a/src/current_sense/hardware_specific/samd21_mcu.h
+++ b/src/current_sense/hardware_specific/samd21_mcu.h
@@ -1,3 +1,5 @@
+#ifdef _SAMD21_
+
 #ifndef CURRENT_SENSE_SAMD21_H
 #define CURRENT_SENSE_SAMD21_H
 
@@ -57,5 +59,9 @@ private:
   dmacdescriptor descriptor __attribute__ ((aligned (16)));
 
 };
+
+#endif
+
+
 
 #endif


### PR DESCRIPTION
Make sure the SAMD current sensing compiles without errors when not on SAMD...