### PR TITLE
Correct the commands label to "target velocity"

### DIFF
--- a/examples/motion_control/velocity_motion_control/magnetic_sensor/velocity_control/velocity_control.ino
+++ b/examples/motion_control/velocity_motion_control/magnetic_sensor/velocity_control/velocity_control.ino
@@ -77,7 +77,7 @@ void setup() {
   motor.initFOC();
 
   // add target command T
-  command.add('T', doTarget, "target voltage");
+  command.add('T', doTarget, "target velocity");
 
   Serial.println(F("Motor ready."));
   Serial.println(F("Set the target velocity using serial terminal:"));


### PR DESCRIPTION
I think there is a wrong commands label in this example, line80. 

According the doTarget function, line 32, this command change target_velocity, not the voltage.