### PR TITLE
Driver refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Library Compile](https://github.com/simplefoc/Arduino-FOC/workflows/Library%20Compile/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![arduino-library-badge](https://www.ardu-badge.com/badge/Simple%20FOC.svg?)](https://www.ardu-badge.com/badge/Simple%20FOC.svg)
+[![status](https://joss.theoj.org/papers/4382445f249e064e9f0a7f6c1bb06b1d/status.svg)](https://joss.theoj.org/papers/4382445f249e064e9f0a7f6c1bb06b1d)
 
 We live in very exciting times 😃! BLDC motors are entering the hobby community more and more and many great projects have already emerged leveraging their far superior dynamics and power capabilities. BLDC motors have numerous advantages over regular DC motors but they have one big disadvantage, the complexity of control. Even though it has become relatively easy to design and manufacture PCBs and create our own hardware solutions for driving BLDC motors the proper low-cost solutions are yet to come. One of the reasons for this is the apparent complexity of writing the BLDC driving algorithms, Field oriented control (FOC) being an example of one of the most efficient ones.
 The solutions that can be found on-line are almost exclusively very specific for certain hardware configuration and the microcontroller architecture used.

--- a/src/common/base_classes/BLDCDriver.h
+++ b/src/common/base_classes/BLDCDriver.h
@@ -23,6 +23,7 @@ class BLDCDriver{
         float dc_c; //!< currently set duty cycle on phaseC
 
         bool initialized = false; // true if driver was successfully initialized
+        void* params = 0; // pointer to hardware specific parameters of driver
 
         /**
          * Set phase voltages to the harware

--- a/src/common/base_classes/StepperDriver.h
+++ b/src/common/base_classes/StepperDriver.h
@@ -18,7 +18,7 @@ class StepperDriver{
         float voltage_limit; //!< limiting voltage set to the motor
         
         bool initialized = false; // true if driver was successfully initialized
-        HardwareDriverParams params = 0;
+        void* params = 0; // pointer to hardware specific parameters of driver
 
         /** 
          * Set phase voltages to the harware 

--- a/src/common/base_classes/StepperDriver.h
+++ b/src/common/base_classes/StepperDriver.h
@@ -1,6 +1,8 @@
 #ifndef STEPPERDRIVER_H
 #define STEPPERDRIVER_H
 
+#include "drivers/hardware_api.h"
+
 class StepperDriver{
     public:
         
@@ -16,7 +18,8 @@ class StepperDriver{
         float voltage_limit; //!< limiting voltage set to the motor
         
         bool initialized = false; // true if driver was successfully initialized
-            
+        HardwareDriverParams params = 0;
+
         /** 
          * Set phase voltages to the harware 
          * 

--- a/src/current_sense/hardware_specific/stm32g4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32g4_mcu.cpp
@@ -1,5 +1,6 @@
 #include "../hardware_api.h"
 #include "stm32g4_hal.h"
+#include "Arduino.h"
 
 #if defined(STM32G4xx) 
 #define _ADC_VOLTAGE 3.3
@@ -29,9 +30,10 @@ float _readADCVoltageInline(const int pin){
     raw_adc = adcBuffer1[1];
   else if(pin == PA6) // = ADC2_IN3 = phase V (OP2_OUT) on B-G431B-ESC1
     raw_adc = adcBuffer2[0];
+#ifdef PB1
   else if(pin == PB1) // = ADC1_IN12 = phase W (OP3_OUT) on B-G431B-ESC1
     raw_adc = adcBuffer1[0];
-
+#endif
   return raw_adc * _ADC_CONV;
 }
 // do the same for low side sensing

--- a/src/drivers/BLDCDriver3PWM.cpp
+++ b/src/drivers/BLDCDriver3PWM.cpp
@@ -56,9 +56,8 @@ int BLDCDriver3PWM::init() {
 
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
-  _configure3PWM(pwm_frequency, pwmA, pwmB, pwmC);
-  initialized = true; // TODO atm the api gives no feedback if initialization succeeded
-  return 0;
+  params = _configure3PWM(pwm_frequency, pwmA, pwmB, pwmC);
+  return params!=0 && params->initSuccess;
 }
 
 
@@ -88,5 +87,5 @@ void BLDCDriver3PWM::setPwm(float Ua, float Ub, float Uc) {
 
   // hardware specific writing
   // hardware specific function - depending on driver and mcu
-  _writeDutyCycle3PWM(dc_a, dc_b, dc_c, pwmA, pwmB, pwmC);
+  _writeDutyCycle3PWM(dc_a, dc_b, dc_c, params);
 }

--- a/src/drivers/BLDCDriver3PWM.cpp
+++ b/src/drivers/BLDCDriver3PWM.cpp
@@ -57,7 +57,7 @@ int BLDCDriver3PWM::init() {
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
   params = _configure3PWM(pwm_frequency, pwmA, pwmB, pwmC);
-  return params!=0 && params->initSuccess;
+  return params!=SIMPLEFOC_DRIVER_INIT_FAILED;
 }
 
 

--- a/src/drivers/BLDCDriver3PWM.h
+++ b/src/drivers/BLDCDriver3PWM.h
@@ -58,7 +58,6 @@ class BLDCDriver3PWM: public BLDCDriver
     */
     virtual void setPhaseState(int sa, int sb, int sc) override;
   private:
-        
 };
 
 

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -59,8 +59,9 @@ int BLDCDriver6PWM::init() {
   // configure 6pwm
   // hardware specific function - depending on driver and mcu
   params = _configure6PWM(pwm_frequency, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
-  return params!=0 && params->initSuccess;
+  return params!=SIMPLEFOC_DRIVER_INIT_FAILED;
 }
+
 
 // Set voltage to the pwm pin
 void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
@@ -75,7 +76,7 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
   dc_c = _constrain(Uc / voltage_power_supply, 0.0f , 1.0f );
   // hardware specific writing
   // hardware specific function - depending on driver and mcu
-  _writeDutyCycle6PWM(dc_a, dc_b, dc_c, dead_zone, params);
+  _writeDutyCycle6PWM(dc_a, dc_b, dc_c, params);
 }
 
 

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -58,9 +58,8 @@ int BLDCDriver6PWM::init() {
 
   // configure 6pwm
   // hardware specific function - depending on driver and mcu
-  int result = _configure6PWM(pwm_frequency, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
-  initialized = (result==0);
-  return result;
+  params = _configure6PWM(pwm_frequency, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
+  return params!=0 && params->initSuccess;
 }
 
 // Set voltage to the pwm pin
@@ -76,7 +75,7 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
   dc_c = _constrain(Uc / voltage_power_supply, 0.0f , 1.0f );
   // hardware specific writing
   // hardware specific function - depending on driver and mcu
-  _writeDutyCycle6PWM(dc_a, dc_b, dc_c, dead_zone, pwmA_h,pwmA_l, pwmB_h,pwmB_l, pwmC_h,pwmC_l);
+  _writeDutyCycle6PWM(dc_a, dc_b, dc_c, dead_zone, params);
 }
 
 

--- a/src/drivers/StepperDriver2PWM.cpp
+++ b/src/drivers/StepperDriver2PWM.cpp
@@ -79,9 +79,8 @@ int StepperDriver2PWM::init() {
 
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
-  _configure2PWM(pwm_frequency, pwm1, pwm2);
-  initialized = true; // TODO atm the api gives no feedback if initialization succeeded
-  return 0;
+  params = _configure2PWM(pwm_frequency, pwm1, pwm2);
+  return params!=0 && params->initSuccess;
 }
 
 
@@ -103,5 +102,5 @@ void StepperDriver2PWM::setPwm(float Ua, float Ub) {
   if( _isset(dir2b) ) digitalWrite(dir2b, Ub >= 0 ? HIGH : LOW );
 
   // write to hardware
-  _writeDutyCycle2PWM(duty_cycle1, duty_cycle2, pwm1, pwm2);
+  _writeDutyCycle2PWM(duty_cycle1, duty_cycle2, params);
 }

--- a/src/drivers/StepperDriver2PWM.cpp
+++ b/src/drivers/StepperDriver2PWM.cpp
@@ -80,7 +80,7 @@ int StepperDriver2PWM::init() {
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
   params = _configure2PWM(pwm_frequency, pwm1, pwm2);
-  return params!=0 && params->initSuccess;
+  return params!=SIMPLEFOC_DRIVER_INIT_FAILED;
 }
 
 

--- a/src/drivers/StepperDriver4PWM.cpp
+++ b/src/drivers/StepperDriver4PWM.cpp
@@ -55,7 +55,7 @@ int StepperDriver4PWM::init() {
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
   params = _configure4PWM(pwm_frequency, pwm1A, pwm1B, pwm2A, pwm2B);
-  return params!=0 && params->initSuccess;
+  return params!=SIMPLEFOC_DRIVER_INIT_FAILED;
 }
 
 

--- a/src/drivers/StepperDriver4PWM.cpp
+++ b/src/drivers/StepperDriver4PWM.cpp
@@ -54,9 +54,8 @@ int StepperDriver4PWM::init() {
 
   // Set the pwm frequency to the pins
   // hardware specific function - depending on driver and mcu
-  _configure4PWM(pwm_frequency, pwm1A, pwm1B, pwm2A, pwm2B);
-  initialized = true; // TODO atm the api gives no feedback if initialization succeeded
-  return 0;
+  params = _configure4PWM(pwm_frequency, pwm1A, pwm1B, pwm2A, pwm2B);
+  return params!=0 && params->initSuccess;
 }
 
 
@@ -77,5 +76,5 @@ void StepperDriver4PWM::setPwm(float Ualpha, float Ubeta) {
   else
     duty_cycle2A = _constrain(abs(Ubeta)/voltage_power_supply,0.0f,1.0f);
   // write to hardware
-  _writeDutyCycle4PWM(duty_cycle1A, duty_cycle1B, duty_cycle2A, duty_cycle2B, pwm1A, pwm1B, pwm2A, pwm2B);
+  _writeDutyCycle4PWM(duty_cycle1A, duty_cycle1B, duty_cycle2A, duty_cycle2B, params);
 }

--- a/src/drivers/hardware_api.h
+++ b/src/drivers/hardware_api.h
@@ -4,6 +4,18 @@
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 
+
+struct HardwareDriverParamsBase {
+    int pins[6];
+    long pwm_frequency;
+    int dead_zone;
+    bool initSuccess;
+};
+
+typedef struct HardwareDriverParamsBase* HardwareDriverParams;
+
+
+
 /** 
  * Configuring PWM frequency, resolution and alignment
  * - Stepper driver - 2PWM setting
@@ -13,7 +25,7 @@
  * @param pinA pinA bldc driver
  * @param pinB pinB bldc driver
  */
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB);
+HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const int pinB);
 
 /** 
  * Configuring PWM frequency, resolution and alignment
@@ -25,7 +37,7 @@ void _configure2PWM(long pwm_frequency, const int pinA, const int pinB);
  * @param pinB pinB bldc driver
  * @param pinC pinC bldc driver
  */
-void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC);
+HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC);
 
 /** 
  * Configuring PWM frequency, resolution and alignment
@@ -38,7 +50,7 @@ void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const in
  * @param pin2A pin2A stepper driver
  * @param pin2B pin2B stepper driver
  */
-void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B);
+HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B);
 
 /** 
  * Configuring PWM frequency, resolution and alignment
@@ -56,7 +68,7 @@ void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const 
  * 
  * @return 0 if config good, -1 if failed
  */
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l);
+HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l);
 
 /** 
  * Function setting the duty cycle to the pwm pin (ex. analogWrite())
@@ -68,7 +80,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
  * @param pinA  phase A hardware pin number
  * @param pinB  phase B hardware pin number
  */ 
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB);
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, HardwareDriverParams params = 0);
 
 /** 
  * Function setting the duty cycle to the pwm pin (ex. analogWrite())
@@ -82,7 +94,7 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB);
  * @param pinB  phase B hardware pin number
  * @param pinC  phase C hardware pin number
  */ 
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC);
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, HardwareDriverParams params = 0);
 
 /** 
  * Function setting the duty cycle to the pwm pin (ex. analogWrite())
@@ -98,7 +110,7 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
  * @param pin2A  phase 2A hardware pin number
  * @param pin2B  phase 2B hardware pin number
  */ 
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B);
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, HardwareDriverParams params = 0);
 
 
 /** 
@@ -118,6 +130,6 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
  * @param pinC_l  phase C low-side hardware pin number
  * 
  */ 
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, HardwareDriverParams params = 0);
 
 #endif

