### PR TITLE
RP2040 driver improvements, StepDirListener fix

### DIFF
--- a/src/communication/StepDirListener.cpp
+++ b/src/communication/StepDirListener.cpp
@@ -13,7 +13,7 @@ void StepDirListener::init(){
 }
 
 void StepDirListener::enableInterrupt(void (*doA)()){
-    attachInterrupt(digitalPinToInterrupt(pin_step), doA, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(pin_step), doA, polarity);
 }
 
 void StepDirListener::attach(float* variable){
@@ -22,15 +22,15 @@ void StepDirListener::attach(float* variable){
 
 void StepDirListener::handle(){ 
   // read step status
-  bool step = digitalRead(pin_step);
+  //bool step = digitalRead(pin_step);
   // update counter only on rising edge 
-  if(step && step != step_active){
-     if(digitalRead(pin_dir)) 
+  //if(step && step != step_active){
+    if(digitalRead(pin_dir)) 
         count++;
-     else 
+    else 
         count--;
-   }
-   step_active = step;
+   //}
+   //step_active = step;
    // if attached variable update it
    if(attached_variable) *attached_variable = getValue();
 }

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -4,6 +4,12 @@
 #include "Arduino.h"
 #include "../common/foc_utils.h"
 
+
+#if defined(_STM32_DEF_)
+#define PinStatus int
+#endif
+
+
 /**
  * Step/Dir listenner class for easier interraction with this communication interface.
  */
@@ -47,7 +53,7 @@ class StepDirListener
     int pin_step; //!< step pin
     int pin_dir; //!< direction pin
     long count; //!< current counter value - should be set to 0 for homing
-    int polarity = RISING; //!< polarity of the step pin
+    PinStatus polarity = RISING; //!< polarity of the step pin
 
   private:
     float* attached_variable = nullptr; //!< pointer to the attached variable 

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -5,7 +5,7 @@
 #include "../common/foc_utils.h"
 
 
-#if defined(_STM32_DEF_) || defined(ESP_H) || defined(ARDUINO_ARCH_AVR)
+#if defined(_STM32_DEF_) || defined(ESP_H) || defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_SAM_DUE)
 #define PinStatus int
 #endif
 

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -47,11 +47,13 @@ class StepDirListener
     int pin_step; //!< step pin
     int pin_dir; //!< direction pin
     long count; //!< current counter value - should be set to 0 for homing
+    PinStatus polarity = RISING; //!< polarity of the step pin
 
   private:
     float* attached_variable = nullptr; //!< pointer to the attached variable 
     float counter_to_value; //!< step counter to value 
-    bool step_active = 0; //!< current step pin status (HIGH/LOW) - debouncing variable
+    //bool step_active = 0; //!< current step pin status (HIGH/LOW) - debouncing variable
+
 };
 
 #endif

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -47,7 +47,7 @@ class StepDirListener
     int pin_step; //!< step pin
     int pin_dir; //!< direction pin
     long count; //!< current counter value - should be set to 0 for homing
-    PinStatus polarity = RISING; //!< polarity of the step pin
+    int polarity = RISING; //!< polarity of the step pin
 
   private:
     float* attached_variable = nullptr; //!< pointer to the attached variable 

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -5,7 +5,7 @@
 #include "../common/foc_utils.h"
 
 
-#if defined(_STM32_DEF_)
+#if defined(_STM32_DEF_) || defined(ESP_H) || defined(ARDUINO_ARCH_AVR)
 #define PinStatus int
 #endif
 

--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -6,10 +6,7 @@
 
 #define SIMPLEFOC_DEBUG_RP2040
 
-
-
-#include "Arduino.h"
-#include "communication/SimpleFOCDebug.h"
+#include "../hardware_api.h"
 
 
 // these defines determine the polarity of the PWM output. Normally, the polarity is active-high,
@@ -30,6 +27,10 @@
 #define SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH true
 #endif
 
+
+#define _PWM_FREQUENCY 24000
+#define _PWM_FREQUENCY_MAX 66000
+#define _PWM_FREQUENCY_MIN 5000
 
 
 typedef struct RP2040DriverParams {
@@ -59,7 +60,7 @@ void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* para
 	pwm_set_phase_correct(slice, true);
 	uint16_t wrapvalue = ((125L * 1000L * 1000L) / pwm_frequency) / 2L - 1L;
 	if (wrapvalue < 999) wrapvalue = 999; // 66kHz, resolution 1000
-	if (wrapvalue > 3299) wrapvalue = 3299; // 20kHz, resolution 3300
+	if (wrapvalue > 12499) wrapvalue = 12499; // 20kHz, resolution 12500
 #ifdef SIMPLEFOC_DEBUG_RP2040
 	SimpleFOCDebug::print("Configuring pin ");
 	SimpleFOCDebug::print(pin);
@@ -96,6 +97,8 @@ void syncSlices() {
 
 void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
 	RP2040DriverParams* params = new RP2040DriverParams();
+	if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY;
+	else pwm_frequency = _constrain(pwm_frequency, _PWM_FREQUENCY_MIN, _PWM_FREQUENCY_MAX);
 	params->pwm_frequency = pwm_frequency;
 	setupPWM(pinA, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 0);
 	setupPWM(pinB, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 1);
@@ -107,6 +110,8 @@ void* _configure2PWM(long pwm_frequency, const int pinA, const int pinB) {
 
 void* _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const int pinC) {
 	RP2040DriverParams* params = new RP2040DriverParams();
+	if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY;
+	else pwm_frequency = _constrain(pwm_frequency, _PWM_FREQUENCY_MIN, _PWM_FREQUENCY_MAX);
 	params->pwm_frequency = pwm_frequency;
 	setupPWM(pinA, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 0);
 	setupPWM(pinB, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 1);
@@ -120,6 +125,8 @@ void* _configure3PWM(long pwm_frequency, const int pinA, const int pinB, const i
 
 void* _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const int pin2A, const int pin2B) {
 	RP2040DriverParams* params = new RP2040DriverParams();
+	if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY;
+	else pwm_frequency = _constrain(pwm_frequency, _PWM_FREQUENCY_MIN, _PWM_FREQUENCY_MAX);
 	params->pwm_frequency = pwm_frequency;
 	setupPWM(pin1A, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 0);
 	setupPWM(pin1B, pwm_frequency, !SIMPLEFOC_PWM_ACTIVE_HIGH, params, 1);
@@ -133,6 +140,8 @@ void* _configure4PWM(long pwm_frequency, const int pin1A, const int pin1B, const
 void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, const int pinA_l,  const int pinB_h, const int pinB_l, const int pinC_h, const int pinC_l) {
 	// non-PIO solution...
 	RP2040DriverParams* params = new RP2040DriverParams();
+	if( !pwm_frequency || !_isset(pwm_frequency) ) pwm_frequency = _PWM_FREQUENCY;
+	else pwm_frequency = _constrain(pwm_frequency, _PWM_FREQUENCY_MIN, _PWM_FREQUENCY_MAX);
 	params->pwm_frequency = pwm_frequency;
 	params->dead_zone = dead_zone;
 	setupPWM(pinA_h, pwm_frequency, !SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH, params, 0);

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -167,6 +167,9 @@ void _startTimers(HardwareTimer **timers_to_start, int timer_num)
   for (int i=0; i < timer_num; i++) {
     if(timers_to_start[i] == NP) return;
     timers_to_start[i]->resume();
+    #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-DRV: Starting timer ", getTimerNumber(get_timer_index(timers_to_start[i]->getHandle()->Instance)));
+    #endif
   }
 }
 


### PR DESCRIPTION
Several improvements:

- RP2040 driver improvements: sets a default PWM frequency (24kHz) if input frequency is NOT_SET
- RP2040 driver improvements: minimum allowed frequency lowered to 5kHz (formerly 20kHz, for no reason)
- RP2040 driver improvements: introduce 3 build-flags to control the PWM polarity: 
   - SIMPLEFOC_PWM_ACTIVE_HIGH (for all PWM modes except 6-PWM)
   - SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH (for 6-PWM, high side FETs)
   - SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH (for 6-PWM, low side FETs)
 - StepDirListener: change to listen on RISING edge by default, remove double-checking code
     Fix for: https://github.com/simplefoc/Arduino-FOC/issues/169
 - StepDirListener: introduce field "polarity" in class, to control whether RISING or FALLING edge triggers interrupt