### PR TITLE
BLDCMotor: make setPhaseVoltage public

### DIFF
--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -70,10 +70,7 @@ class BLDCMotor: public FOCMotor
     float Ua, Ub, Uc;//!< Current phase voltages Ua,Ub and Uc set to motor
     float	Ualpha, Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
-
-  private:
-    // FOC methods 
-    /**
+  /**
     * Method using FOC to set Uq to the motor at the optimal angle
     * Heart of the FOC algorithm
     * 
@@ -82,6 +79,10 @@ class BLDCMotor: public FOCMotor
     * @param angle_el current electrical angle of the motor
     */
     void setPhaseVoltage(float Uq, float Ud, float angle_el);
+
+  private:
+    // FOC methods 
+
     /** Sensor alignment to electrical 0 angle of the motor */
     int alignSensor();
     /** Current sense and motor phase alignment */


### PR DESCRIPTION
Just this small change, to make setPhaseVoltage public.

This is in preparation for code that wants to run alignment or calibration routines from outside the motor class.