### PR TITLE
Set phase state (stm32)

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -522,7 +522,7 @@ void BLDCMotor::setPhaseVoltage(float Uq, float Ud, float angle_el) {
         Ub -= Umin;
         Uc -= Umin;
       }
-
+      driver->setPhaseState(_ACTIVE, _ACTIVE, _ACTIVE);
       break;
 
     case FOCModulationType::SpaceVectorPWM :
@@ -608,6 +608,7 @@ void BLDCMotor::setPhaseVoltage(float Uq, float Ud, float angle_el) {
       Ua = Ta*driver->voltage_limit;
       Ub = Tb*driver->voltage_limit;
       Uc = Tc*driver->voltage_limit;
+      driver->setPhaseState(_ACTIVE, _ACTIVE, _ACTIVE);
       break;
 
   }

--- a/src/drivers/BLDCDriver6PWM.cpp
+++ b/src/drivers/BLDCDriver6PWM.cpp
@@ -83,8 +83,5 @@ void BLDCDriver6PWM::setPwm(float Ua, float Ub, float Uc) {
 
 // Set voltage to the pwm pin
 void BLDCDriver6PWM::setPhaseState(int sa, int sb, int sc) {
-  _UNUSED(sa);
-  _UNUSED(sb);
-  _UNUSED(sc);
-  // TODO implement disabling
+  _setPhaseState(sa, sb, sc, params);
 }

--- a/src/drivers/hardware_api.h
+++ b/src/drivers/hardware_api.h
@@ -152,4 +152,18 @@ void _writeDutyCycle4PWM(float dc_1a,  float dc_1b, float dc_2a, float dc_2b, vo
  */ 
 void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc_c, void* params);
 
+/**
+ * Function setting the phase state
+ * - BLDC driver - 6PWM setting
+ * - hardware specific
+ *
+ * @param dc_a  phase A state (_ACTIVE, _HIGH_IMPEDANCE)
+ * @param dc_b  phase B state (_ACTIVE, _HIGH_IMPEDANCE)
+ * @param dc_c  phase C state (_ACTIVE, _HIGH_IMPEDANCE)
+ * @param params  the driver parameters
+ *
+ */
+void _setPhaseState(int sa, int sb, int sc, void* params);
+
+
 #endif

--- a/src/drivers/hardware_specific/generic_mcu.cpp
+++ b/src/drivers/hardware_specific/generic_mcu.cpp
@@ -121,3 +121,13 @@ __attribute__((weak)) void _writeDutyCycle6PWM(float dc_a,  float dc_b, float dc
   _UNUSED(dc_c);
   _UNUSED(params);
 }
+
+// Function setting the phase state. i.e. active / disabled
+// - BLDC driver - 6PWM setting
+// - hardware specific
+__attribute__((weak)) void _setPhaseState(int sa, int sb, int sc, void* params){
+  _UNUSED(sa);
+  _UNUSED(sb);
+  _UNUSED(sc);
+  _UNUSED(params);
+}

--- a/src/drivers/hardware_specific/stm32_mcu.h
+++ b/src/drivers/hardware_specific/stm32_mcu.h
@@ -22,6 +22,7 @@ typedef struct STM32DriverParams {
   long pwm_frequency;
   float dead_zone;
   uint8_t interface_type;
+  uint8_t phase_status[3] = {_ACTIVE, _ACTIVE, _ACTIVE};
 } STM32DriverParams;
 
 // timer synchornisation functions


### PR DESCRIPTION
I need this functionality for backemf sensing, since it's a nice isolated change I'm putting it up for review now.

Tested on the B-G431B, this is the only board I have. I'm not sure if this has the desired effect on boards with software 6pwm.

I'm not very happy with the API design, it relies on the user calling `_setPWM` shortly after `_setPhaseState`. Maybe remove `BLDCDriver::setPhaseState(sa, sb, sc)` and modify the signature of `setPwm(Ua, Ub, Uc)` to include the phase state, for example `setPwm(float Ua, float Ub, float Uc, int stateA, int stateB, int stateC)`. 9 times out of 10 you'll want to atomically change the pwm and phase state anyway. Maybe I'm overthinking things.



For testing, use `Trapezoid_120`. I believe `Trapezoid_150` is broken but that's out of scope for this pull request.