### PR TITLE
20220520Lowpass_filter_dt_safety_check_inlcude_zero

### DIFF
--- a/src/common/lowpass_filter.cpp
+++ b/src/common/lowpass_filter.cpp
@@ -13,7 +13,7 @@ float LowPassFilter::operator() (float x)
     unsigned long timestamp = _micros();
     float dt = (timestamp - timestamp_prev)*1e-6f;
 
-    if (dt < 0.0f ) dt = 1e-3f;
+    if (dt <= 0.0f ) dt = 1e-3f;
     else if(dt > 0.3f) {
         y_prev = x;
         timestamp_prev = timestamp;


### PR DESCRIPTION
Arduino-FOC\src\common\lowpass_filter.cpp
LowPassFilter::operator()
Line 16

quote  from [askuric](https://github.com/askuric)
if (dt < 1e-3f;) dt = 1e-3f;  is not a good idea.
There are a lot of cases the dt is smaller than 1ms. And fixing the dt to values higher than 1ms would result in impaired dynamics.
if (dt < 0.0f ) dt = 1e-3f; is only a safety check. For example for micros() rollover.
However, you're right that we can include the dt=0 case and I agree that should be included.
So I am in to change the line to if (dt <= 0.0f ) dt = 1e-3f;.