--- a/src/drivers/hardware_specific/atmega2560_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega2560_mcu.cpp
@@ -28,64 +28,79 @@ void _pinHighFrequency(const int pin){
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
   _pinHighFrequency(pinC);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
-  analogWrite(pinC, 255.0f*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pin1A);
   _pinHighFrequency(pin1B);
   _pinHighFrequency(pin2A);
   _pinHighFrequency(pin2B);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params) {
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0f*dc_1a);
-  analogWrite(pin1B, 255.0f*dc_1b);
-  analogWrite(pin2A, 255.0f*dc_2a);
-  analogWrite(pin2B, 255.0f*dc_2b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 
@@ -122,14 +137,20 @@ int _configureComplementaryPair(int pinH, int pinL) {
 // - BLDC driver - 6PWM setting
 // - hardware specific
 // supports Arudino/ATmega328
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
   //  High PWM frequency
   // - always max 32kHz
   int ret_flag = 0;
   ret_flag += _configureComplementaryPair(pinA_h, pinA_l);
   ret_flag += _configureComplementaryPair(pinB_h, pinB_l);
   ret_flag += _configureComplementaryPair(pinC_h, pinC_l);
-  return ret_flag; // returns -1 if not well configured
+  if (ret_flag!=0) return SIMPLEFOC_DRIVER_INIT_FAILED;
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA_h,, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency
+    .dead_zone = dead_zone
+  };
+  return params;
 }
 
 // function setting the
@@ -149,10 +170,10 @@ void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
 // supports Arudino/ATmega328
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  _setPwmPair(pinA_h, pinA_l, dc_a*255.0, dead_zone*255.0);
-  _setPwmPair(pinB_h, pinB_l, dc_b*255.0, dead_zone*255.0);
-  _setPwmPair(pinC_h, pinC_l, dc_c*255.0, dead_zone*255.0);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  _setPwmPair(((GenericDriverParams*)params)->pins[0], ((GenericDriverParams*)params)->pins[1], dc_a*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[2], ((GenericDriverParams*)params)->pins[3], dc_b*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[4], ((GenericDriverParams*)params)->pins[5], dc_c*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
 }
 
 #endif

--- a/src/drivers/hardware_specific/atmega328_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega328_mcu.cpp
@@ -21,68 +21,81 @@ void _pinHighFrequency(const int pin){
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 // supports Arudino/ATmega328
-void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
-  _UNUSED(pwm_frequency);
+void* _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 // supports Arudino/ATmega328
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
-  _UNUSED(pwm_frequency);
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
   _pinHighFrequency(pinC);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
-  analogWrite(pinC, 255.0f*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 // supports Arudino/ATmega328
-void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pin1A);
   _pinHighFrequency(pin1B);
   _pinHighFrequency(pin2A);
   _pinHighFrequency(pin2B);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0f*dc_1a);
-  analogWrite(pin1B, 255.0f*dc_1b);
-  analogWrite(pin2A, 255.0f*dc_2a);
-  analogWrite(pin2B, 255.0f*dc_2b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 
@@ -118,16 +131,20 @@ int _configureComplementaryPair(int pinH, int pinL) {
 // - BLDC driver - 6PWM setting
 // - hardware specific
 // supports Arudino/ATmega328
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
-  _UNUSED(pwm_frequency);
-  _UNUSED(dead_zone);
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
   //  High PWM frequency
   // - always max 32kHz
   int ret_flag = 0;
   ret_flag += _configureComplementaryPair(pinA_h, pinA_l);
   ret_flag += _configureComplementaryPair(pinB_h, pinB_l);
   ret_flag += _configureComplementaryPair(pinC_h, pinC_l);
-  return ret_flag; // returns -1 if not well configured
+  if (ret_flag!=0) return SIMPLEFOC_DRIVER_INIT_FAILED;
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA_h,, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency
+    .dead_zone = dead_zone
+  };
+  return params;
 }
 
 // function setting the
@@ -147,10 +164,10 @@ void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
 // supports Arudino/ATmega328
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  _setPwmPair(pinA_h, pinA_l, dc_a*255.0, dead_zone*255.0);
-  _setPwmPair(pinB_h, pinB_l, dc_b*255.0, dead_zone*255.0);
-  _setPwmPair(pinC_h, pinC_l, dc_c*255.0, dead_zone*255.0);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  _setPwmPair(((GenericDriverParams*)params)->pins[0], ((GenericDriverParams*)params)->pins[1], dc_a*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[2], ((GenericDriverParams*)params)->pins[3], dc_b*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[4], ((GenericDriverParams*)params)->pins[5], dc_c*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
 }
 
 #endif

--- a/src/drivers/hardware_specific/atmega32u4_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega32u4_mcu.cpp
@@ -31,64 +31,79 @@ void _pinHighFrequency(const int pin){
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pinA);
   _pinHighFrequency(pinB);
   _pinHighFrequency(pinC);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware 
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 
 // function setting the pwm duty cycle to the hardware 
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0*dc_a);
-  analogWrite(pinB, 255.0*dc_b);
-  analogWrite(pinC, 255.0*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
    //  High PWM frequency
    // - always max 32kHz
   _pinHighFrequency(pin1A);
   _pinHighFrequency(pin1B);
   _pinHighFrequency(pin2A);
-  _pinHighFrequency(pin2B); 
+  _pinHighFrequency(pin2B);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware  
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0*dc_1a);
-  analogWrite(pin1B, 255.0*dc_1b);
-  analogWrite(pin2A, 255.0*dc_2a);
-  analogWrite(pin2B, 255.0*dc_2b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 
@@ -134,17 +149,21 @@ int _configureComplementaryPair(int pinH, int pinL) {
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
-  _UNUSED(pwm_frequency);
-  _UNUSED(dead_zone);
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
   //  High PWM frequency
   // - always max 32kHz
   int ret_flag = 0;
   ret_flag += _configureComplementaryPair(pinA_h, pinA_l);
   ret_flag += _configureComplementaryPair(pinB_h, pinB_l);
   ret_flag += _configureComplementaryPair(pinC_h, pinC_l);
-  return ret_flag; // returns -1 if not well configured
-
+  if (ret_flag!=0) return SIMPLEFOC_DRIVER_INIT_FAILED;
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA_h,, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency
+    .dead_zone = dead_zone
+  };
+  return params;
+}
 
 // function setting the 
 void _setPwmPair(int pinH, int pinL, float val, int dead_time)
@@ -163,10 +182,10 @@ void _setPwmPair(int pinH, int pinL, float val, int dead_time)
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
 // supports Arudino/ATmega328 
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  _setPwmPair(pinA_h, pinA_l, dc_a*255.0, dead_zone*255.0);
-  _setPwmPair(pinB_h, pinB_l, dc_b*255.0, dead_zone*255.0);
-  _setPwmPair(pinC_h, pinC_l, dc_c*255.0, dead_zone*255.0);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  _setPwmPair(((GenericDriverParams*)params)->pins[0], ((GenericDriverParams*)params)->pins[1], dc_a*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[2], ((GenericDriverParams*)params)->pins[3], dc_b*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
+  _setPwmPair(((GenericDriverParams*)params)->pins[4], ((GenericDriverParams*)params)->pins[5], dc_c*255.0, ((GenericDriverParams*)params)->dead_zone*255.0);
 }
 
 #endif

--- a/src/drivers/hardware_specific/due_mcu.cpp
+++ b/src/drivers/hardware_specific/due_mcu.cpp
@@ -320,13 +320,17 @@ void TC8_Handler()
   if(pwm_counter_vals[17]) TC_SetRB(TC2, 2, pwm_counter_vals[17]);
 }
 
+
+
+
+
 // implementation of the hardware_api.cpp 
 // ---------------------------------------------------------------------------------------------------------------------------------
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware specific
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 50khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // save the pwm frequency
@@ -337,13 +341,21 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
   initPWM(pinC, _pwm_frequency);
   // sync the timers if possible
   syncTimers(pinA, pinB, pinC);
+
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
+
 
 
 // Configuring PWM frequency, resolution and alignment
 //- Stepper driver - 2PWM setting
 // - hardware specific
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency)) pwm_frequency = _PWM_FREQUENCY; // default frequency 50khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // save the pwm frequency
@@ -353,12 +365,21 @@ void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   initPWM(pinB, _pwm_frequency);
   // sync the timers if possible
   syncTimers(pinA, pinB);
+
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
+
+
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency)) pwm_frequency = _PWM_FREQUENCY; // default frequency 50khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // save the pwm frequency
@@ -370,36 +391,52 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
   initPWM(pinD, _pwm_frequency);
   // sync the timers if possible
   syncTimers(pinA, pinB, pinC, pinD);
+
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC, pinD },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* param){
   // transform duty cycle from [0,1] to [0,_max_pwm_value]
-  setPwm(pinA, _max_pwm_value*dc_a);
-  setPwm(pinB, _max_pwm_value*dc_b);
-  setPwm(pinC, _max_pwm_value*dc_c);
+  GenericDriverParams* p = (GenericDriverParams*)param;
+  setPwm(p->pins[0], _max_pwm_value*dc_a);
+  setPwm(p->pins[1], _max_pwm_value*dc_b);
+  setPwm(p->pins[2], _max_pwm_value*dc_c);
 }
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* param){
   // transform duty cycle from [0,1] to [0,_max_pwm_value]
-  setPwm(pin1A, _max_pwm_value*dc_1a);
-  setPwm(pin1B, _max_pwm_value*dc_1b);
-  setPwm(pin2A, _max_pwm_value*dc_2a);
-  setPwm(pin2B, _max_pwm_value*dc_2b);
+  GenericDriverParams* p = (GenericDriverParams*)param;
+  setPwm(p->pins[0], _max_pwm_value*dc_1a);
+  setPwm(p->pins[1], _max_pwm_value*dc_1b);
+  setPwm(p->pins[2], _max_pwm_value*dc_2a);
+  setPwm(p->pins[3], _max_pwm_value*dc_2b);
 }
+
+
 
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 // - Stepper driver - 2PWM setting
 // - hardware specific
-void  _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void  _writeDutyCycle2PWM(float dc_a,  float dc_b, void* param){
   // transform duty cycle from [0,1] to [0,_max_pwm_value]
-  setPwm(pinA, _max_pwm_value*dc_a);
-  setPwm(pinB, _max_pwm_value*dc_b);
+  GenericDriverParams* p = (GenericDriverParams*)param;
+  setPwm(p->pins[0], _max_pwm_value*dc_a);
+  setPwm(p->pins[1], _max_pwm_value*dc_b);
 }
 
 

--- a/src/drivers/hardware_specific/esp32_ledc_mcu.cpp
+++ b/src/drivers/hardware_specific/esp32_ledc_mcu.cpp
@@ -1,6 +1,6 @@
 #include "../hardware_api.h"
 
-#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && !defined(SOC_MCPWM_SUPPORTED) 
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && ( !defined(SOC_MCPWM_SUPPORTED) || defined(SIMPLEFOC_ESP32_USELEDC) )
 
 #include "driver/ledc.h"
 
@@ -25,6 +25,7 @@
 #define LEDC_CHANNELS           (SOC_LEDC_CHANNEL_NUM)
 #endif
 
+
 // current channel stack index
 // support for multiple motors
 // esp32 has 16 channels
@@ -32,50 +33,17 @@
 // esp32c3 has 6 channels
 int channel_index = 0;
 
