### PR TITLE
Typo in pin assignment configuration for 4PWM

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: possible bug
+assignees: ''
+
+---
+
+This is a simplified template, feel free to change it if it does not fit your case.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Describe the hardware setup**
+For us it is very important to know what is the hardware setup you're using in order to be able to help more directly
+- Which motor
+- Which driver
+- Which microcontroller
+- Which position sensor
+- Current sensing used?
+
+**IDE you are using**
+- Arduino IDE 
+- Platformio
+- Something else
+
+**Tried the Getting started guide? - if applicable**
+Have you tried the getting started guide and at which step are you blocked in

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+Description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+Description of what you want to happen.
+
+**Describe alternatives you've considered**
+Description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+info@simplefoc.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/README.md
+++ b/README.md
@@ -51,23 +51,28 @@ Therefore this is an attempt to:
 
 This video demonstrates the *Simple**FOC**library* basic usage, electronic connections and shows its capabilities.
 
-
 ### Features
-- **Arduino compatible**: 
-   - Arduino library code
-  - Arduino Library Manager integration
+- **Easy install**: 
+   - Arduino IDE: Arduino Library Manager integration
+   - PlatformIO
 - **Open-Source**: Full code and documentation available on github
+- **Goal**: 
+   - Support as many [sensor](https://docs.simplefoc.com/position_sensors) + [motor](https://docs.simplefoc.com/motors) + [driver](https://docs.simplefoc.com/drivers) + [current sense](https://docs.simplefoc.com/current_sense)   combination as possible.
+   - Provide the up-to-date and in-depth documentation with API references and the examples
 - **Easy to setup and configure**: 
-  - Easy hardware configuration
-  - Easy [tuning the control loops](https://docs.simplefoc.com/motion_control)
-- **Modular**:
-  - Supports as many [sensors,  BLDC motors  and  driver boards](https://docs.simplefoc.com/supported_hardware) as possible
-  - Supports multiple [MCU architectures](https://docs.simplefoc.com/microcontrollers):
-     - Arduino: UNO, MEGA, any board with ATMega328 chips
-     - STM32 boards: [Nucleo](https://www.st.com/en/evaluation-tools/stm32-nucleo-boards.html), [Bluepill](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill.html) ...
-     - ESP32
-     - Teensy boards
-- **Plug & play**: Arduino <span class="simple">Simple<span class="foc">FOC</span>Shield</span>  
+   - Easy hardware configuration 
+   - Each hardware component is a C++ object (easy to understand) 
+   - Easy [tuning the control loops](https://docs.simplefoc.com/motion_control)
+   - [*Simple**FOC**Studio*](https://docs.simplefoc.com/studio) configuration GUI tool
+   - Built-in communication and monitoring
+- **Cross-platform**:
+   - Seamless code transfer from one microcontroller family to another 
+   - Supports multiple [MCU architectures](https://docs.simplefoc.com/microcontrollers):
+      - Arduino: UNO, MEGA, DUE, Leonardo ....
+      - STM32
+      - ESP32
+      - Teensy
+      - many more ...
 
 <p align=""> <img src="https://docs.simplefoc.com/extras/Images/uno_l6234.jpg"  height="170px">  <img src="https://docs.simplefoc.com/extras/Images/hmbgc_v22.jpg" height="170px">  <img src="https://docs.simplefoc.com/extras/Images/foc_shield_v13.jpg"  height="170px"></p>
 

--- a/README.md
+++ b/README.md
@@ -95,38 +95,18 @@ This video demonstrates the *Simple**FOC**library* basic usage, electronic conne
 
 <p align=""> <img src="https://docs.simplefoc.com/extras/Images/uno_l6234.jpg"  height="170px">  <img src="https://docs.simplefoc.com/extras/Images/hmbgc_v22.jpg" height="170px">  <img src="https://docs.simplefoc.com/extras/Images/foc_shield_v13.jpg"  height="170px"></p>
 
-## Arduino *SimpleFOCShield* v2.0.4
-<p align="">
-<a href="https://youtu.be/G5pbo0C6ujE">
-<img src="https://docs.simplefoc.com/extras/Images/foc_shield_video.jpg"  height="320px">
-</a>
-</p>
 
-### Features
-- **Plug & play**: In combination with Arduino *Simple**FOC**library* - [github](https://github.com/simplefoc/Arduino-FOC)
-- **Low-cost**: Price of €15 - [Check the pricing](https://www.simplefoc.com/shop) 
-- **In-line current sensing**: Up to 3Amps/5Amps bidirectional
-   - configurable: 3.3Amps - 3.3V adc, 5Amps - 5V adc
-- **Integrated 8V regulator**: 
-   - Enable/disable by soldering pads
-- **Max power 120W** - max current 5A, power-supply 12-24V
-   - Designed for Gimbal motors with the internal resistance >10 Ωs. 
-- **Stackable**: running 2 motors in the same time
-- **Encoder/Hall sensors interface**: Integrated 3.3kΩ pullups (configurable)
-- **I2C interface**: Integrated 4.7kΩ pullups (configurable)
-- **Configurable pinout**: Hardware configuration - soldering connections
-- **Arduino headers**: Arduino UNO, Arduino MEGA, STM32 Nucleo boards...
-- **Open Source**: Fully available fabrication files - [how to make it yourself](https://docs.simplefoc.com/arduino_simplefoc_shield_fabrication)
+## Documentation
+Full API code documentation as well as example projects and step by step guides can be found on our [docs website](https://docs.simplefoc.com/).
 
-<p align=""><img src="https://simplefoc.com/assets/img/v2.jpg" height="180px">   <img src="https://simplefoc.com/assets/img/v1.jpg"  height="180px"> <img src="https://docs.simplefoc.com/extras/Images/simple_foc_shield_v13_small.gif"  height="180x"></p>
-
+![image](https://user-images.githubusercontent.com/36178713/168475410-105e4e3d-082a-4015-98ff-d380c7992dfd.png)
 
 
 ## Getting Started
 Depending on if you want to use this library as the plug and play Arduino library or you want to get insight in the algorithm and make changes there are two ways to install this code.
 
 - Full library installation [Docs](https://docs.simplefoc.com/library_download)
-- Minimal project builder [Docs](https://docs.simplefoc.com/minimal_download)
+- PlatformIO [Docs](https://docs.simplefoc.com/library_platformio)
 
 ### Arduino *SimpleFOClibrary* installation to Arduino IDE
 #### Arduino Library Manager 
@@ -149,14 +129,19 @@ git clone https://github.com/simplefoc/Arduino-FOC.git
 ```
 - Reopen Arduino IDE and you should have the library examples in `File > Examples > Simple FOC`.
 
-###  *SimpleFOClibrary* minimal project builder
+## Community and contributing
 
-For those willing to experiment and to modify the code I suggest using the minimal project builder [minimal branch](https://github.com/simplefoc/Arduino-FOC/tree/minimal). 
- > This code is completely independent and you can run it as any other Arduino Sketch without the need for any libraries. 
+For all the questions regarding the potential implementation, applications, supported hardware and similar please visit our [community forum](https://community.simplefoc.com) or our [discord server](https://discord.gg/kWBwuzY32n).
 
-All you need to do is:
-- Go to [minimal branch](https://github.com/simplefoc/Arduino-FOC/tree/minimal) 
-- Follow the tutorial in the README file and choose only the library files that are necessary for your application.
+It is always helpful to hear the stories/problems/suggestions of people implementing the code and you might find a lot of answered questions there already! 
+
+### Github Issues & Pull requests
+
+Please do not hesitate to leave an issue if you have problems/advices/suggestions regarding the code!
+
+Pull requests are welcome, but let's first discuss them in [community forum](https://community.simplefoc.com)!
+
+If you'd like to contribute to this porject but you are not very familiar with github, don't worry, let us know either by posting at the community forum , by posting a github issue or at our discord server.
 
 ## Arduino code example
 This is a simple Arduino code example implementing the velocity control program of a BLDC motor with encoder. 
@@ -229,9 +214,6 @@ Here are some of the *Simple**FOC**library* and *Simple**FOC**Shield* applicatio
 </a>
 </p>
 
-
-## Documentation
-Find out more information about the Arduino SimpleFOC project in [docs website](https://docs.simplefoc.com/) 
 
 
 ## Arduino FOC repo structure

--- a/README.md
+++ b/README.md
@@ -19,27 +19,46 @@ Therefore this is an attempt to:
    - See also [@byDagor](https://github.com/byDagor)'s *fully-integrated* ESP32 based board: [Dagor Brushless Controller](https://github.com/byDagor/Dagor-Brushless-Controller)
 
 
-> NEXT RELEASE 📢: <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.2 
-> - GenericCurrentSense bugfix and testing
-> - bugfix leonardo #170
-> - bugfix - no index search after specifying natural direction
-> - Odrive example code see `examples/hardware_specific/odrive_example`
-> - Low level API restructuring
->    - Driver API
->    - Current sense API
-> - New debugging interface
->    - Static class SimpleFOCDebug
-> - Low-side current sensing
->    - ESP32 generic support for multiple motors
->    - Added low-side current sensing support for stm32 - only one motor
->        - f1 family
->        - f4 family
->        - g4 family
-> - New handling of current limit using voltage 
->    - Support for motor KV rating - back emf estimation
->    - Using motor phase resistance
 
-
+<blockquote class="info">
+   <p class="heading">NEW RELEASE 📢: <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.2 <a href="https://github.com/simplefoc/Arduino-FOC/releases/tag/v2.2.2">see release</a></p>
+   <ul>
+      <li>GenericCurrentSense bugfix and testing</li>
+      <li>bugfix leonardo #170</li>
+      <li>bugfix - no index search after specifying natural direction</li>
+      <li>Low level API restructuring
+         <ul dir="auto">
+            <li>Driver API</li>
+            <li>Current sense API</li>
+         </ul>
+      </li>
+      <li>New debugging interface - <a href="https://docs.simplefoc.com/debugging">see in docs</a>
+         <ul dir="auto">
+            <li>Static class SimpleFOCDebug</li>
+         </ul>
+      </li>
+      <li>CurrentSense API change - added method <code class="highlighter-rouge">linkDriver()</code> - <a href="https://docs.simplefoc.com/current_sense">see in docs</a></li>
+      <li>Low-side current sensing - <a href="https://docs.simplefoc.com/low_side_current_sense">see in docs</a>
+         <ul dir="auto">
+            <li>ESP32 generic support for multiple motors</li>
+            <li>Added low-side current sensing support for stm32 - only one motor
+            <ul dir="auto">
+               <li>f1 family</li>
+               <li>f4 family</li>
+               <li>g4 family</li>
+            </ul>
+            </li>
+         </ul>
+      </li>
+      <li>New appraoch for current estimation for torque control using voltage - <a href="https://docs.simplefoc.com/voltage_torque_mode">see in docs </a>
+         <ul dir="auto">
+            <li>Support for motor KV rating - back emf estimation</li>
+            <li>Using motor phase resistance</li>
+         </ul>
+      </li>
+      <li>KV rating and phase resistance used for open-loop current limiting as well - <a href="https://docs.simplefoc.com/open_loop_motion_control">see in docs </a> </li>
+   </ul>
+</blockquote>
 
 ## Arduino *SimpleFOClibrary* v2.2
 

--- a/src/drivers/hardware_specific/atmega2560_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega2560_mcu.cpp
@@ -86,7 +86,7 @@ void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const 
   _pinHighFrequency(pin2A);
   _pinHighFrequency(pin2B);
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pins = { pin1A, pin1B, pin2A, pin2B },
     .pwm_frequency = pwm_frequency
   };
   return params;

--- a/src/drivers/hardware_specific/atmega328_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega328_mcu.cpp
@@ -81,7 +81,7 @@ void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const 
   _pinHighFrequency(pin2A);
   _pinHighFrequency(pin2B);
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pins = { pin1A, pin1B, pin2A, pin2B },
     .pwm_frequency = pwm_frequency
   };
   return params;

--- a/src/drivers/hardware_specific/atmega32u4_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega32u4_mcu.cpp
@@ -89,7 +89,7 @@ void* _configure4PWM(long pwm_frequency,const int pin1A, const int pin1B, const 
   _pinHighFrequency(pin2A);
   _pinHighFrequency(pin2B);
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pins = { pin1A, pin1B, pin2A, pin2B },
     .pwm_frequency = pwm_frequency
   };
   return params;

--- a/src/drivers/hardware_specific/esp8266_mcu.cpp
+++ b/src/drivers/hardware_specific/esp8266_mcu.cpp
@@ -54,7 +54,7 @@ void* _configure4PWM(long pwm_frequency,const int pinA, const int pinB, const in
   _setHighFrequency(pwm_frequency, pinC);
   _setHighFrequency(pwm_frequency, pinD);
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pins = { pin1A, pin1B, pin2A, pin2B },
     .pwm_frequency = pwm_frequency
   };
   return params;


### PR DESCRIPTION
I made this small correction in multiple files. Once I did my project seem to work better. I still need some hardware. Without knowing the inner workings of the project. It does look like a simple typo that got copied over multiple files.

```
 GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pin1A, pin2A, pin2A, pin2B },
+    .pins = { pin1A, pin1B, pin2A, pin2B },
    .pwm_frequency = pwm_frequency
  };
```