### PR TITLE
enable SPI sensor for RP2040, its now supported

### DIFF
--- a/src/sensors/MagneticSensorSPI.cpp
+++ b/src/sensors/MagneticSensorSPI.cpp
@@ -1,4 +1,3 @@
-#ifndef TARGET_RP2040
 
 #include "MagneticSensorSPI.h"
 
@@ -160,4 +159,3 @@ void MagneticSensorSPI::close(){
 }
 
 
-#endif

--- a/src/sensors/MagneticSensorSPI.h
+++ b/src/sensors/MagneticSensorSPI.h
@@ -1,7 +1,6 @@
 #ifndef MAGNETICSENSORSPI_LIB_H
 #define MAGNETICSENSORSPI_LIB_H
 
-#ifndef TARGET_RP2040
 
 #include "Arduino.h"
 #include <SPI.h>
@@ -82,5 +81,4 @@ class MagneticSensorSPI: public Sensor{
 };
 
 
-#endif
 #endif


### PR DESCRIPTION
remove the ifdefs protecting the SPI code on RP2040, since it now works (due to updates in the RP2040 framework, nothing we did).