-// slot for the 3pwm bldc motors
-typedef struct {
-  int pinID;
-  int ch1;
-  int ch2;
-  int ch3;
-} bldc_3pwm_motor_slots_t;
-
-// slot for the 2pwm stepper motors
-typedef struct {
-  int pinID;
-  int ch1;
-  int ch2;
-} stepper_2pwm_motor_slots_t;
-
-// slot for the 4pwm stepper motors
-typedef struct {
-  int pinID;
-  int ch1;
-  int ch2;
-  int ch3;
-  int ch4;
-} stepper_4pwm_motor_slots_t;
 
 
-// define motor slots array
-bldc_3pwm_motor_slots_t esp32_bldc_3pwm_motor_slots[4] = {
-  {_EMPTY_SLOT, 0,0,0}, // 1st motor
-  {_EMPTY_SLOT, 0,0,0}, // 2nd motor
-  {_EMPTY_SLOT, 0,0,0}, // 3st motor // esp32s2 & esp32
-  {_EMPTY_SLOT, 0,0,0}, // 4nd motor // esp32 only
-};
-stepper_2pwm_motor_slots_t esp32_stepper_2pwm_motor_slots[4]={
-  {_EMPTY_SLOT, 0,0}, // 1st motor
-  {_EMPTY_SLOT, 0,0}, // 2nd motor
-  {_EMPTY_SLOT, 0,0}, // 3rd motor
-  {_EMPTY_SLOT, 0,0}  // 4th motor - esp32s2 and esp32
-};
-stepper_4pwm_motor_slots_t esp32_stepper_4pwm_motor_slots[4]={
-  {_EMPTY_SLOT, 0,0,0,0}, // 1st motor
-  {_EMPTY_SLOT, 0,0,0,0}, // 2nd motor - esp32s2 and esp32
-  {_EMPTY_SLOT, 0,0,0,0}, // 3st motor - only esp32
-  {_EMPTY_SLOT, 0,0,0,0}, // 4st motor - only esp32
-};
+
+typedef struct ESP32LEDCDriverParams {
+  int channels[6];
+  long pwm_frequency;
+} ESP32LEDCDriverParams;
+
+
+
+
 
 //  configure High PWM frequency
 void _setHighFrequency(const long freq, const int pin, const int channel){
@@ -83,122 +51,98 @@ void _setHighFrequency(const long freq, const int pin, const int channel){
   ledcAttachPin(pin, channel);
 }
 
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+
+
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
 
   // check if enough channels available
-  if ( channel_index + 2 >= LEDC_CHANNELS ) return;
+  if ( channel_index + 2 >= LEDC_CHANNELS ) return SIMPLEFOC_DRIVER_INIT_FAILED;
 
-  stepper_2pwm_motor_slots_t m_slot = {};
+  int ch1 = channel_index++;
+  int ch2 = channel_index++;
+  _setHighFrequency(pwm_frequency, pinA, ch1);
+  _setHighFrequency(pwm_frequency, pinB, ch2);
 
-  // determine which motor are we connecting
-  // and set the appropriate configuration parameters
-  for(int slot_num = 0; slot_num < 4; slot_num++){
-    if(esp32_stepper_2pwm_motor_slots[slot_num].pinID == _EMPTY_SLOT){ // put the new motor in the first empty slot
-      esp32_stepper_2pwm_motor_slots[slot_num].pinID = pinA;
-      esp32_stepper_2pwm_motor_slots[slot_num].ch1 = channel_index++;
-      esp32_stepper_2pwm_motor_slots[slot_num].ch2 = channel_index++;
-      m_slot = esp32_stepper_2pwm_motor_slots[slot_num];
-      break;
-    }
-  }
-
-  _setHighFrequency(pwm_frequency, pinA, m_slot.ch1);
-  _setHighFrequency(pwm_frequency, pinB, m_slot.ch2);
+  ESP32LEDCDriverParams* params = new ESP32LEDCDriverParams {
+    .channels = { ch1, ch2 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+
+
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
 
   // check if enough channels available
-  if ( channel_index + 3 >= LEDC_CHANNELS ) return;
+  if ( channel_index + 3 >= LEDC_CHANNELS ) return SIMPLEFOC_DRIVER_INIT_FAILED;
 
-  bldc_3pwm_motor_slots_t m_slot = {};
+  int ch1 = channel_index++;
+  int ch2 = channel_index++;
+  int ch3 = channel_index++;
+  _setHighFrequency(pwm_frequency, pinA, ch1);
+  _setHighFrequency(pwm_frequency, pinB, ch2);
+  _setHighFrequency(pwm_frequency, pinC, ch3);
 
-  // determine which motor are we connecting
-  // and set the appropriate configuration parameters
-  for(int slot_num = 0; slot_num < 4; slot_num++){
-    if(esp32_bldc_3pwm_motor_slots[slot_num].pinID == _EMPTY_SLOT){ // put the new motor in the first empty slot
-      esp32_bldc_3pwm_motor_slots[slot_num].pinID = pinA;
-      esp32_bldc_3pwm_motor_slots[slot_num].ch1 = channel_index++;
-      esp32_bldc_3pwm_motor_slots[slot_num].ch2 = channel_index++;
-      esp32_bldc_3pwm_motor_slots[slot_num].ch3 = channel_index++;
-      m_slot = esp32_bldc_3pwm_motor_slots[slot_num];
-      break;
-    }
-  }
-
-  _setHighFrequency(pwm_frequency, pinA, m_slot.ch1);
-  _setHighFrequency(pwm_frequency, pinB, m_slot.ch2);
-  _setHighFrequency(pwm_frequency, pinC, m_slot.ch3);
+  ESP32LEDCDriverParams* params = new ESP32LEDCDriverParams {
+    .channels = { ch1, ch2, ch3 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+
+
+void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
 
   // check if enough channels available
-  if ( channel_index + 4 >= LEDC_CHANNELS ) return;
+  if ( channel_index + 4 >= LEDC_CHANNELS ) return SIMPLEFOC_DRIVER_INIT_FAILED;
 
+  int ch1 = channel_index++;
+  int ch2 = channel_index++;
+  int ch3 = channel_index++;
+  int ch4 = channel_index++;
+  _setHighFrequency(pwm_frequency, pinA, ch1);
+  _setHighFrequency(pwm_frequency, pinB, ch2);
+  _setHighFrequency(pwm_frequency, pinC, ch3);
+  _setHighFrequency(pwm_frequency, pinD, ch4);
 
-  stepper_4pwm_motor_slots_t m_slot = {};
-
-  // determine which motor are we connecting
-  // and set the appropriate configuration parameters
-  for(int slot_num = 0; slot_num < 4; slot_num++){
-    if(esp32_stepper_4pwm_motor_slots[slot_num].pinID == _EMPTY_SLOT){ // put the new motor in the first empty slot
-      esp32_stepper_4pwm_motor_slots[slot_num].pinID = pinA;
-      esp32_stepper_4pwm_motor_slots[slot_num].ch1 = channel_index++;
-      esp32_stepper_4pwm_motor_slots[slot_num].ch2 = channel_index++;
-      esp32_stepper_4pwm_motor_slots[slot_num].ch3 = channel_index++;
-      esp32_stepper_4pwm_motor_slots[slot_num].ch4 = channel_index++;
-      m_slot = esp32_stepper_4pwm_motor_slots[slot_num];
-      break;
-    }
-  }
-
-  _setHighFrequency(pwm_frequency, pinA, m_slot.ch1);
-  _setHighFrequency(pwm_frequency, pinB, m_slot.ch2);
-  _setHighFrequency(pwm_frequency, pinC, m_slot.ch3);
-  _setHighFrequency(pwm_frequency, pinD, m_slot.ch4);
+  ESP32LEDCDriverParams* params = new ESP32LEDCDriverParams {
+    .channels = { ch1, ch2, ch3, ch4 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
-// determine which motor slot is the motor connected to
-  for(int i = 0; i < 4; i++){
-    if(esp32_stepper_2pwm_motor_slots[i].pinID == pinA){ // if motor slot found
-      ledcWrite(esp32_stepper_2pwm_motor_slots[i].ch1, _constrain(_PWM_RES*dc_a, 0, _PWM_RES));
-      ledcWrite(esp32_stepper_2pwm_motor_slots[i].ch2, _constrain(_PWM_RES*dc_b, 0, _PWM_RES));
-      break;
-    }
-  }
+
+
+
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[0], _constrain(_PWM_RES*dc_a, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[1], _constrain(_PWM_RES*dc_b, 0, _PWM_RES));
 }
 
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 4; i++){
-    if(esp32_bldc_3pwm_motor_slots[i].pinID == pinA){ // if motor slot found
-      ledcWrite(esp32_bldc_3pwm_motor_slots[i].ch1, _constrain(_PWM_RES*dc_a, 0, _PWM_RES));
-      ledcWrite(esp32_bldc_3pwm_motor_slots[i].ch2, _constrain(_PWM_RES*dc_b, 0, _PWM_RES));
-      ledcWrite(esp32_bldc_3pwm_motor_slots[i].ch3, _constrain(_PWM_RES*dc_c, 0, _PWM_RES));
-      break;
-    }
-  }
+
+
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[0], _constrain(_PWM_RES*dc_a, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[1], _constrain(_PWM_RES*dc_b, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[2], _constrain(_PWM_RES*dc_c, 0, _PWM_RES));
 }
 
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 4; i++){
-    if(esp32_stepper_4pwm_motor_slots[i].pinID == pin1A){ // if motor slot found
-      ledcWrite(esp32_stepper_4pwm_motor_slots[i].ch1, _constrain(_PWM_RES*dc_1a, 0, _PWM_RES));
-      ledcWrite(esp32_stepper_4pwm_motor_slots[i].ch2, _constrain(_PWM_RES*dc_1b, 0, _PWM_RES));
-      ledcWrite(esp32_stepper_4pwm_motor_slots[i].ch3, _constrain(_PWM_RES*dc_2a, 0, _PWM_RES));
-      ledcWrite(esp32_stepper_4pwm_motor_slots[i].ch4, _constrain(_PWM_RES*dc_2b, 0, _PWM_RES));
-      break;
-    }
-  }
+
+
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[0], _constrain(_PWM_RES*dc_1a, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[1], _constrain(_PWM_RES*dc_1b, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[2], _constrain(_PWM_RES*dc_2a, 0, _PWM_RES));
+  ledcWrite(((ESP32LEDCDriverParams*)params)->channels[3], _constrain(_PWM_RES*dc_2b, 0, _PWM_RES));
 }
 
 #endif

--- a/src/drivers/hardware_specific/esp32_mcu.cpp
+++ b/src/drivers/hardware_specific/esp32_mcu.cpp
@@ -1,6 +1,6 @@
 #include "../hardware_api.h"
 
-#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) 
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) && !defined(SIMPLEFOC_ESP32_USELEDC)
 
 #include "driver/mcpwm.h"
 #include "soc/mcpwm_reg.h"

--- a/src/drivers/hardware_specific/esp32_mcu.cpp
+++ b/src/drivers/hardware_specific/esp32_mcu.cpp
@@ -35,6 +35,7 @@ typedef struct {
   mcpwm_io_signals_t mcpwm_b;
   mcpwm_io_signals_t mcpwm_c;
 } bldc_3pwm_motor_slots_t;
+
 typedef struct {
   int pin1A;
   mcpwm_dev_t* mcpwm_num;
@@ -46,6 +47,7 @@ typedef struct {
   mcpwm_io_signals_t mcpwm_2a;
   mcpwm_io_signals_t mcpwm_2b;
 } stepper_4pwm_motor_slots_t;
+
 typedef struct {
   int pin1pwm;
   mcpwm_dev_t* mcpwm_num;
@@ -68,6 +70,8 @@ typedef struct {
   mcpwm_io_signals_t mcpwm_bl;
   mcpwm_io_signals_t mcpwm_cl;
 } bldc_6pwm_motor_slots_t;
+
+
 
 // define bldc motor slots array
 bldc_3pwm_motor_slots_t esp32_bldc_3pwm_motor_slots[4] =  {
@@ -96,6 +100,19 @@ stepper_2pwm_motor_slots_t esp32_stepper_2pwm_motor_slots[4] =  {
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_A, MCPWM0A, MCPWM1A}, // 3rd motor will be MCPWM1 channel A
   {_EMPTY_SLOT, &MCPWM1, MCPWM_UNIT_1, MCPWM_OPR_B, MCPWM0B, MCPWM1B}  // 4th motor will be MCPWM1 channel B
   };
+
+
+
+typedef struct ESP32MCPWMDriverParams {
+  long pwm_frequency;
+  mcpwm_unit_t mcpwm_unit;
+  mcpwm_operator_t mcpwm_operator1;
+  mcpwm_operator_t mcpwm_operator2;
+} ESP32MCPWMDriverParams;
+
+
+
+
 
 // configuring high frequency pwm timer
 // a lot of help from this post from Paul Gauld
@@ -180,7 +197,7 @@ void _configureTimerFrequency(long pwm_frequency, mcpwm_dev_t* mcpwm_num,  mcpwm
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 // supports Arudino/ATmega328, STM32 and ESP32
-void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
 
@@ -218,6 +235,12 @@ void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
   // configure the timer
   _configureTimerFrequency(pwm_frequency, m_slot.mcpwm_num,  m_slot.mcpwm_unit);
 
+  ESP32MCPWMDriverParams* params = new ESP32MCPWMDriverParams {
+    .pwm_frequency = pwm_frequency,
+    .mcpwm_unit = m_slot.mcpwm_unit,
+    .mcpwm_operator1 = m_slot.mcpwm_operator
+  };
+  return params;
 }
 
 
@@ -225,7 +248,7 @@ void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 // supports Arudino/ATmega328, STM32 and ESP32
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
 
@@ -263,13 +286,19 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
   // configure the timer
   _configureTimerFrequency(pwm_frequency, m_slot.mcpwm_num,  m_slot.mcpwm_unit);
 
+  ESP32MCPWMDriverParams* params = new ESP32MCPWMDriverParams {
+    .pwm_frequency = pwm_frequency,
+    .mcpwm_unit = m_slot.mcpwm_unit,
+    .mcpwm_operator1 = m_slot.mcpwm_operator
+  };
+  return params;
 }
 
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25hz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max
   stepper_4pwm_motor_slots_t m_slot = {};
@@ -312,66 +341,68 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
 
   // configure the timer
   _configureTimerFrequency(pwm_frequency, m_slot.mcpwm_num,  m_slot.mcpwm_unit);
+
+  ESP32MCPWMDriverParams* params = new ESP32MCPWMDriverParams {
+    .pwm_frequency = pwm_frequency,
+    .mcpwm_unit = m_slot.mcpwm_unit,
+    .mcpwm_operator1 = m_slot.mcpwm_operator1,
+    .mcpwm_operator2 = m_slot.mcpwm_operator2
+  };
+  return params;
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 //  ESP32 uses MCPWM
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 4; i++){
-    if(esp32_stepper_2pwm_motor_slots[i].pin1pwm == pinA){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,100]
-      mcpwm_set_duty(esp32_stepper_2pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, esp32_stepper_2pwm_motor_slots[i].mcpwm_operator, dc_a*100.0);
-      mcpwm_set_duty(esp32_stepper_2pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, esp32_stepper_2pwm_motor_slots[i].mcpwm_operator, dc_b*100.0);
-      break;
-    }
-  }
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
+  // se the PWM on the slot timers
+  // transform duty cycle from [0,1] to [0,100]
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_a*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_b*100.0);
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 //  ESP32 uses MCPWM
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 4; i++){
-    if(esp32_bldc_3pwm_motor_slots[i].pinA == pinA){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,100]
-      mcpwm_set_duty(esp32_bldc_3pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, esp32_bldc_3pwm_motor_slots[i].mcpwm_operator, dc_a*100.0);
-      mcpwm_set_duty(esp32_bldc_3pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, esp32_bldc_3pwm_motor_slots[i].mcpwm_operator, dc_b*100.0);
-      mcpwm_set_duty(esp32_bldc_3pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_2, esp32_bldc_3pwm_motor_slots[i].mcpwm_operator, dc_c*100.0);
-      break;
-    }
-  }
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  // se the PWM on the slot timers
+  // transform duty cycle from [0,1] to [0,100]
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_a*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_b*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_2, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_c*100.0);
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 //  ESP32 uses MCPWM
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 2; i++){
-    if(esp32_stepper_4pwm_motor_slots[i].pin1A == pin1A){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,100]
-      mcpwm_set_duty(esp32_stepper_4pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, esp32_stepper_4pwm_motor_slots[i].mcpwm_operator1, dc_1a*100.0);
-      mcpwm_set_duty(esp32_stepper_4pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, esp32_stepper_4pwm_motor_slots[i].mcpwm_operator1, dc_1b*100.0);
-      mcpwm_set_duty(esp32_stepper_4pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, esp32_stepper_4pwm_motor_slots[i].mcpwm_operator2, dc_2a*100.0);
-      mcpwm_set_duty(esp32_stepper_4pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, esp32_stepper_4pwm_motor_slots[i].mcpwm_operator2, dc_2b*100.0);
-      break;
-    }
-  }
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
+  // se the PWM on the slot timers
+  // transform duty cycle from [0,1] to [0,100]
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_1a*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator1, dc_1b*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator2, dc_2a*100.0);
+  mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, ((ESP32MCPWMDriverParams*)params)->mcpwm_operator2, dc_2b*100.0);
 }
