### PR TITLE
SAMD code improvements

### DIFF
--- a/src/drivers/hardware_specific/samd21_mcu.cpp
+++ b/src/drivers/hardware_specific/samd21_mcu.cpp
@@ -159,6 +159,7 @@ void configureSAMDClock() {
 		REG_GCLK_GENCTRL = GCLK_GENCTRL_IDC |           // Set the duty cycle to 50/50 HIGH/LOW
 						 GCLK_GENCTRL_GENEN |         	// Enable GCLK4
 						 GCLK_GENCTRL_SRC_DFLL48M |   	// Set the 48MHz clock source
+						// GCLK_GENCTRL_SRC_FDPLL |   	// Set the 96MHz clock source
 						 GCLK_GENCTRL_ID(4);          	// Select GCLK4
 		while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
 
@@ -305,11 +306,11 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate, 
 
 
 
-void writeSAMDDutyCycle(int chaninfo, float dc) {
-	uint8_t tccn = GetTCNumber(chaninfo);
-	uint8_t chan = GetTCChannelNumber(chaninfo);
+void writeSAMDDutyCycle(tccConfiguration* info, float dc) {
+	uint8_t tccn = GetTCNumber(info->tcc.chaninfo);
+	uint8_t chan = GetTCChannelNumber(info->tcc.chaninfo);
 	if (tccn<TCC_INST_NUM) {
-		Tcc* tcc = (Tcc*)GetTC(chaninfo);
+		Tcc* tcc = (Tcc*)GetTC(info->tcc.chaninfo);
 		// set via CC
 //		tcc->CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
 //		uint32_t chanbit = 0x1<<(TCC_SYNCBUSY_CC0_Pos+chan);
@@ -324,7 +325,7 @@ void writeSAMDDutyCycle(int chaninfo, float dc) {
 //		while ( tcc->SYNCBUSY.bit.CTRLB > 0 );
 	}
 	else {
-		Tc* tc = (Tc*)GetTC(chaninfo);
+		Tc* tc = (Tc*)GetTC(info->tcc.chaninfo);
 		tc->COUNT8.CC[chan].reg = (uint8_t)((SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1) * dc);
 		while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
 	}

--- a/src/drivers/hardware_specific/samd51_mcu.cpp
+++ b/src/drivers/hardware_specific/samd51_mcu.cpp
@@ -7,6 +7,16 @@
 
 
 
+// expected frequency on DPLL, since we don't configure it ourselves. Typically this is the CPU frequency.
+// for custom boards or overclockers you can override it using this define.
+#ifndef SIMPLEFOC_SAMD51_DPLL_FREQ
+#define SIMPLEFOC_SAMD51_DPLL_FREQ 120000000
+#endif
+
+
+
+
+
 //	TCC#   Channels   WO_NUM   Counter size   Fault   Dithering   Output matrix   DTI   SWAP   Pattern generation
 //	0         6         8         24-bit       Yes       Yes       Yes            Yes   Yes    Yes
 //	1         4         8         24-bit       Yes       Yes       Yes            Yes   Yes    Yes
@@ -16,7 +26,6 @@
 
 
 #define NUM_WO_ASSOCIATIONS 72
-
 
 struct wo_association WO_associations[] = {
 
@@ -112,7 +121,7 @@ struct wo_association& getWOAssociation(EPortType port, uint32_t pin) {
 
 
 EPioType getPeripheralOfPermutation(int permutation, int pin_position) {
-	return ((permutation>>pin_position)&0x01)==0x1?PIO_TIMER_ALT:PIO_TIMER;
+	return ((permutation>>pin_position)&0x01)==0x1?PIO_TCC_PDEC:PIO_TIMER_ALT;
 }
 
 
@@ -124,24 +133,17 @@ void syncTCC(Tcc* TCCx) {
 
 
 
-void writeSAMDDutyCycle(int chaninfo, float dc) {
-	uint8_t tccn = GetTCNumber(chaninfo);
-	uint8_t chan = GetTCChannelNumber(chaninfo);
+void writeSAMDDutyCycle(tccConfiguration* info, float dc) {
+	uint8_t tccn = GetTCNumber(info->tcc.chaninfo);
+	uint8_t chan = GetTCChannelNumber(info->tcc.chaninfo);
 	if (tccn<TCC_INST_NUM) {
-		Tcc* tcc = (Tcc*)GetTC(chaninfo);
+		Tcc* tcc = (Tcc*)GetTC(info->tcc.chaninfo);
 		// set via CCBUF
-		while ( (tcc->SYNCBUSY.vec.CC & (0x1<<chan)) > 0 );
-		tcc->CCBUF[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc); // TODO pwm frequency!
-//		tcc->STATUS.vec.CCBUFV |= (0x1<<chan);
-//		while ( tcc->SYNCBUSY.bit.STATUS > 0 );
-//		tcc->CTRLBSET.reg |= TCC_CTRLBSET_CMD(TCC_CTRLBSET_CMD_UPDATE_Val);
-//		while ( tcc->SYNCBUSY.bit.CTRLB > 0 );
+//		while ( (tcc->SYNCBUSY.vec.CC & (0x1<<chan)) > 0 );
+		tcc->CCBUF[chan].reg = (uint32_t)((info->pwm_res-1) * dc); // TODO pwm frequency!
 	}
-	else {
-		// Tc* tc = (Tc*)GetTC(chaninfo);
-		// //tc->COUNT16.CC[chan].reg = (uint32_t)((SIMPLEFOC_SAMD_PWM_RESOLUTION-1) * dc);
-		// tc->COUNT8.CC[chan].reg = (uint8_t)((SIMPLEFOC_SAMD_PWM_TC_RESOLUTION-1) * dc);
-		// while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
+	else { 
+		// we don't support the TC channels on SAMD51, isn't worth it.
 	}
 }
 
@@ -183,8 +185,8 @@ void configureSAMDClock() {
 		while (GCLK->SYNCBUSY.vec.GENCTRL&(0x1<<PWM_CLOCK_NUM));
 
 		GCLK->GENCTRL[PWM_CLOCK_NUM].reg = GCLK_GENCTRL_GENEN | GCLK_GENCTRL_DIV(1) | GCLK_GENCTRL_IDC
-										 | GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DFLL_Val);
-	 	 	 	 	 	 	 	 	 	 //| GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DPLL0_Val);
+										 //| GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DFLL_Val);
+	 	 	 	 	 	 	 	 	 	 | GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DPLL0_Val);
 		while (GCLK->SYNCBUSY.vec.GENCTRL&(0x1<<PWM_CLOCK_NUM));
 
 #ifdef SIMPLEFOC_SAMD_DEBUG
@@ -221,10 +223,19 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate, 
 		tcc->DRVCTRL.vec.INVEN = (tcc->DRVCTRL.vec.INVEN&invenMask)|invenVal;
 		syncTCC(tcc); // wait for sync
 
+		// work out pwm resolution for desired frequency and constrain to max/min values
+		long pwm_resolution = (SIMPLEFOC_SAMD51_DPLL_FREQ/2) / pwm_frequency;
+		if (pwm_resolution>SIMPLEFOC_SAMD_MAX_PWM_RESOLUTION) 
+			pwm_resolution = SIMPLEFOC_SAMD_MAX_PWM_RESOLUTION;
+		if (pwm_resolution<SIMPLEFOC_SAMD_MIN_PWM_RESOLUTION) 
+			pwm_resolution = SIMPLEFOC_SAMD_MIN_PWM_RESOLUTION;
+		// store for later use
+		tccConfig.pwm_res = pwm_resolution;
+
 		if (hw6pwm>0.0) {
 			tcc->WEXCTRL.vec.DTIEN |= (1<<tccConfig.tcc.chan);
-			tcc->WEXCTRL.bit.DTLS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
-			tcc->WEXCTRL.bit.DTHS = hw6pwm*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1);
+			tcc->WEXCTRL.bit.DTLS = hw6pwm*(pwm_resolution-1);
+			tcc->WEXCTRL.bit.DTHS = hw6pwm*(pwm_resolution-1);
 			syncTCC(tcc); // wait for sync
 		}
 
@@ -232,7 +243,7 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate, 
 			tcc->WAVE.reg |= TCC_WAVE_POL(0xF)|TCC_WAVE_WAVEGEN_DSTOP;   // Set wave form configuration - TODO check this... why set like this?
 			while ( tcc->SYNCBUSY.bit.WAVE == 1 ); // wait for sync
 
-			tcc->PER.reg = SIMPLEFOC_SAMD_PWM_RESOLUTION - 1;                 // Set counter Top using the PER register
+			tcc->PER.reg = pwm_resolution - 1;                 // Set counter Top using the PER register
 			while ( tcc->SYNCBUSY.bit.PER == 1 ); // wait for sync
 
 			// set all channels to 0%
@@ -254,11 +265,12 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate, 
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.print(tccConfig.tcc.chan);
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.print("[");
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.print(tccConfig.wo);
-		SIMPLEFOC_SAMD_DEBUG_SERIAL.println("]");
+		SIMPLEFOC_SAMD_DEBUG_SERIAL.print("]  pwm res ");
+		SIMPLEFOC_SAMD_DEBUG_SERIAL.println(pwm_resolution);		
 #endif
 	}
 	else if (tccConfig.tcc.tccn>=TCC_INST_NUM) {
-		Tc* tc = (Tc*)GetTC(tccConfig.tcc.chaninfo);
+		//Tc* tc = (Tc*)GetTC(tccConfig.tcc.chaninfo);
 
 		// disable
 		// tc->COUNT8.CTRLA.bit.ENABLE = 0;
@@ -280,8 +292,9 @@ void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate, 
 		// while ( tc->COUNT8.STATUS.bit.SYNCBUSY == 1 );
 
 	#ifdef SIMPLEFOC_SAMD_DEBUG
-		SIMPLEFOC_SAMD_DEBUG_SERIAL.print("Initialized TC ");
+		SIMPLEFOC_SAMD_DEBUG_SERIAL.print("Not initialized: TC ");
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.println(tccConfig.tcc.tccn);
+		SIMPLEFOC_SAMD_DEBUG_SERIAL.print("TC units not supported on SAMD51");
 	#endif
 	}
 

--- a/src/drivers/hardware_specific/samd_mcu.h
+++ b/src/drivers/hardware_specific/samd_mcu.h
@@ -29,8 +29,16 @@
 
 #ifndef SIMPLEFOC_SAMD_PWM_RESOLUTION
 #define SIMPLEFOC_SAMD_PWM_RESOLUTION 1000
-#define SIMPLEFOC_SAMD_PWM_TC_RESOLUTION 250
 #endif
+
+#define SIMPLEFOC_SAMD_DEFAULT_PWM_FREQUENCY_HZ 24000
+// arbitrary maximum. On SAMD51 with 120MHz clock this means 2kHz minimum pwm frequency
+#define SIMPLEFOC_SAMD_MAX_PWM_RESOLUTION 30000
+// lets not go too low - 400 with clock speed of 120MHz on SAMD51 means 150kHz maximum PWM frequency...
+//						 400 with 48MHz clock on SAMD21 means 60kHz maximum PWM frequency...
+#define SIMPLEFOC_SAMD_MIN_PWM_RESOLUTION 400 
+// this is the most we can support on the TC units
+#define SIMPLEFOC_SAMD_PWM_TC_RESOLUTION 250
 
 #ifndef SIMPLEFOC_SAMD_MAX_TCC_PINCONFIGURATIONS
 #define SIMPLEFOC_SAMD_MAX_TCC_PINCONFIGURATIONS 24
@@ -49,6 +57,7 @@ struct tccConfiguration {
 		};
 		uint16_t chaninfo;
 	} tcc;
+	uint16_t pwm_res;
 };
 
 
@@ -92,7 +101,7 @@ extern bool tccConfigured[TCC_INST_NUM+TC_INST_NUM];
 
 
 struct wo_association& getWOAssociation(EPortType port, uint32_t pin);
-void writeSAMDDutyCycle(int chaninfo, float dc);
+void writeSAMDDutyCycle(tccConfiguration* info, float dc);
 void configureSAMDClock();
 void configureTCC(tccConfiguration& tccConfig, long pwm_frequency, bool negate=false, float hw6pwm=-1);
 __inline__ void syncTCC(Tcc* TCCx) __attribute__((always_inline, unused));


### PR DESCRIPTION
* The PIN assignment issue on SAMD/E51 has been fixed
* Removed unnecessary syncs which were slowing down setting the PWM speed in some cases
* SAMD/E51 now uses the DPLL clock source, for faster PWM frequencies
* pwm_frequency can now be set for both SAMD/E51 and SAMD21
* on SAMD51 it should be possible to set it between 2kHz and 150kHz