### PR TITLE
define sizes and explicit values for all enums

### DIFF
--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -24,31 +24,31 @@
 /**
  *  Motiron control type
  */
-enum MotionControlType{
-  torque,//!< Torque control
-  velocity,//!< Velocity motion control
-  angle,//!< Position/angle motion control
-  velocity_openloop,
-  angle_openloop
+enum MotionControlType : uint8_t {
+  torque            = 0x00,     //!< Torque control
+  velocity          = 0x01,     //!< Velocity motion control
+  angle             = 0x02,     //!< Position/angle motion control
+  velocity_openloop = 0x03,
+  angle_openloop    = 0x04
 };
 
 /**
  *  Motiron control type
  */
-enum TorqueControlType{
-  voltage, //!< Torque control using voltage
-  dc_current, //!< Torque control using DC current (one current magnitude)
-  foc_current //!< torque control using dq currents
+enum TorqueControlType : uint8_t { 
+  voltage            = 0x00,     //!< Torque control using voltage
+  dc_current         = 0x01,     //!< Torque control using DC current (one current magnitude)
+  foc_current        = 0x02,     //!< torque control using dq currents
 };
 
 /**
  *  FOC modulation type
  */
-enum FOCModulationType{
-  SinePWM, //!< Sinusoidal PWM modulation
-  SpaceVectorPWM, //!< Space vector modulation method
-  Trapezoid_120,
-  Trapezoid_150
+enum FOCModulationType : uint8_t {
+  SinePWM            = 0x00,     //!< Sinusoidal PWM modulation
+  SpaceVectorPWM     = 0x01,     //!< Space vector modulation method
+  Trapezoid_120      = 0x02,     
+  Trapezoid_150      = 0x03,     
 };
 
 /**

--- a/src/common/base_classes/Sensor.h
+++ b/src/common/base_classes/Sensor.h
@@ -6,19 +6,19 @@
 /**
  *  Direction structure
  */
-enum Direction{
-    CW      = 1,  //clockwise
+enum Direction : int8_t {
+    CW      = 1,  // clockwise
     CCW     = -1, // counter clockwise
-    UNKNOWN = 0   //not yet known or invalid state
+    UNKNOWN = 0   // not yet known or invalid state
 };
 
 
 /**
  *  Pullup configuration structure
  */
-enum Pullup{
-    USE_INTERN, //!< Use internal pullups
-    USE_EXTERN //!< Use external pullups
+enum Pullup : uint8_t {
+    USE_INTERN = 0x00, //!< Use internal pullups
+    USE_EXTERN = 0x01  //!< Use external pullups
 };
 
 /**

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -12,10 +12,10 @@
 
 
 // Commander verbose display to the user type
-enum VerboseMode{
-  nothing = 0,   // display nothing - good for monitoring
-  on_request,    // display only on user request
-  user_friendly  // display textual messages to the user
+enum VerboseMode : uint8_t {
+  nothing       = 0x00, // display nothing - good for monitoring
+  on_request    = 0x01, // display only on user request
+  user_friendly = 0x02  // display textual messages to the user
 };
 
 

--- a/src/sensors/Encoder.h
+++ b/src/sensors/Encoder.h
@@ -10,9 +10,9 @@
 /**
  *  Quadrature mode configuration structure
  */
-enum Quadrature{
-  ON, //!<  Enable quadrature mode CPR = 4xPPR
-  OFF //!<  Disable quadrature mode / CPR = PPR
+enum Quadrature : uint8_t {
+  ON    = 0x00, //!<  Enable quadrature mode CPR = 4xPPR
+  OFF   = 0x01  //!<  Disable quadrature mode / CPR = PPR
 };
 
 class Encoder: public Sensor{


### PR DESCRIPTION
This commit adds defined sizes (uint8_t or int8_t in one case) and explicit values to all our enums.

This is due to the work on I2CCommander, and the need to do serialisation/deserialisation of these values in binary format.

While in theory the C++ compiler would probably have generated stable values, making them explicit guarantees this, and is also a form of documentation (e.g. makes it easy to see which enum constant has byte value 0x04 when looking at a Wireshark capture).

in addition there is a subtlety that enums are usually ints e.g. (sizeof(enumtype)==4 on 32 bit MCUs) but if you don't specify it isn't guaranteed. So when serialising, you could wind up with different sizes for the enum types on different architectures (or maybe due to compiler settings). Also that makes them subject to endianness problems (ugh :-( ). 
Luckily all our enums have <256 elements, so I have defined their size to 8bit integers which gets rid of all these problems.