+
+
+
 
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
 
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = 20000; // default frequency 20khz - centered pwm has twice lower frequency
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 40kHz max - centered pwm has twice lower frequency
@@ -387,7 +418,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
     }
   }
   // if no slots available
-  if(slot_num >= 2) return -1;
+  if(slot_num >= 2) return SIMPLEFOC_DRIVER_INIT_FAILED;
 
   // disable all the slots with the same MCPWM
   if( slot_num == 0 ){
@@ -415,26 +446,28 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   // configure the timer
   _configureTimerFrequency(pwm_frequency, m_slot.mcpwm_num,  m_slot.mcpwm_unit, dead_zone);
   // return
-  return 0;
+  ESP32MCPWMDriverParams* params = new ESP32MCPWMDriverParams {
+    .pwm_frequency = pwm_frequency,
+    .mcpwm_unit = m_slot.mcpwm_unit    
+  };
+  return params;
 }
+
+
+
 
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 // - BLDC driver - 6PWM setting
 // - hardware specific
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  // determine which motor slot is the motor connected to
-  for(int i = 0; i < 2; i++){
-    if(esp32_bldc_6pwm_motor_slots[i].pinAH == pinA_h){ // if motor slot found
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
       // se the PWM on the slot timers
       // transform duty cycle from [0,1] to [0,100.0]
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, MCPWM_OPR_A, dc_a*100.0);
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_0, MCPWM_OPR_B, dc_a*100.0);
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, MCPWM_OPR_A, dc_b*100.0);
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_1, MCPWM_OPR_B, dc_b*100.0);
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_2, MCPWM_OPR_A, dc_c*100.0);
-      mcpwm_set_duty(esp32_bldc_6pwm_motor_slots[i].mcpwm_unit, MCPWM_TIMER_2, MCPWM_OPR_B, dc_c*100.0);
-      break;
-    }
-  }
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, MCPWM_OPR_A, dc_a*100.0);
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_0, MCPWM_OPR_B, dc_a*100.0);
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, MCPWM_OPR_A, dc_b*100.0);
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_1, MCPWM_OPR_B, dc_b*100.0);
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_2, MCPWM_OPR_A, dc_c*100.0);
+      mcpwm_set_duty(((ESP32MCPWMDriverParams*)params)->mcpwm_unit, MCPWM_TIMER_2, MCPWM_OPR_B, dc_c*100.0);
 }
+
 #endif

--- a/src/drivers/hardware_specific/esp8266_mcu.cpp
+++ b/src/drivers/hardware_specific/esp8266_mcu.cpp
@@ -15,63 +15,78 @@ void _setHighFrequency(const long freq, const int pin){
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
   _setHighFrequency(pwm_frequency, pinC);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
   _setHighFrequency(pwm_frequency, pinC);
   _setHighFrequency(pwm_frequency, pinD);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
-  analogWrite(pinC, 255.0f*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0f*dc_1a);
-  analogWrite(pin1B, 255.0f*dc_1b);
-  analogWrite(pin2A, 255.0f*dc_2a);
-  analogWrite(pin2B, 255.0f*dc_2b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 #endif

--- a/src/drivers/hardware_specific/generic_mcu.cpp
+++ b/src/drivers/hardware_specific/generic_mcu.cpp
@@ -9,11 +9,10 @@
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) HardwareDriverParams _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
-  HardwareDriverParams params = new struct DriverParamsBase {
-    .pins = { pinA, pinB, -1, -1, -1, -1 },
-    .pwm_frequency = pwm_frequency,
-    .initSuccess = true
+__attribute__((weak)) void* _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
   };
   return params;
 }
@@ -22,11 +21,10 @@ __attribute__((weak)) HardwareDriverParams _configure2PWM(long pwm_frequency,con
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) HardwareDriverParams _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
-  HardwareDriverParams params = new struct DriverParamsBase {
-    .pins = { pinA, pinB, pinC, -1, -1, -1 },
-    .pwm_frequency = pwm_frequency,
-    .initSuccess = true
+__attribute__((weak)) void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
   };
   return params;
 }
@@ -36,11 +34,10 @@ __attribute__((weak)) HardwareDriverParams _configure3PWM(long pwm_frequency,con
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) HardwareDriverParams _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
-  HardwareDriverParams params = new struct DriverParamsBase {
-    .pins = { pin1A, pin1B, pin2A, pin2B, -1, -1 },
-    .pwm_frequency = pwm_frequency,
-    .initSuccess = true
+__attribute__((weak)) void* _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pin1A, pin1B, pin2A, pin2B },
+    .pwm_frequency = pwm_frequency
   };
   return params;
 }
@@ -48,61 +45,49 @@ __attribute__((weak)) HardwareDriverParams _configure4PWM(long pwm_frequency,con
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-__attribute__((weak)) HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
-  HardwareDriverParams params = new struct DriverParamsBase {
-    .pins = { pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
-    .pwm_frequency = pwm_frequency,
-    .dead_zone = dead_zone,
-    .initSuccess = true
-  };
-  return params;
+__attribute__((weak)) void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+  return SIMPLEFOC_DRIVER_INIT_FAILED;
 }
 
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-__attribute__((weak)) void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+__attribute__((weak)) void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-__attribute__((weak)) void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+__attribute__((weak)) void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
-  analogWrite(pinC, 255.0f*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-__attribute__((weak)) void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+__attribute__((weak)) void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0f*dc_1a);
-  analogWrite(pin1B, 255.0f*dc_1b);
-  analogWrite(pin2A, 255.0f*dc_2a);
-  analogWrite(pin2B, 255.0f*dc_2b);
+  
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 // - BLDC driver - 6PWM setting
 // - hardware specific
-__attribute__((weak)) void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
+__attribute__((weak)) void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
   _UNUSED(dc_a);
   _UNUSED(dc_b);
   _UNUSED(dc_c);
-  _UNUSED(dead_zone);
-  _UNUSED(pinA_h);
-  _UNUSED(pinB_h);
-  _UNUSED(pinC_h);
-  _UNUSED(pinA_l);
-  _UNUSED(pinB_l);
-  _UNUSED(pinC_l);
-  return;
+  _UNUSED(params);
 }

--- a/src/drivers/hardware_specific/generic_mcu.cpp
+++ b/src/drivers/hardware_specific/generic_mcu.cpp
@@ -9,23 +9,26 @@
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
-  _UNUSED(pwm_frequency);
-  _UNUSED(pinA);
-  _UNUSED(pinB);
-  return;
+__attribute__((weak)) HardwareDriverParams _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+  HardwareDriverParams params = new struct DriverParamsBase {
+    .pins = { pinA, pinB, -1, -1, -1, -1 },
+    .pwm_frequency = pwm_frequency,
+    .initSuccess = true
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
-  _UNUSED(pwm_frequency);
-  _UNUSED(pinA);
-  _UNUSED(pinB);
-  _UNUSED(pinC);
-  return;
+__attribute__((weak)) HardwareDriverParams _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+  HardwareDriverParams params = new struct DriverParamsBase {
+    .pins = { pinA, pinB, pinC, -1, -1, -1 },
+    .pwm_frequency = pwm_frequency,
+    .initSuccess = true
+  };
+  return params;
 }
 
 
@@ -33,28 +36,26 @@ __attribute__((weak)) void _configure3PWM(long pwm_frequency,const int pinA, con
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
 // in generic case dont do anything
-__attribute__((weak)) void _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
-  _UNUSED(pwm_frequency);
-  _UNUSED(pin1A);
-  _UNUSED(pin1B);
-  _UNUSED(pin2A);
-  _UNUSED(pin2B);
-  return;
+__attribute__((weak)) HardwareDriverParams _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+  HardwareDriverParams params = new struct DriverParamsBase {
+    .pins = { pin1A, pin1B, pin2A, pin2B, -1, -1 },
+    .pwm_frequency = pwm_frequency,
+    .initSuccess = true
+  };
+  return params;
 }
 
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-__attribute__((weak)) int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
-  _UNUSED(pwm_frequency);
-  _UNUSED(dead_zone);
-  _UNUSED(pinA_h);
-  _UNUSED(pinB_h);
-  _UNUSED(pinC_h);
-  _UNUSED(pinA_l);
-  _UNUSED(pinB_l);
-  _UNUSED(pinC_l);
-  return -1;
+__attribute__((weak)) HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+  HardwareDriverParams params = new struct DriverParamsBase {
+    .pins = { pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency,
+    .dead_zone = dead_zone,
+    .initSuccess = true
+  };
+  return params;
 }
 
 

--- a/src/drivers/hardware_specific/nrf52_mcu.cpp
+++ b/src/drivers/hardware_specific/nrf52_mcu.cpp
@@ -22,7 +22,7 @@
 #define _TAKEN_SLOT (-0x55)
 
 int pwm_range;
-float dead_time;
+
 
 static NRF_PWM_Type* pwms[PWM_COUNT] = {
   NRF_PWM0,
@@ -72,7 +72,22 @@ stepper_motor_slots_t nrf52_stepper_motor_slots[4] =  {
 bldc_6pwm_motor_slots_t nrf52_bldc_6pwm_motor_slots[2] =  { 
   {_EMPTY_SLOT, pwms[0], pwms[1], {0,0,0,0,0,0,0,0}},// 1st motor will be on PWM0 & PWM1
   {_EMPTY_SLOT, pwms[2], pwms[3], {0,0,0,0,0,0,0,0}} // 2nd motor will be on PWM1 & PWM2
-  };  
+  };
+
+
+
+typedef struct NRF52DriverParams {
+  union {
+    bldc_3pwm_motor_slots_t* slot3pwm;
+    bldc_6pwm_motor_slots_t* slot6pwm;
+    stepper_motor_slots_t* slotstep;
+  } slot;
+  long pwm_frequency;
+  float dead_time;
+} NRF52DriverParams;
+
+
+
 
 // configuring high frequency pwm timer
 void _configureHwPwm(NRF_PWM_Type* mcpwm1,  NRF_PWM_Type* mcpwm2){
@@ -103,7 +118,7 @@ void _configureHwPwm(NRF_PWM_Type* mcpwm1,  NRF_PWM_Type* mcpwm2){
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
 
   if( !pwm_frequency || pwm_frequency == NOT_SET) pwm_frequency = PWM_FREQ; // default frequency 20khz for a resolution of 800
   else pwm_frequency = _constrain(pwm_frequency, 0, PWM_MAX_FREQ); // constrain to 62.5kHz max for a resolution of 256  
@@ -123,6 +138,9 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
       break;
     }
   }
+  // if no slots available
+  if(slot_num >= 4) return SIMPLEFOC_DRIVER_INIT_FAILED;
+
   // disable all the slots with the same MCPWM 
   if(slot_num < 2){
     // slot 0 of the stepper
@@ -149,12 +167,20 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
 
   // configure the pwm
   _configureHwPwm(nrf52_bldc_3pwm_motor_slots[slot_num].mcpwm, nrf52_bldc_3pwm_motor_slots[slot_num].mcpwm);
+
+  NRF52DriverParams* params = new NRF52DriverParams();
+  params->slot.slot3pwm = &(nrf52_bldc_3pwm_motor_slots[slot_num]);
+  params->pwm_frequency = pwm_frequency;
+  return params;
 }
+
+
+
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC, const int pinD) {
 
   if( !pwm_frequency || pwm_frequency == NOT_SET) pwm_frequency = PWM_FREQ; // default frequency 20khz for a resolution of 800
   else pwm_frequency = _constrain(pwm_frequency, 0, PWM_MAX_FREQ); // constrain to 62.5kHz max for a resolution of 256
@@ -175,8 +201,11 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
       break;
     }
   }
