### PR TITLE
Remove warnigs

### DIFF
--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -237,7 +237,7 @@ class Commander
      *          - velocity (open and closed loop) : velocity torque (ex.M10 2.5 or M10 to only chanage the target witout limits)
      *          - angle    (open and closed loop) : angle velocity torque (ex.M3.5 10 2.5 or M3.5 to only chanage the target witout limits)
      */
-    void motion(FOCMotor* motor, char* user_cmd, char* separator = " ");
+    void motion(FOCMotor* motor, char* user_cmd, char* separator = (char *)" ");
 
   private:
     // Subscribed command callback variables

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -207,7 +207,7 @@ class Commander
      *    - velocity : velocity torque (ex.P10 2.5 or P10 to only chanage the target witout limits)
      *    - angle    : angle velocity torque (ex.P3.5 10 2.5 or P3.5 to only chanage the target witout limits)
      */
-    void target(FOCMotor* motor, char* user_cmd, char* separator = " ");
+    void target(FOCMotor* motor, char* user_cmd, char* separator = (char *)" ");
 
     /**
      * FOC motor (StepperMotor and BLDCMotor) motion control interfaces

--- a/src/current_sense/GenericCurrentSense.cpp
+++ b/src/current_sense/GenericCurrentSense.cpp
@@ -56,7 +56,7 @@ PhaseCurrent_s GenericCurrentSense::getPhaseCurrents(){
 // 3 - success but gains inverted
 // 4 - success but pins reconfigured and gains inverted
 int GenericCurrentSense::driverAlign(float voltage){
-    (void) voltage; // remove unused parameter warning
+    _UNUSED(voltage) ; // remove unused parameter warning
     int exit_flag = 1;
     if(skip_align) return exit_flag;
 

--- a/src/current_sense/GenericCurrentSense.cpp
+++ b/src/current_sense/GenericCurrentSense.cpp
@@ -56,6 +56,7 @@ PhaseCurrent_s GenericCurrentSense::getPhaseCurrents(){
 // 3 - success but gains inverted
 // 4 - success but pins reconfigured and gains inverted
 int GenericCurrentSense::driverAlign(float voltage){
+    (void) voltage; // remove unused parameter warning
     int exit_flag = 1;
     if(skip_align) return exit_flag;
 

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -82,8 +82,8 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
 
 // Set voltage to the pwm pin
 void BLDCDriver6PWM::setPhaseState(int sa, int sb, int sc) {
-  (void) sa;
-  (void) sb;
-  (void) sc;
+  _UNUSED(sa);
+  _UNUSED(sb);
+  _UNUSED(sc);
   // TODO implement disabling
 }

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -82,5 +82,8 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
 
 // Set voltage to the pwm pin
 void BLDCDriver6PWM::setPhaseState(int sa, int sb, int sc) {
+  (void) sa;
+  (void) sb;
+  (void) sc;
   // TODO implement disabling
 }

--- a/src/drivers/hardware_specific/generic_mcu.cpp
+++ b/src/drivers/hardware_specific/generic_mcu.cpp
@@ -46,6 +46,15 @@ __attribute__((weak)) void* _configure4PWM(long pwm_frequency, const int pin1A, 
 // - BLDC driver - 6PWM setting
 // - hardware specific
 __attribute__((weak)) void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l){
+  _UNUSED(pwm_frequency);
+  _UNUSED(dead_zone);
+  _UNUSED(pinA_h);
+  _UNUSED(pinA_l);
+  _UNUSED(pinB_h);
+  _UNUSED(pinB_l);
+  _UNUSED(pinC_h);
+  _UNUSED(pinC_l);
+
   return SIMPLEFOC_DRIVER_INIT_FAILED;
 }
 


### PR DESCRIPTION
I am working in a port to another platform where the compiler keeps complaining about "unused paramerer warning". That is, when a function does not use all its arguments.

The fix is very simple and has no other implications. 

Also another warning when doing: 
char* separator = " "

That a simple cast removes it. 