### PR TITLE
Prevent unintended float-to-double casts

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -458,8 +458,8 @@ void BLDCMotor::setPhaseVoltage(float Uq, float Ud, float angle_el) {
       center = driver->voltage_limit/2;
       // Clarke transform
       Ua = Ualpha + center;
-      Ub = -0.5 * Ualpha  + _SQRT3_2 * Ubeta + center;
-      Uc = -0.5 * Ualpha - _SQRT3_2 * Ubeta + center;
+      Ub = -0.5f * Ualpha  + _SQRT3_2 * Ubeta + center;
+      Uc = -0.5f * Ualpha - _SQRT3_2 * Ubeta + center;
 
       if (!modulation_centered) {
         float Umin = min(Ua, min(Ub, Uc));
@@ -502,7 +502,7 @@ void BLDCMotor::setPhaseVoltage(float Uq, float Ud, float angle_el) {
       sector = floor(angle_el / _PI_3) + 1;
       // calculate the duty cycles
       float T1 = _SQRT3*_sin(sector*_PI_3 - angle_el) * Uout;
-      float T2 = _SQRT3*_sin(angle_el - (sector-1.0)*_PI_3) * Uout;
+      float T2 = _SQRT3*_sin(angle_el - (sector-1.0f)*_PI_3) * Uout;
       // two versions possible
       float T0 = 0; // pulled to 0 - better for low power supply voltage
       if (modulation_centered) {

--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -23,11 +23,11 @@ float _sin(float a){
   }else if(a < _3PI_2){
     // return -sine_array[(int)(199.0f*((a - _PI) / (_PI/2.0)))];
     //return -sine_array[-398 + (int)(126.6873f*a)];           // float array optimized
-    return -0.0001*sine_array[-398 + _round(126.6873f*a)];      // int array optimized
+    return -0.0001f*sine_array[-398 + _round(126.6873f*a)];      // int array optimized
   } else {
     // return -sine_array[(int)(199.0f*(1.0f - (a - 3*_PI/2) / (_PI/2.0)))];
     //return -sine_array[796 - (int)(126.6873f*a)];           // float array optimized
-    return -0.0001*sine_array[796 - _round(126.6873f*a)];      // int array optimized
+    return -0.0001f*sine_array[796 - _round(126.6873f*a)];      // int array optimized
   }
 }
 

--- a/src/common/foc_utils.h
+++ b/src/common/foc_utils.h
@@ -5,7 +5,7 @@
 
 // sign function
 #define _sign(a) ( ( (a) < 0 )  ?  -1   : ( (a) > 0 ) )
-#define _round(x) ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+#define _round(x) ((x)>=0?(long)((x)+0.5f):(long)((x)-0.5f))
 #define _constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define _sqrt(a) (_sqrtApprox(a))
 #define _isset(a) ( (a) != (NOT_SET) )
@@ -25,7 +25,7 @@
 #define _3PI_2 4.71238898038f
 #define _PI_6 0.52359877559f
 
-#define NOT_SET -12345.0
+#define NOT_SET -12345.0f
 #define _HIGH_IMPEDANCE 0
 #define _HIGH_Z _HIGH_IMPEDANCE
 #define _ACTIVE 1

--- a/src/common/pid.cpp
+++ b/src/common/pid.cpp
@@ -28,7 +28,7 @@ float PIDController::operator() (float error){
     float proportional = P * error;
     // Tustin transform of the integral part
     // u_ik = u_ik_1  + I*Ts/2*(ek + ek_1)
-    float integral = integral_prev + I*Ts*0.5*(error + error_prev);
+    float integral = integral_prev + I*Ts*0.5f*(error + error_prev);
     // antiwindup - limit the output
     integral = _constrain(integral, -limit, limit);
     // Discrete derivation

--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -80,9 +80,9 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     // read the current 100 times ( arbitrary number )
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4f*c1.a;
-        c.b = c.b*0.6 + 0.4f*c1.b;
-        c.c = c.c*0.6 + 0.4f*c1.c;
+        c.a = c.a*0.6f + 0.4f*c1.a;
+        c.b = c.b*0.6f + 0.4f*c1.b;
+        c.c = c.c*0.6f + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
@@ -117,9 +117,9 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
     // read the current 50 times
     for (int i = 0; i < 100; i++) {
         PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4f*c1.a;
-        c.b = c.b*0.6 + 0.4f*c1.b;
-        c.c = c.c*0.6 + 0.4f*c1.c;
+        c.a = c.a*0.6f + 0.4f*c1.a;
+        c.b = c.b*0.6f + 0.4f*c1.b;
+        c.c = c.c*0.6f + 0.4f*c1.c;
         _delay(3);
     }
     driver->setPwm(0, 0, 0);
@@ -155,7 +155,7 @@ int InlineCurrentSense::driverAlign(BLDCDriver *driver, float voltage){
         // read the adc voltage 500 times ( arbitrary number )
         for (int i = 0; i < 50; i++) {
             PhaseCurrent_s c1 = getPhaseCurrents();
-            c.c = (c.c+c1.c)/50.0;
+            c.c = (c.c+c1.c)/50.0f;
         }
         driver->setPwm(0, 0, 0);
         gain_c *= _sign(c.c);

--- a/src/current_sense/InlineCurrentSense.h
+++ b/src/current_sense/InlineCurrentSense.h
@@ -48,17 +48,17 @@ class InlineCurrentSense: public CurrentSense{
   	int pinC; //!< pin C analog pin for current measurement
 
     // gain variables
-    double shunt_resistor; //!< Shunt resistor value 
-    double amp_gain; //!< amp gain value 
-    double volts_to_amps_ratio; //!< Volts to amps ratio
+    float shunt_resistor; //!< Shunt resistor value
+    float amp_gain; //!< amp gain value
+    float volts_to_amps_ratio; //!< Volts to amps ratio
     
     /**
      *  Function finding zero offsets of the ADC
      */
     void calibrateOffsets();
-    double offset_ia; //!< zero current A voltage value (center of the adc reading)
-    double offset_ib; //!< zero current B voltage value (center of the adc reading)
-    double offset_ic; //!< zero current C voltage value (center of the adc reading)
+    float offset_ia; //!< zero current A voltage value (center of the adc reading)
+    float offset_ib; //!< zero current B voltage value (center of the adc reading)
+    float offset_ic; //!< zero current C voltage value (center of the adc reading)
 
 };
 

--- a/src/current_sense/LowsideCurrentSense.h
+++ b/src/current_sense/LowsideCurrentSense.h
@@ -49,17 +49,17 @@ class LowsideCurrentSense: public CurrentSense{
   	int pinC; //!< pin C analog pin for current measurement
 
     // gain variables
-    double shunt_resistor; //!< Shunt resistor value
-    double amp_gain; //!< amp gain value
-    double volts_to_amps_ratio; //!< Volts to amps ratio
+    float shunt_resistor; //!< Shunt resistor value
+    float amp_gain; //!< amp gain value
+    float volts_to_amps_ratio; //!< Volts to amps ratio
 
     /**
      *  Function finding zero offsets of the ADC
      */
     void calibrateOffsets();
-    double offset_ia; //!< zero current A voltage value (center of the adc reading)
-    double offset_ib; //!< zero current B voltage value (center of the adc reading)
-    double offset_ic; //!< zero current C voltage value (center of the adc reading)
+    float offset_ia; //!< zero current A voltage value (center of the adc reading)
+    float offset_ib; //!< zero current B voltage value (center of the adc reading)
+    float offset_ic; //!< zero current C voltage value (center of the adc reading)
 
 };
 

--- a/src/drivers/BLDCDriver3PWM.cpp
+++ b/src/drivers/BLDCDriver3PWM.cpp
@@ -75,9 +75,9 @@ void BLDCDriver3PWM::setPhaseState(int sa, int sb, int sc) {
 void BLDCDriver3PWM::setPwm(float Ua, float Ub, float Uc) {
 
   // limit the voltage in driver
-  Ua = _constrain(Ua, 0.0, voltage_limit);
-  Ub = _constrain(Ub, 0.0, voltage_limit);
-  Uc = _constrain(Uc, 0.0, voltage_limit);
+  Ua = _constrain(Ua, 0.0f, voltage_limit);
+  Ub = _constrain(Ub, 0.0f, voltage_limit);
+  Uc = _constrain(Uc, 0.0f, voltage_limit);
   // calculate duty cycle
   // limited in [0,1]
   dc_a = _constrain(Ua / voltage_power_supply, 0.0f , 1.0f );

--- a/src/drivers/StepperDriver2PWM.cpp
+++ b/src/drivers/StepperDriver2PWM.cpp
@@ -89,8 +89,8 @@ void StepperDriver2PWM::setPwm(float Ua, float Ub) {
   Ua = _constrain(Ua, -voltage_limit, voltage_limit);
   Ub = _constrain(Ub, -voltage_limit, voltage_limit);
   // hardware specific writing
-  duty_cycle1 = _constrain(abs(Ua)/voltage_power_supply,0.0,1.0);
-  duty_cycle2 = _constrain(abs(Ub)/voltage_power_supply,0.0,1.0);
+  duty_cycle1 = _constrain(abs(Ua)/voltage_power_supply,0.0f,1.0f);
+  duty_cycle2 = _constrain(abs(Ub)/voltage_power_supply,0.0f,1.0f);
 
   // phase 1 direction
   digitalWrite(dir1a, Ua >= 0 ? LOW : HIGH);

--- a/src/drivers/StepperDriver4PWM.cpp
+++ b/src/drivers/StepperDriver4PWM.cpp
@@ -66,14 +66,14 @@ void StepperDriver4PWM::setPwm(float Ualpha, float Ubeta) {
   Ubeta = _constrain(Ubeta, -voltage_limit, voltage_limit);
   // hardware specific writing
   if( Ualpha > 0 )
-    duty_cycle1B = _constrain(abs(Ualpha)/voltage_power_supply,0.0,1.0);
+    duty_cycle1B = _constrain(abs(Ualpha)/voltage_power_supply,0.0f,1.0f);
   else
-    duty_cycle1A = _constrain(abs(Ualpha)/voltage_power_supply,0.0,1.0);
+    duty_cycle1A = _constrain(abs(Ualpha)/voltage_power_supply,0.0f,1.0f);
 
   if( Ubeta > 0 )
-    duty_cycle2B = _constrain(abs(Ubeta)/voltage_power_supply,0.0,1.0);
+    duty_cycle2B = _constrain(abs(Ubeta)/voltage_power_supply,0.0f,1.0f);
   else
-    duty_cycle2A = _constrain(abs(Ubeta)/voltage_power_supply,0.0,1.0);
+    duty_cycle2A = _constrain(abs(Ubeta)/voltage_power_supply,0.0f,1.0f);
   // write to hardware
   _writeDutyCycle4PWM(duty_cycle1A, duty_cycle1B, duty_cycle2A, duty_cycle2B, pwm1A, pwm1B, pwm2A, pwm2B);
 }

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -4,7 +4,7 @@
 #if defined(_STM32_DEF_)
 // default pwm parameters
 #define _PWM_RESOLUTION 12 // 12bit
-#define _PWM_RANGE 4095.0// 2^12 -1 = 4095
+#define _PWM_RANGE 4095// 2^12 -1 = 4095
 #define _PWM_FREQUENCY 25000 // 25khz
 #define _PWM_FREQUENCY_MAX 50000 // 50khz
 


### PR DESCRIPTION
There are a few doubles left:

One explicit cast in Encoder::HandleIndex. I think this function can be implemented without any floating point math, but I don't have a test setup for this encoder.

There are various explicit float-to-double casts in esp32_mcu and due_mcu. These are in non-critical code paths only used during setup.