+  // if no slots available
+  if (slot_num >= 4) return SIMPLEFOC_DRIVER_INIT_FAILED;
+
   // disable all the slots with the same MCPWM 
-  if( slot_num < 2 ){
+  if (slot_num < 2){
     // slots 0 and 1 of the 3pwm bldc
     nrf52_bldc_3pwm_motor_slots[slot_num].pinA = _TAKEN_SLOT;
     // slot 0 of the 6pwm bldc
@@ -202,54 +231,51 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
 
   // configure the pwm
   _configureHwPwm(nrf52_stepper_motor_slots[slot_num].mcpwm, nrf52_stepper_motor_slots[slot_num].mcpwm);
+
+  NRF52DriverParams* params = new NRF52DriverParams();
+  params->slot.slotstep = &(nrf52_stepper_motor_slots[slot_num]);
+  params->pwm_frequency = pwm_frequency;
+  return params;  
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
-  // determine which motor slot is the motor connected to 
-  for(int i = 0; i < 4; i++){
-    if(nrf52_bldc_3pwm_motor_slots[i].pinA == pinA){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,range]
-      
-      nrf52_bldc_3pwm_motor_slots[i].mcpwm_channel_sequence[0] = (int)(dc_a * pwm_range) | 0x8000;
-      nrf52_bldc_3pwm_motor_slots[i].mcpwm_channel_sequence[1] = (int)(dc_b * pwm_range) | 0x8000;
-      nrf52_bldc_3pwm_motor_slots[i].mcpwm_channel_sequence[2] = (int)(dc_c * pwm_range) | 0x8000;
-  
-      nrf52_bldc_3pwm_motor_slots[i].mcpwm->TASKS_SEQSTART[0] = 1;
-      break;
-    }
-  }
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  // transform duty cycle from [0,1] to [0,range]
+  bldc_3pwm_motor_slots_t* p = ((NRF52DriverParams*)params)->slot.slot3pwm;
+  p->mcpwm_channel_sequence[0] = (int)(dc_a * pwm_range) | 0x8000;
+  p->mcpwm_channel_sequence[1] = (int)(dc_b * pwm_range) | 0x8000;
+  p->mcpwm_channel_sequence[2] = (int)(dc_c * pwm_range) | 0x8000;
+
+  p->mcpwm->TASKS_SEQSTART[0] = 1;
 }
+
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A){
-  // determine which motor slot is the motor connected to 
-  for(int i = 0; i < 4; i++){
-    if(nrf52_stepper_motor_slots[i].pin1A == pin1A){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,range]
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
 
-      nrf52_stepper_motor_slots[i].mcpwm_channel_sequence[0] = (int)(dc_1a * pwm_range) | 0x8000;
-      nrf52_stepper_motor_slots[i].mcpwm_channel_sequence[1] = (int)(dc_1b * pwm_range) | 0x8000;
-      nrf52_stepper_motor_slots[i].mcpwm_channel_sequence[2] = (int)(dc_2a * pwm_range) | 0x8000;
-      nrf52_stepper_motor_slots[i].mcpwm_channel_sequence[3] = (int)(dc_2b * pwm_range) | 0x8000;
+  stepper_motor_slots_t* p = ((NRF52DriverParams*)params)->slot.slotstep;
+  p->mcpwm_channel_sequence[0] = (int)(dc_1a * pwm_range) | 0x8000;
+  p->mcpwm_channel_sequence[1] = (int)(dc_1b * pwm_range) | 0x8000;
+  p->mcpwm_channel_sequence[2] = (int)(dc_2a * pwm_range) | 0x8000;
+  p->mcpwm_channel_sequence[3] = (int)(dc_2b * pwm_range) | 0x8000;
 
-      nrf52_stepper_motor_slots[i].mcpwm->TASKS_SEQSTART[0] = 1;
-      break;
-    }
-  }
+  p->mcpwm->TASKS_SEQSTART[0] = 1;
 }
 
 /* Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
 */
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
   
   if( !pwm_frequency || pwm_frequency == NOT_SET) pwm_frequency = PWM_FREQ; // default frequency 20khz - centered pwm has twice lower frequency for a resolution of 400
   else pwm_frequency = _constrain(pwm_frequency*2, 0, PWM_MAX_FREQ); // constrain to 62.5kHz max => 31.25kHz for a resolution of 256  
@@ -257,6 +283,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   pwm_range = (PWM_CLK / pwm_frequency);
   pwm_range /= 2; // scale the frequency (centered PWM)
 
+  float dead_time;
   if (dead_zone != NOT_SET){
     dead_time = dead_zone/2;
   }else{
@@ -281,7 +308,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
     }
   }
   // if no slots available
-  if(slot_num >= 2) return -1;
+  if(slot_num >= 2) return SIMPLEFOC_DRIVER_INIT_FAILED;
 
   // disable all the slots with the same MCPWM 
   if( slot_num == 0 ){
@@ -324,31 +351,30 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
   // configure the pwm type
   _configureHwPwm(nrf52_bldc_6pwm_motor_slots[slot_num].mcpwm1, nrf52_bldc_6pwm_motor_slots[slot_num].mcpwm2);
   
-  // return 
-  return 0;
+  NRF52DriverParams* params = new NRF52DriverParams();
+  params->slot.slot6pwm = &(nrf52_bldc_6pwm_motor_slots[slot_num]);
+  params->pwm_frequency = pwm_frequency;
+  params->dead_time = dead_time;
+  return params; 
 }
+
+
+
 
 /* Function setting the duty cycle to the pwm pin
 //  - BLDC driver - 6PWM setting
 //  - hardware specific
 */
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, const int pinA_h, const int, const int, const int, const int, const int){
-  for(int i = 0; i < 2; i++){
-    if(nrf52_bldc_6pwm_motor_slots[i].pinAH == pinA_h){ // if motor slot found
-      // se the PWM on the slot timers
-      // transform duty cycle from [0,1] to [0,range]
-
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[0] = (int)(_constrain(dc_a-dead_time,0,1)*pwm_range) | 0x8000;
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[1] = (int)(_constrain(dc_a+dead_time,0,1)*pwm_range);
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[2] = (int)(_constrain(dc_b-dead_time,0,1)*pwm_range) | 0x8000;
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[3] = (int)(_constrain(dc_b+dead_time,0,1)*pwm_range);
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[4] = (int)(_constrain(dc_c-dead_time,0,1)*pwm_range) | 0x8000;
-      nrf52_bldc_6pwm_motor_slots[i].mcpwm_channel_sequence[5] = (int)(_constrain(dc_c+dead_time,0,1)*pwm_range);
-     
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+      bldc_6pwm_motor_slots_t* p = ((NRF52DriverParams*)params)->slot.slot6pwm;
+      float dead_time = ((NRF52DriverParams*)params)->dead_time;
+      p->mcpwm_channel_sequence[0] = (int)(_constrain(dc_a-dead_time,0,1)*pwm_range) | 0x8000;
+      p->mcpwm_channel_sequence[1] = (int)(_constrain(dc_a+dead_time,0,1)*pwm_range);
+      p->mcpwm_channel_sequence[2] = (int)(_constrain(dc_b-dead_time,0,1)*pwm_range) | 0x8000;
+      p->mcpwm_channel_sequence[3] = (int)(_constrain(dc_b+dead_time,0,1)*pwm_range);
+      p->mcpwm_channel_sequence[4] = (int)(_constrain(dc_c-dead_time,0,1)*pwm_range) | 0x8000;
+      p->mcpwm_channel_sequence[5] = (int)(_constrain(dc_c+dead_time,0,1)*pwm_range);     
       NRF_EGU0->TASKS_TRIGGER[0] = 1;
-      break;
-    }
-  }
 }
 
 

--- a/src/drivers/hardware_specific/nrf52_mcu.cpp
+++ b/src/drivers/hardware_specific/nrf52_mcu.cpp
@@ -115,6 +115,16 @@ void _configureHwPwm(NRF_PWM_Type* mcpwm1,  NRF_PWM_Type* mcpwm2){
   }
 }
 
+
+
+// can we support it using the generic driver on this MCU? Commented out to fall back to generic driver for 2-pwm
+// void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+//   return SIMPLEFOC_DRIVER_INIT_FAILED; // not supported
+// }
+
+
+
+
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic

--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -19,6 +19,14 @@
 
 
 
+typedef struct RP2040DriverParams {
+  int pins[6];
+  uint slice[6];
+  uint chan[6];
+  long pwm_frequency;
+  float dead_zone;
+} RP2040DriverParams;
+
 
 // until I can figure out if this can be quickly read from some register, keep it here.
 // it also serves as a marker for what slices are already used.
@@ -27,10 +35,13 @@ uint16_t wrapvalues[NUM_PWM_SLICES];
 
 // TODO add checks which channels are already used...
 
-void setupPWM(int pin, long pwm_frequency, bool invert = false) {
+void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* params, uint8_t index) {
 	gpio_set_function(pin, GPIO_FUNC_PWM);
 	uint slice = pwm_gpio_to_slice_num(pin);
 	uint chan = pwm_gpio_to_channel(pin);
+	params->pins[index] = pin;
+	params->slice[index] = slice;
+	params->chan[index] = chan;
 	pwm_set_clkdiv_int_frac(slice, 1, 0); // fastest pwm we can get
 	pwm_set_phase_correct(slice, true);
 	uint16_t wrapvalue = ((125L * 1000L * 1000L) / pwm_frequency) / 2L - 1L;
@@ -61,7 +72,7 @@ void setupPWM(int pin, long pwm_frequency, bool invert = false) {
 
 
 void syncSlices() {
-	for (int i=0;i<NUM_PWM_SLICES;i++) {
+	for (uint i=0;i<NUM_PWM_SLICES;i++) {
 		pwm_set_enabled(i, false);
 		pwm_set_counter(i, 0);
 	}
@@ -70,52 +81,62 @@ void syncSlices() {
 }
 
 
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
-	setupPWM(pinA, pwm_frequency);
-	setupPWM(pinB, pwm_frequency);
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+	RP2040DriverParams* params = new RP2040DriverParams();
+	params->pwm_frequency = pwm_frequency;
+	setupPWM(pinA, pwm_frequency, false, params, 0);
+	setupPWM(pinB, pwm_frequency, false, params, 1);
 	syncSlices();
+	return params;
 }
 
 
 
-void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
-	setupPWM(pinA, pwm_frequency);
-	setupPWM(pinB, pwm_frequency);
-	setupPWM(pinC, pwm_frequency);
+void* _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
+	RP2040DriverParams* params = new RP2040DriverParams();
+	params->pwm_frequency = pwm_frequency;
+	setupPWM(pinA, pwm_frequency, false, params, 0);
+	setupPWM(pinB, pwm_frequency, false, params, 1);
+	setupPWM(pinC, pwm_frequency, false, params, 2);
 	syncSlices();
+	return params;
 }
 
 
 
 
-void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
-	setupPWM(pin1A, pwm_frequency);
-	setupPWM(pin1B, pwm_frequency);
-	setupPWM(pin2A, pwm_frequency);
-	setupPWM(pin2B, pwm_frequency);
+void* _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+	RP2040DriverParams* params = new RP2040DriverParams();
+	params->pwm_frequency = pwm_frequency;
+	setupPWM(pin1A, pwm_frequency, false, params, 0);
+	setupPWM(pin1B, pwm_frequency, false, params, 1);
+	setupPWM(pin2A, pwm_frequency, false, params, 2);
+	setupPWM(pin2B, pwm_frequency, false, params, 3);
 	syncSlices();
+	return params;
 }
 
 
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
 	// non-PIO solution...
-	setupPWM(pinA_h, pwm_frequency);
-	setupPWM(pinB_h, pwm_frequency);
-	setupPWM(pinC_h, pwm_frequency);
-	setupPWM(pinA_l, pwm_frequency, true);
-	setupPWM(pinB_l, pwm_frequency, true);
-	setupPWM(pinC_l, pwm_frequency, true);
+	RP2040DriverParams* params = new RP2040DriverParams();
+	params->pwm_frequency = pwm_frequency;
+	params->dead_zone = dead_zone;
+	setupPWM(pinA_h, pwm_frequency, false, params, 0);
+	setupPWM(pinB_h, pwm_frequency, false, params, 2);
+	setupPWM(pinC_h, pwm_frequency, false, params, 4);
+	setupPWM(pinA_l, pwm_frequency, true, params, 1);
+	setupPWM(pinB_l, pwm_frequency, true, params, 3);
+	setupPWM(pinC_l, pwm_frequency, true, params, 5);
 	syncSlices();
-	return 0;
+	return params;
 }
 
 
 
 
 
-void writeDutyCycle(float val, int pin) {
-	uint slice = pwm_gpio_to_slice_num(pin);
-	uint chan = pwm_gpio_to_channel(pin);
+void writeDutyCycle(float val, uint slice, uint chan) {
 	pwm_set_chan_level(slice, chan, (wrapvalues[slice]+1) * val);
 }
 
@@ -123,26 +144,26 @@ void writeDutyCycle(float val, int pin) {
 
 
 
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB) {
-	writeDutyCycle(dc_a, pinA);
-	writeDutyCycle(dc_b, pinB);
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params) {
+	writeDutyCycle(dc_a, ((RP2040DriverParams*)params)->slice[0], ((RP2040DriverParams*)params)->chan[0]);
+	writeDutyCycle(dc_b, ((RP2040DriverParams*)params)->slice[1], ((RP2040DriverParams*)params)->chan[1]);
 }
 
 
 
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC) {
-	writeDutyCycle(dc_a, pinA);
-	writeDutyCycle(dc_b, pinB);
-	writeDutyCycle(dc_c, pinC);
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params) {
+	writeDutyCycle(dc_a, ((RP2040DriverParams*)params)->slice[0], ((RP2040DriverParams*)params)->chan[0]);
+	writeDutyCycle(dc_b, ((RP2040DriverParams*)params)->slice[1], ((RP2040DriverParams*)params)->chan[1]);
+	writeDutyCycle(dc_c, ((RP2040DriverParams*)params)->slice[2], ((RP2040DriverParams*)params)->chan[2]);
 }
 
 
 
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B) {
-	writeDutyCycle(dc_1a, pin1A);
-	writeDutyCycle(dc_1b, pin1B);
-	writeDutyCycle(dc_2a, pin2A);
-	writeDutyCycle(dc_2b, pin2B);
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params) {
+	writeDutyCycle(dc_1a, ((RP2040DriverParams*)params)->slice[0], ((RP2040DriverParams*)params)->chan[0]);
+	writeDutyCycle(dc_1b, ((RP2040DriverParams*)params)->slice[1], ((RP2040DriverParams*)params)->chan[1]);
+	writeDutyCycle(dc_2a, ((RP2040DriverParams*)params)->slice[2], ((RP2040DriverParams*)params)->chan[2]);
+	writeDutyCycle(dc_2b, ((RP2040DriverParams*)params)->slice[3], ((RP2040DriverParams*)params)->chan[3]);
 }
 
 inline float swDti(float val, float dt) {
@@ -151,13 +172,13 @@ inline float swDti(float val, float dt) {
 	return ret;
 }
 
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l) {
-	writeDutyCycle(dc_a, pinA_h);
-	writeDutyCycle(swDti(dc_a, dead_zone), pinA_l);
-	writeDutyCycle(dc_b, pinB_h);
-	writeDutyCycle(swDti(dc_b,dead_zone), pinB_l);
-	writeDutyCycle(dc_c, pinC_h);
-	writeDutyCycle(swDti(dc_c,dead_zone), pinC_l);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params) {
+	writeDutyCycle(dc_a, ((RP2040DriverParams*)params)->slice[0], ((RP2040DriverParams*)params)->chan[0]);
+	writeDutyCycle(swDti(dc_a, ((RP2040DriverParams*)params)->dead_zone), ((RP2040DriverParams*)params)->slice[1], ((RP2040DriverParams*)params)->chan[1]);
+	writeDutyCycle(dc_b, ((RP2040DriverParams*)params)->slice[2], ((RP2040DriverParams*)params)->chan[2]);
+	writeDutyCycle(swDti(dc_b, ((RP2040DriverParams*)params)->dead_zone), ((RP2040DriverParams*)params)->slice[3], ((RP2040DriverParams*)params)->chan[3]);
+	writeDutyCycle(dc_c, ((RP2040DriverParams*)params)->slice[4], ((RP2040DriverParams*)params)->chan[4]);
+	writeDutyCycle(swDti(dc_c, ((RP2040DriverParams*)params)->dead_zone), ((RP2040DriverParams*)params)->slice[5], ((RP2040DriverParams*)params)->chan[5]);
 }
 
 #endif

--- a/src/drivers/hardware_specific/samd_mcu.cpp
+++ b/src/drivers/hardware_specific/samd_mcu.cpp
@@ -682,7 +682,7 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params) {
  * @param pinB  phase B hardware pin number
  * @param pinC  phase C hardware pin number
  */
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC, void* params) {
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params) {
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0], dc_a);
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1], dc_b);
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2], dc_c);
@@ -706,7 +706,7 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
  * @param pin2A  phase 2A hardware pin number
  * @param pin2B  phase 2B hardware pin number
  */
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B, void* params){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0], dc_1a);
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1], dc_1b);
 	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2], dc_2a);
@@ -740,13 +740,14 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
  * @param pinC_l  phase C low-side hardware pin number
  *
  */
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l, float dead_zone, void* params){
-	tccConfiguration* tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0];
-	tccConfiguration* tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1];
-	uint32_t pwm_res =((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0]->pwm_res;
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+	SAMDHardwareDriverParams* p = (SAMDHardwareDriverParams*)params;
+	tccConfiguration* tcc1 = p->tccPinConfigurations[0];
+	tccConfiguration* tcc2 = p->tccPinConfigurations[1];
+	uint32_t pwm_res =p->tccPinConfigurations[0]->pwm_res;
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
 		// low-side on a different pin of same TCC - do dead-time in software...
-		float ls = dc_a+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1)); // TODO resolution!!!
+		float ls = dc_a+(p->dead_zone * (pwm_res-1)); // TODO resolution!!!
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_a);
 		writeSAMDDutyCycle(tcc2, ls);
@@ -754,10 +755,10 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, int pinA_h, int pi
 	else
 		writeSAMDDutyCycle(tcc1, dc_a); // dead-time is done is hardware, no need to set low side pin explicitly
 
-	tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2];
-	tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[3];
+	tcc1 = p->tccPinConfigurations[2];
+	tcc2 = p->tccPinConfigurations[3];
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_b+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1));
+		float ls = dc_b+(p->dead_zone * (pwm_res-1));
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_b);
 		writeSAMDDutyCycle(tcc2, ls);
@@ -765,10 +766,10 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, int pinA_h, int pi
 	else
 		writeSAMDDutyCycle(tcc1, dc_b);
 
-	tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[4];
-	tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[5];
+	tcc1 = p->tccPinConfigurations[4];
+	tcc2 = p->tccPinConfigurations[5];
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_c+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1));
+		float ls = dc_c+(p->dead_zone * (pwm_res-1));
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_c);
 		writeSAMDDutyCycle(tcc2, ls);

--- a/src/drivers/hardware_specific/samd_mcu.cpp
+++ b/src/drivers/hardware_specific/samd_mcu.cpp
@@ -278,7 +278,7 @@ int checkPermutations(uint8_t num, int pins[], bool (*checkFunc)(tccConfiguratio
  * @param pinA pinA bldc driver
  * @param pinB pinB bldc driver
  */
-HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -289,7 +289,7 @@ HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const in
 #ifdef SIMPLEFOC_SAMD_DEBUG
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Bad combination!");
 #endif
-		return;
+		return SIMPLEFOC_DRIVER_INIT_FAILED;
 	}
 
 	tccConfiguration tccConfs[2] = { getTCCChannelNr(pinA, getPeripheralOfPermutation(compatibility, 0)),
@@ -329,7 +329,11 @@ HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const in
 	SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Configured TCCs...");
 #endif
 
-	return; // Someone with a stepper-setup who can test it?
+	SAMDHardwareDriverParams* params = new SAMDHardwareDriverParams {
+		.tccPinConfigurations = { getTccPinConfiguration(pinA), getTccPinConfiguration(pinB) },
+		.pwm_frequency = (uint32_t)pwm_frequency
+	}; // Someone with a stepper-setup who can test it?
+	return params;
 }
 
 
@@ -375,7 +379,7 @@ HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const in
  * @param pinB pinB bldc driver
  * @param pinC pinC bldc driver
  */
-HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -386,7 +390,7 @@ HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const in
 #ifdef SIMPLEFOC_SAMD_DEBUG
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Bad combination!");
 #endif
-		return;
+		return SIMPLEFOC_DRIVER_INIT_FAILED;
 	}
 
 	tccConfiguration tccConfs[3] = { getTCCChannelNr(pinA, getPeripheralOfPermutation(compatibility, 0)),
@@ -431,6 +435,11 @@ HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const in
 	SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Configured TCCs...");
 #endif
 
+	return new SAMDHardwareDriverParams {
+		.tccPinConfigurations = { getTccPinConfiguration(pinA), getTccPinConfiguration(pinB), getTccPinConfiguration(pinC) },
+		.pwm_frequency = (uint32_t)pwm_frequency
+	};
+
 }
 
 
@@ -451,7 +460,7 @@ HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const in
  * @param pin2A pin2A stepper driver
  * @param pin2B pin2B stepper driver
  */
-HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+void* _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -462,7 +471,7 @@ HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const i
 #ifdef SIMPLEFOC_SAMD_DEBUG
 		SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Bad combination!");
 #endif
-		return;
+		return SIMPLEFOC_DRIVER_INIT_FAILED;
 	}
 
 	tccConfiguration tccConfs[4] = { getTCCChannelNr(pin1A, getPeripheralOfPermutation(compatibility, 0)),
@@ -512,7 +521,10 @@ HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const i
 	SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Configured TCCs...");
 #endif
 
-	return; // Someone with a stepper-setup who can test it?
+	return new SAMDHardwareDriverParams {
+		.tccPinConfigurations = { getTccPinConfiguration(pin1A), getTccPinConfiguration(pin1B), getTccPinConfiguration(pin2A), getTccPinConfiguration(pin2B) },
+		.pwm_frequency = (uint32_t)pwm_frequency
+	};
 }
 
 
@@ -552,7 +564,7 @@ HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const i
  *
  * @return 0 if config good, -1 if failed
  */
-HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
 	// we want to use a TCC channel with 1 non-inverted and 1 inverted output for each phase, with dead-time insertion
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
@@ -565,7 +577,7 @@ HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const i
 #ifdef SIMPLEFOC_SAMD_DEBUG
 			SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Bad combination!");
 #endif
-			return -1;
+			return SIMPLEFOC_DRIVER_INIT_FAILED;
 		}
 	}
 
@@ -595,7 +607,7 @@ HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const i
 	allAttached |= attachTCC(pinCh);
 	allAttached |= attachTCC(pinCl);
 	if (!allAttached)
-		return -1;
+		return SIMPLEFOC_DRIVER_INIT_FAILED;
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Attached pins...");
 #endif
@@ -628,7 +640,11 @@ HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const i
 	SIMPLEFOC_SAMD_DEBUG_SERIAL.println("Configured TCCs...");
 #endif
 
-	return 0;
+	return new SAMDHardwareDriverParams {
+		.tccPinConfigurations = { getTccPinConfiguration(pinA_h), getTccPinConfiguration(pinA_l), getTccPinConfiguration(pinB_h), getTccPinConfiguration(pinB_l), getTccPinConfiguration(pinC_h), getTccPinConfiguration(pinC_l) },
+		.pwm_frequency = (uint32_t)pwm_frequency,
+		.dead_zone = dead_zone,
+	};
 }
 
 
@@ -644,11 +660,9 @@ HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const i
  * @param pinA  phase A hardware pin number
  * @param pinB  phase B hardware pin number
  */
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, HardwareDriverParams params) {
-	tccConfiguration* tccI = getTccPinConfiguration(pinA);
-	writeSAMDDutyCycle(tccI, dc_a);
-	tccI = getTccPinConfiguration(pinB);
-	writeSAMDDutyCycle(tccI, dc_b);
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params) {
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0], dc_a);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1], dc_b);
 	return;
 }
 
@@ -668,13 +682,10 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, HardwareDriverParams params) {
  * @param pinB  phase B hardware pin number
  * @param pinC  phase C hardware pin number
  */
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, HardwareDriverParams params) {
-	tccConfiguration* tccI = getTccPinConfiguration(pinA);
-	writeSAMDDutyCycle(tccI, dc_a);
-	tccI = getTccPinConfiguration(pinB);
-	writeSAMDDutyCycle(tccI, dc_b);
-	tccI = getTccPinConfiguration(pinC);
-	writeSAMDDutyCycle(tccI, dc_c);
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC, void* params) {
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0], dc_a);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1], dc_b);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2], dc_c);
 	return;
 }
 
@@ -695,15 +706,11 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, HardwareDriverPara
  * @param pin2A  phase 2A hardware pin number
  * @param pin2B  phase 2B hardware pin number
  */
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, HardwareDriverParams params){
-	tccConfiguration* tccI = getTccPinConfiguration(pin1A);
-	writeSAMDDutyCycle(tccI, dc_1a);
-	tccI = getTccPinConfiguration(pin2A);
-	writeSAMDDutyCycle(tccI, dc_2a);
-	tccI = getTccPinConfiguration(pin1B);
-	writeSAMDDutyCycle(tccI, dc_1b);
-	tccI = getTccPinConfiguration(pin2B);
-	writeSAMDDutyCycle(tccI, dc_2b);
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B, void* params){
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0], dc_1a);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1], dc_1b);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2], dc_2a);
+	writeSAMDDutyCycle(((SAMDHardwareDriverParams*)params)->tccPinConfigurations[3], dc_2b);
 	return;
 }
 
@@ -733,12 +740,13 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, Ha
  * @param pinC_l  phase C low-side hardware pin number
  *
  */
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, HardwareDriverParams params){
-	tccConfiguration* tcc1 = getTccPinConfiguration(pinA_h);
-	tccConfiguration* tcc2 = getTccPinConfiguration(pinA_l);
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l, float dead_zone, void* params){
+	tccConfiguration* tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0];
+	tccConfiguration* tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[1];
+	uint32_t pwm_res =((SAMDHardwareDriverParams*)params)->tccPinConfigurations[0]->pwm_res;
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
 		// low-side on a different pin of same TCC - do dead-time in software...
-		float ls = dc_a+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+		float ls = dc_a+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1)); // TODO resolution!!!
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_a);
 		writeSAMDDutyCycle(tcc2, ls);
@@ -746,10 +754,10 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, H
 	else
 		writeSAMDDutyCycle(tcc1, dc_a); // dead-time is done is hardware, no need to set low side pin explicitly
 
-	tcc1 = getTccPinConfiguration(pinB_h);
-	tcc2 = getTccPinConfiguration(pinB_l);
+	tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[2];
+	tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[3];
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_b+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+		float ls = dc_b+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1));
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_b);
 		writeSAMDDutyCycle(tcc2, ls);
@@ -757,10 +765,10 @@ void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, H
 	else
 		writeSAMDDutyCycle(tcc1, dc_b);
 
-	tcc1 = getTccPinConfiguration(pinC_h);
-	tcc2 = getTccPinConfiguration(pinC_l);
+	tcc1 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[4];
+	tcc2 = ((SAMDHardwareDriverParams*)params)->tccPinConfigurations[5];
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {
-		float ls = dc_c+(dead_zone*(SIMPLEFOC_SAMD_PWM_RESOLUTION-1));
+		float ls = dc_c+(((SAMDHardwareDriverParams*)params)->dead_zone * (pwm_res-1));
 		if (ls>1.0) ls = 1.0f; // no off-time is better than too-short dead-time
 		writeSAMDDutyCycle(tcc1, dc_c);
 		writeSAMDDutyCycle(tcc2, ls);

--- a/src/drivers/hardware_specific/samd_mcu.cpp
+++ b/src/drivers/hardware_specific/samd_mcu.cpp
@@ -278,7 +278,7 @@ int checkPermutations(uint8_t num, int pins[], bool (*checkFunc)(tccConfiguratio
  * @param pinA pinA bldc driver
  * @param pinB pinB bldc driver
  */
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+HardwareDriverParams _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -375,7 +375,7 @@ void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
  * @param pinB pinB bldc driver
  * @param pinC pinC bldc driver
  */
-void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
+HardwareDriverParams _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -451,7 +451,7 @@ void _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const in
  * @param pin2A pin2A stepper driver
  * @param pin2B pin2B stepper driver
  */
-void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
+HardwareDriverParams _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
 #endif
@@ -552,7 +552,7 @@ void _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const 
  *
  * @return 0 if config good, -1 if failed
  */
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
+HardwareDriverParams _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
 	// we want to use a TCC channel with 1 non-inverted and 1 inverted output for each phase, with dead-time insertion
 #ifdef SIMPLEFOC_SAMD_DEBUG
 	printAllPinInfos();
@@ -644,7 +644,7 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
  * @param pinA  phase A hardware pin number
  * @param pinB  phase B hardware pin number
  */
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB) {
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, HardwareDriverParams params) {
 	tccConfiguration* tccI = getTccPinConfiguration(pinA);
 	writeSAMDDutyCycle(tccI, dc_a);
 	tccI = getTccPinConfiguration(pinB);
@@ -668,7 +668,7 @@ void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB) {
  * @param pinB  phase B hardware pin number
  * @param pinC  phase C hardware pin number
  */
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC) {
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, HardwareDriverParams params) {
 	tccConfiguration* tccI = getTccPinConfiguration(pinA);
 	writeSAMDDutyCycle(tccI, dc_a);
 	tccI = getTccPinConfiguration(pinB);
@@ -695,7 +695,7 @@ void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB
  * @param pin2A  phase 2A hardware pin number
  * @param pin2B  phase 2B hardware pin number
  */
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, HardwareDriverParams params){
 	tccConfiguration* tccI = getTccPinConfiguration(pin1A);
 	writeSAMDDutyCycle(tccI, dc_1a);
 	tccI = getTccPinConfiguration(pin2A);
@@ -733,7 +733,7 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
  * @param pinC_l  phase C low-side hardware pin number
  *
  */
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, HardwareDriverParams params){
 	tccConfiguration* tcc1 = getTccPinConfiguration(pinA_h);
 	tccConfiguration* tcc2 = getTccPinConfiguration(pinA_l);
 	if (tcc1->tcc.chaninfo!=tcc2->tcc.chaninfo) {

--- a/src/drivers/hardware_specific/samd_mcu.h
+++ b/src/drivers/hardware_specific/samd_mcu.h
@@ -80,10 +80,11 @@ struct wo_association {
 
 
 
-struct SAMDHardwareDriverParams : public HardwareDriverParamsBase {
-	SAMDHardwareDriverParams(int numPins) : tccPinConfigurations[numPins] {};
-	tccConfiguration tccPinConfigurations[6];
-};
+typedef struct SAMDHardwareDriverParams {
+	tccConfiguration* tccPinConfigurations[6];
+	uint32_t pwm_frequency;
+	float dead_zone;
+} SAMDHardwareDriverParams;
 
 
 

--- a/src/drivers/hardware_specific/samd_mcu.h
+++ b/src/drivers/hardware_specific/samd_mcu.h
@@ -80,6 +80,14 @@ struct wo_association {
 
 
 
+struct SAMDHardwareDriverParams : public HardwareDriverParamsBase {
+	SAMDHardwareDriverParams(int numPins) : tccPinConfigurations[numPins] {};
+	tccConfiguration tccPinConfigurations[6];
+};
+
+
+
+
 #if defined(_SAMD21_)
 #define NUM_PIO_TIMER_PERIPHERALS 2
 #elif defined(_SAMD51_)||defined(_SAME51_)

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -142,7 +142,7 @@ void _alignPWMTimers(HardwareTimer *HT1,HardwareTimer *HT2,HardwareTimer *HT3,Ha
 }
 
 // configure hardware 6pwm interface only one timer with inverted channels
-STM32DriverParams* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l)
+STM32DriverParams* _initHardware6PWMInterface(long PWM_freq, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l)
 {
   
 #if !defined(STM32L0xx) // L0 boards dont have hardware 6pwm interface 
@@ -168,7 +168,7 @@ STM32DriverParams* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone
     HardwareTimer_Handle[index]->handle.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED3;
     HardwareTimer_Handle[index]->handle.Init.RepetitionCounter = 1;
     HAL_TIM_Base_Init(&(HardwareTimer_Handle[index]->handle));
-    ((HardwareTimer *)HardwareTimer_Handle[index]->__this)->setOverflow(PWM_freq, HERTZ_FORMAT);
+    ((HardwareTimer *)HardwareTimer_Handle[index]->__this)->setOverflow((uint32_t)PWM_freq, HERTZ_FORMAT);
   }
   HardwareTimer *HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
 

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -32,6 +32,12 @@ HardwareTimer* _initPinPWM(uint32_t PWM_freq, int ulPin)
 {
   PinName pin = digitalPinToPinName(ulPin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM);
+  if (Instance == NP) {
+    Serial.print("No timer on pin ");
+    Serial.println(ulPin);
+    delay(1000);
+    return NP;
+  }
 
   uint32_t index = get_timer_index(Instance);
   if (HardwareTimer_Handle[index] == NULL) {

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -14,15 +14,28 @@
 #define _ERROR_6PWM -1
 
 
-// setting pwm to hardware pin - instead analogWrite()
-void _setPwm(int ulPin, uint32_t value, int resolution)
-{
-  PinName pin = digitalPinToPinName(ulPin);
-  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM);
-  uint32_t index = get_timer_index(Instance);
-  HardwareTimer *HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
 
-  uint32_t channel = STM_PIN_CHANNEL(pinmap_function(pin, PinMap_PWM));
+typedef struct STM32DriverParams {
+  HardwareTimer* timers[6];
+  uint32_t channels[6];
+  long pwm_frequency;
+  float dead_zone;
+  uint8_t interface_type;
+} STM32DriverParams;
+
+
+
+
+
+// setting pwm to hardware pin - instead analogWrite()
+void _setPwm(HardwareTimer *HT, uint32_t channel, uint32_t value, int resolution)
+{
+  // PinName pin = digitalPinToPinName(ulPin);
+  // TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin, PinMap_PWM);
+  // uint32_t index = get_timer_index(Instance);
+  // HardwareTimer *HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
+
+  //uint32_t channel = STM_PIN_CHANNEL(pinmap_function(pin, PinMap_PWM));
   HT->setCaptureCompare(channel, value, (TimerCompareFormat_t)resolution);
 }
 
@@ -129,7 +142,7 @@ void _alignPWMTimers(HardwareTimer *HT1,HardwareTimer *HT2,HardwareTimer *HT3,Ha
 }
 
 // configure hardware 6pwm interface only one timer with inverted channels
-HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l)
+STM32DriverParams* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l)
 {
   
 #if !defined(STM32L0xx) // L0 boards dont have hardware 6pwm interface 
@@ -139,6 +152,12 @@ HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, in
   PinName vlPinName = digitalPinToPinName(pinB_l);
   PinName whPinName = digitalPinToPinName(pinC_h);
   PinName wlPinName = digitalPinToPinName(pinC_l);
+  uint32_t channel1 = STM_PIN_CHANNEL(pinmap_function(uhPinName, PinMap_PWM));
+  uint32_t channel2 = STM_PIN_CHANNEL(pinmap_function(ulPinName, PinMap_PWM));
+  uint32_t channel3 = STM_PIN_CHANNEL(pinmap_function(vhPinName, PinMap_PWM));
+  uint32_t channel4 = STM_PIN_CHANNEL(pinmap_function(vlPinName, PinMap_PWM));
+  uint32_t channel5 = STM_PIN_CHANNEL(pinmap_function(whPinName, PinMap_PWM));
+  uint32_t channel6 = STM_PIN_CHANNEL(pinmap_function(wlPinName, PinMap_PWM));
 
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(uhPinName, PinMap_PWM);
 
@@ -153,12 +172,12 @@ HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, in
   }
   HardwareTimer *HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
 
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(uhPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, uhPinName);
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(ulPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, ulPinName);
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(vhPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, vhPinName);
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(vlPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, vlPinName);
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(whPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, whPinName);
-  HT->setMode(STM_PIN_CHANNEL(pinmap_function(wlPinName, PinMap_PWM)), TIMER_OUTPUT_COMPARE_PWM1, wlPinName);
+  HT->setMode(channel1, TIMER_OUTPUT_COMPARE_PWM1, uhPinName);
+  HT->setMode(channel2, TIMER_OUTPUT_COMPARE_PWM1, ulPinName);
+  HT->setMode(channel3, TIMER_OUTPUT_COMPARE_PWM1, vhPinName);
+  HT->setMode(channel4, TIMER_OUTPUT_COMPARE_PWM1, vlPinName);
+  HT->setMode(channel5, TIMER_OUTPUT_COMPARE_PWM1, whPinName);
+  HT->setMode(channel6, TIMER_OUTPUT_COMPARE_PWM1, wlPinName);
 
   // dead time is set in nanoseconds
   uint32_t dead_time_ns = (float)(1e9f/PWM_freq)*dead_zone;
@@ -177,9 +196,18 @@ HardwareTimer* _initHardware6PWMInterface(uint32_t PWM_freq, float dead_zone, in
   HT->getHandle()->Instance->CNT = TIM1->ARR;
 
   HT->resume();
-  return HT;
+
+  STM32DriverParams* params = new STM32DriverParams {
+    .timers = { HT },
+    .channels = { channel1, channel3, channel5 },
+    .pwm_frequency = PWM_freq,
+    .dead_zone = dead_zone,
+    .interface_type = _HARDWARE_6PWM
+  };
+    
+  return params;
 #else 
-  return nullptr; // return nothing
+  return SIMPLEFOC_DRIVER_INIT_FAILED; // return nothing
 #endif
 }
 
@@ -223,7 +251,7 @@ int _interfaceType(const int pinA_h, const int pinA_l,  const int pinB_h, const 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
   if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // center-aligned frequency is uses two periods
@@ -233,13 +261,24 @@ void _configure2PWM(long pwm_frequency,const int pinA, const int pinB) {
   HardwareTimer* HT2 = _initPinPWM(pwm_frequency, pinB);
   // allign the timers
   _alignPWMTimers(HT1, HT2, HT2);
+  
+  uint32_t channel1 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinA), PinMap_PWM));
+  uint32_t channel2 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinB), PinMap_PWM));
+
+  STM32DriverParams* params = new STM32DriverParams {
+    .timers = { HT1, HT2 },
+    .channels = { channel1, channel2 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
 
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // center-aligned frequency is uses two periods
@@ -250,12 +289,25 @@ void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int
   HardwareTimer* HT3 = _initPinPWM(pwm_frequency, pinC);
   // allign the timers
   _alignPWMTimers(HT1, HT2, HT3);
+  
+  uint32_t channel1 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinA), PinMap_PWM));
+  uint32_t channel2 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinB), PinMap_PWM));
+  uint32_t channel3 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinC), PinMap_PWM));
+
+  STM32DriverParams* params = new STM32DriverParams {
+    .timers = { HT1, HT2, HT3 },
+    .channels = { channel1, channel2, channel3 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
+
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
   if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   // center-aligned frequency is uses two periods
@@ -267,37 +319,51 @@ void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int
   HardwareTimer* HT4 = _initPinPWM(pwm_frequency, pinD);
   // allign the timers
   _alignPWMTimers(HT1, HT2, HT3, HT4);
+
+  uint32_t channel1 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinA), PinMap_PWM));
+  uint32_t channel2 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinB), PinMap_PWM));
+  uint32_t channel3 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinC), PinMap_PWM));
+  uint32_t channel4 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinD), PinMap_PWM));
+
+  STM32DriverParams* params = new STM32DriverParams {
+    .timers = { HT1, HT2, HT3, HT4 },
+    .channels = { channel1, channel2, channel3, channel4 },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
+
+
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 //- hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params){
   // transform duty cycle from [0,1] to [0,4095]
-  _setPwm(pinA, _PWM_RANGE*dc_a, _PWM_RESOLUTION);
-  _setPwm(pinB, _PWM_RANGE*dc_b, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[0], _PWM_RANGE*dc_a, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[1], ((STM32DriverParams*)params)->channels[1], _PWM_RANGE*dc_b, _PWM_RESOLUTION);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 //- hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,4095]
-  _setPwm(pinA, _PWM_RANGE*dc_a, _PWM_RESOLUTION);
-  _setPwm(pinB, _PWM_RANGE*dc_b, _PWM_RESOLUTION);
-  _setPwm(pinC, _PWM_RANGE*dc_c, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[0], _PWM_RANGE*dc_a, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[1], ((STM32DriverParams*)params)->channels[1], _PWM_RANGE*dc_b, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[2], ((STM32DriverParams*)params)->channels[2], _PWM_RANGE*dc_c, _PWM_RESOLUTION);
 }
 
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 //- hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,4095]
-  _setPwm(pin1A, _PWM_RANGE*dc_1a, _PWM_RESOLUTION);
-  _setPwm(pin1B, _PWM_RANGE*dc_1b, _PWM_RESOLUTION);
-  _setPwm(pin2A, _PWM_RANGE*dc_2a, _PWM_RESOLUTION);
-  _setPwm(pin2B, _PWM_RANGE*dc_2b, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[0], _PWM_RANGE*dc_1a, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[1], ((STM32DriverParams*)params)->channels[1], _PWM_RANGE*dc_1b, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[2], ((STM32DriverParams*)params)->channels[2], _PWM_RANGE*dc_2a, _PWM_RESOLUTION);
+  _setPwm(((STM32DriverParams*)params)->timers[3], ((STM32DriverParams*)params)->channels[3], _PWM_RANGE*dc_2b, _PWM_RESOLUTION);
 }
 
 
@@ -306,7 +372,7 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, in
 // Configuring PWM frequency, resolution and alignment
 // - BLDC driver - 6PWM setting
 // - hardware specific
-int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
   if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to |%0kHz max
   // center-aligned frequency is uses two periods
@@ -314,47 +380,58 @@ int _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const 
 
   // find configuration
   int config = _interfaceType(pinA_h, pinA_l,  pinB_h, pinB_l, pinC_h, pinC_l);
+  STM32DriverParams* params;
   // configure accordingly
   switch(config){
     case _ERROR_6PWM:
-      return -1; // fail
-      break;
+      return SIMPLEFOC_DRIVER_INIT_FAILED;
     case _HARDWARE_6PWM:
-      _initHardware6PWMInterface(pwm_frequency, dead_zone, pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
+      params = _initHardware6PWMInterface(pwm_frequency, dead_zone, pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l);
       break;
     case _SOFTWARE_6PWM:
       HardwareTimer* HT1 = _initPinPWMHigh(pwm_frequency, pinA_h);
       _initPinPWMLow(pwm_frequency, pinA_l);
-      HardwareTimer* HT2 = _initPinPWMHigh(pwm_frequency,pinB_h);
+      HardwareTimer* HT2 = _initPinPWMHigh(pwm_frequency, pinB_h);
       _initPinPWMLow(pwm_frequency, pinB_l);
-      HardwareTimer* HT3 = _initPinPWMHigh(pwm_frequency,pinC_h);
+      HardwareTimer* HT3 = _initPinPWMHigh(pwm_frequency, pinC_h);
       _initPinPWMLow(pwm_frequency, pinC_l);
       _alignPWMTimers(HT1, HT2, HT3);
+      uint32_t channel1 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinA_h), PinMap_PWM));
+      uint32_t channel2 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinA_l), PinMap_PWM));
+      uint32_t channel3 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinB_h), PinMap_PWM));
+      uint32_t channel4 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinB_l), PinMap_PWM));
+      uint32_t channel5 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinC_h), PinMap_PWM));
+      uint32_t channel6 = STM_PIN_CHANNEL(pinmap_function(digitalPinToPinName(pinC_l), PinMap_PWM));
+      params = new STM32DriverParams {
+        .timers = { HT1, HT2, HT3 },
+        .channels = { channel1, channel2, channel3, channel4, channel5, channel6 },
+        .pwm_frequency = pwm_frequency,
+        .dead_zone = dead_zone,
+        .interface_type = _SOFTWARE_6PWM
+      };
       break;
   }
-  return 0; // success
+  return params; // success
 }
 
 // Function setting the duty cycle to the pwm pin (ex. analogWrite())
 // - BLDC driver - 6PWM setting
 // - hardware specific
-void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, float dead_zone, int pinA_h, int pinA_l, int pinB_h, int pinB_l, int pinC_h, int pinC_l){
-  // find configuration
-  int config = _interfaceType(pinA_h, pinA_l,  pinB_h, pinB_l, pinC_h, pinC_l);
-  // set pwm accordingly
-  switch(config){
+void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params){
+  switch(((STM32DriverParams*)params)->interface_type){
     case _HARDWARE_6PWM:
-      _setPwm(pinA_h, _PWM_RANGE*dc_a, _PWM_RESOLUTION);
-      _setPwm(pinB_h, _PWM_RANGE*dc_b, _PWM_RESOLUTION);
-      _setPwm(pinC_h, _PWM_RANGE*dc_c, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[0], _PWM_RANGE*dc_a, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[1], _PWM_RANGE*dc_b, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[2], _PWM_RANGE*dc_c, _PWM_RESOLUTION);
       break;
     case _SOFTWARE_6PWM:
-      _setPwm(pinA_l, _constrain(dc_a + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinA_h, _constrain(dc_a - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinB_l, _constrain(dc_b + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinB_h, _constrain(dc_b - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinC_l, _constrain(dc_c + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
-      _setPwm(pinC_h, _constrain(dc_c - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      float dead_zone = ((STM32DriverParams*)params)->dead_zone;
+      _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[0], _constrain(dc_a + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[0], ((STM32DriverParams*)params)->channels[1], _constrain(dc_a - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[1], ((STM32DriverParams*)params)->channels[2], _constrain(dc_b + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[1], ((STM32DriverParams*)params)->channels[3], _constrain(dc_b - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[2], ((STM32DriverParams*)params)->channels[4], _constrain(dc_c + dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
+      _setPwm(((STM32DriverParams*)params)->timers[2], ((STM32DriverParams*)params)->channels[5], _constrain(dc_c - dead_zone/2, 0, 1)*_PWM_RANGE, _PWM_RESOLUTION);
       break;
   }
 }

--- a/src/drivers/hardware_specific/teensy_mcu.cpp
+++ b/src/drivers/hardware_specific/teensy_mcu.cpp
@@ -15,63 +15,78 @@ void _setHighFrequency(const long freq, const int pin){
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
+void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
+void* _configure3PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
   _setHighFrequency(pwm_frequency, pinC);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the high pwm frequency to the supplied pins
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const int pinC, const int pinD) {
+void* _configure4PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC, const int pinD) {
   if(!pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY; // default frequency 25khz
   else pwm_frequency = _constrain(pwm_frequency, 0, _PWM_FREQUENCY_MAX); // constrain to 50kHz max
   _setHighFrequency(pwm_frequency, pinA);
   _setHighFrequency(pwm_frequency, pinB);
   _setHighFrequency(pwm_frequency, pinC);
   _setHighFrequency(pwm_frequency, pinD);
+  GenericDriverParams* params = new GenericDriverParams {
+    .pins = { pinA, pinB, pinC, pinD },
+    .pwm_frequency = pwm_frequency
+  };
+  return params;
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 2PWM setting
 // - hardware speciffic
-void _writeDutyCycle2PWM(float dc_a,  float dc_b, int pinA, int pinB){
+void _writeDutyCycle2PWM(float dc_a,  float dc_b, void* params) {
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
 }
 // function setting the pwm duty cycle to the hardware
 // - BLDC motor - 3PWM setting
 // - hardware speciffic
-void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, int pinA, int pinB, int pinC){
+void _writeDutyCycle3PWM(float dc_a,  float dc_b, float dc_c, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pinA, 255.0f*dc_a);
-  analogWrite(pinB, 255.0f*dc_b);
-  analogWrite(pinC, 255.0f*dc_c);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_c);
 }
 
 // function setting the pwm duty cycle to the hardware
 // - Stepper motor - 4PWM setting
 // - hardware speciffic
-void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, int pin1A, int pin1B, int pin2A, int pin2B){
+void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, void* params){
   // transform duty cycle from [0,1] to [0,255]
-  analogWrite(pin1A, 255.0f*dc_1a);
-  analogWrite(pin1B, 255.0f*dc_1b);
-  analogWrite(pin2A, 255.0f*dc_2a);
-  analogWrite(pin2B, 255.0f*dc_2b);
+  analogWrite(((GenericDriverParams*)params)->pins[0], 255.0f*dc_1a);
+  analogWrite(((GenericDriverParams*)params)->pins[1], 255.0f*dc_1b);
+  analogWrite(((GenericDriverParams*)params)->pins[2], 255.0f*dc_2a);
+  analogWrite(((GenericDriverParams*)params)->pins[3], 255.0f*dc_2b);
 }
 
 #endif


### PR DESCRIPTION
Refactoring of all the PWM drivers to return a parameters stucture pointer of void* type on initialisation (if successful). 

The same pointer is passed to the _writeDutyCycle() methods instead of passing all the pins each time. 

1. This allows each driver to store its internal state, reducing the need for static variables and making multi-motor implementations easier. It also allows the drivers to potentially store other references than the pins, enabling fewer lookups and thus faster execution when setting PWM.
2. It will allow future current-sensing implementations to obtain information from the driver. Since low-side sensing in particular has to be synced to the PWM this is a necessary pre-condition to doing low-side sensing.

At the moment this is in status "in development", but since there is no easy way to do this "driver by driver", I wanted to switch them all over early in this release cycle to give us plenty of time to test the changes, which affect every architecture.

So far I have tried it out on:
- SAMD21 - motor spinning
- SAMD51 - motor spinning
- NRF52 - motor spinning
- STM32F405 - checked PWM only

This change is ready for testing, but there will be further changes as we work with it:
- I have changed only the driver API, and where obvious have stored the required references for that MCU architecture. When we next make changes in a given architecture we may still further optimize what is stored in the driver params for that architecture.
- When we implement current sensing, we will have to move the definitions of the different driver parameter structs into header files so they can be shared between current sense and driver code. I did't do this yet for all the architectures.

But these changes should not further affect the outward facing API of the drivers.

I think we should merge it into dev now, and then we can properly start on low side current sensing... as we implement this we will try out all the architectures...