### PR TITLE
Bg431b ADC extension

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -59,7 +59,7 @@ jobs:
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
 
-          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B-G431B-ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,7 +19,7 @@ jobs:
           - STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8   # stm32 bluepill
           - STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F411RE # stm32 nucleo
           - STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
-          - STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - STMicroelectronics:stm32:Disco:pnum=B-G431B-ESC1      # B-G431-ESC1
           - arduino:mbed_rp2040:pico                 # rpi pico
           
         include:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -63,7 +63,7 @@ jobs:
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
             build-properties: 
-              All:
+              B_G431B_ESC1:
                 -DHAL_ADC_MODULE_ONLY
                 -DHAL_OPAMP_MODULE_ENABLED
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,7 +19,7 @@ jobs:
           - STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8   # stm32 bluepill
           - STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F411RE # stm32 nucleo
           - STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
-          - STMicroelectronics:stm32@2.2.0:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
           - arduino:mbed_rp2040:pico                 # rpi pico
           
         include:
@@ -59,12 +59,11 @@ jobs:
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
 
-          - arduino-boards-fqbn: STMicroelectronics:stm32@2.2.0:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
             build-properties: 
               B_G431B_ESC1:
-                -DHAL_ADC_MODULE_ONLY
                 -DHAL_OPAMP_MODULE_ENABLED
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
@@ -89,3 +88,4 @@ jobs:
           platform-url: ${{ matrix.platform-url }}
           sketch-names: ${{ matrix.sketch-names }}
           sketches-exclude: ${{ matrix.sketches-exclude }}
+          build-properties: ${{ toJson(matrix.build-properties) }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,7 +19,7 @@ jobs:
           - STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8   # stm32 bluepill
           - STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F411RE # stm32 nucleo
           - STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
-          - STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - STMicroelectronics:stm32@2.2.0:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
           - arduino:mbed_rp2040:pico                 # rpi pico
           
         include:
@@ -59,7 +59,7 @@ jobs:
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
 
-          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
+          - arduino-boards-fqbn: STMicroelectronics:stm32@2.2.0:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
             build-properties: 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -57,7 +57,7 @@ jobs:
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8 # bluepill - hs examples
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
-            sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino, stm32_current_control_low_side.ino
+            sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
@@ -68,11 +68,11 @@ jobs:
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
             platform-url: https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
-            sketch-names: odrive_example_encoder.ino, odrive_example_spi.ino
+            sketch-names: odrive_example_encoder.ino, odrive_example_spi.ino, stm32_current_control_low_side.ino
             
           - arduino-boards-fqbn: STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F411RE # nucleo one full example
             platform-url: https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
-            sketch-names: single_full_control_example.ino, stm32_spi_alt_example.ino, sdouble_full_control_example.ino
+            sketch-names: single_full_control_example.ino, stm32_spi_alt_example.ino, sdouble_full_control_example.ino, stm32_current_control_low_side.ino
             
 
       # Do not cancel all jobs / architectures if one job fails

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,6 +10,8 @@ jobs:
         arduino-boards-fqbn:
           - arduino:avr:uno                          # arudino uno
           - arduino:sam:arduino_due_x                # arduino due
+          - arduino:avr:mega2560                     # arduino mega2650
+          - arduino:avr:leonardo                     # arduino leonardo
           - arduino:samd:nano_33_iot                 # samd21
           - adafruit:samd:adafruit_metro_m4          # samd51
           - esp32:esp32:esp32doit-devkit-v1          # esp32
@@ -27,6 +29,12 @@ jobs:
             sketches-exclude: bluepill_position_control, esp32_position_control, esp32_i2c_dual_bus_example, stm32_i2c_dual_bus_example, magnetic_sensor_spi_alt_example, osc_esp32_3pwm, osc_esp32_fullcontrol, nano33IoT_velocity_control, smartstepper_control,esp32_current_control_low_side, stm32_spi_alt_example, esp32_spi_alt_example, B_G431B_ESC1, odrive_example_spi, odrive_example_encoder, single_full_control_example, double_full_control_example
 
           - arduino-boards-fqbn: arduino:sam:arduino_due_x # arduino due - one full example
+            sketch-names: single_full_control_example.ino
+            
+          - arduino-boards-fqbn: arduino:avr:leonardo # arduino leonardo - one full example
+            sketch-names: single_full_control_example.ino
+            
+          - arduino-boards-fqbn: arduino:avr:mega2560 # arduino mega2660 - one full example
             sketch-names: single_full_control_example.ino
             
           - arduino-boards-fqbn: arduino:samd:nano_33_iot  # samd21 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,7 +10,7 @@ jobs:
         arduino-boards-fqbn:
           - arduino:avr:uno                          # arudino uno
           - arduino:sam:arduino_due_x                # arduino due
-          - arduino:avr:mega2560                     # arduino mega2650
+          - arduino:avr:mega                         # arduino mega2650
           - arduino:avr:leonardo                     # arduino leonardo
           - arduino:samd:nano_33_iot                 # samd21
           - adafruit:samd:adafruit_metro_m4          # samd51
@@ -32,9 +32,9 @@ jobs:
             sketch-names: single_full_control_example.ino
             
           - arduino-boards-fqbn: arduino:avr:leonardo # arduino leonardo - one full example
-            sketch-names: single_full_control_example.ino
+            sketch-names: angle_control.ino
             
-          - arduino-boards-fqbn: arduino:avr:mega2560 # arduino mega2660 - one full example
+          - arduino-boards-fqbn: arduino:avr:mega # arduino mega2660 - one full example
             sketch-names: single_full_control_example.ino
             
           - arduino-boards-fqbn: arduino:samd:nano_33_iot  # samd21 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,7 +19,7 @@ jobs:
           - STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8   # stm32 bluepill
           - STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F411RE # stm32 nucleo
           - STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
-          - STMicroelectronics:stm32:Disco:pnum=B-G431B-ESC1      # B-G431-ESC1
+          - STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
           - arduino:mbed_rp2040:pico                 # rpi pico
           
         include:
@@ -59,7 +59,7 @@ jobs:
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
 
-          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B-G431B-ESC1      # B-G431-ESC1
+          - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -62,6 +62,10 @@ jobs:
           - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: B_G431B_ESC1.ino
+            build-properties: 
+              All:
+                -DHAL_ADC_MODULE_ONLY
+                -DHAL_OPAMP_MODULE_ENABLED
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF4:pnum=GENERIC_F405RGTX  # stm32f405 - odrive
             platform-url: https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
@@ -71,7 +75,6 @@ jobs:
             platform-url: https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
             sketch-names: single_full_control_example.ino, stm32_spi_alt_example.ino, sdouble_full_control_example.ino
             
-        
 
       # Do not cancel all jobs / architectures if one job fails
       fail-fast: false

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -32,7 +32,7 @@ jobs:
             sketch-names: single_full_control_example.ino
             
           - arduino-boards-fqbn: arduino:avr:leonardo # arduino leonardo - one full example
-            sketch-names: angle_control.ino
+            sketch-names: open_loop_position_example.ino
             
           - arduino-boards-fqbn: arduino:avr:mega # arduino mega2660 - one full example
             sketch-names: single_full_control_example.ino

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
           - arduino-boards-fqbn: arduino:avr:uno # arudino uno - compiling almost all examples
             sketch-names: '**.ino'
             required-libraries: PciManager
-            sketches-exclude: bluepill_position_control, esp32_position_control, esp32_i2c_dual_bus_example, stm32_i2c_dual_bus_example, magnetic_sensor_spi_alt_example, osc_esp32_3pwm, osc_esp32_fullcontrol, nano33IoT_velocity_control, smartstepper_control,esp32_current_control_low_side, stm32_spi_alt_example, esp32_spi_alt_example, B_G431B_ESC1, odrive_example_spi, odrive_example_encoder, single_full_control_example, double_full_control_example
+            sketches-exclude: bluepill_position_control, esp32_position_control, esp32_i2c_dual_bus_example, stm32_i2c_dual_bus_example, magnetic_sensor_spi_alt_example, osc_esp32_3pwm, osc_esp32_fullcontrol, nano33IoT_velocity_control, smartstepper_control,esp32_current_control_low_side, stm32_spi_alt_example, esp32_spi_alt_example, B_G431B_ESC1, odrive_example_spi, odrive_example_encoder, single_full_control_example, double_full_control_example, stm32_current_control_low_side
 
           - arduino-boards-fqbn: arduino:sam:arduino_due_x # arduino due - one full example
             sketch-names: single_full_control_example.ino
@@ -57,7 +57,7 @@ jobs:
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8 # bluepill - hs examples
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 
-            sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino
+            sketch-names: bluepill_position_control.ino, stm32_i2c_dual_bus_example.ino, stm32_spi_alt_example.ino, stm32_current_control_low_side.ino
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:Disco:pnum=B_G431B_ESC1      # B-G431-ESC1
             platform-url:  https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json 

--- a/README.md
+++ b/README.md
@@ -20,47 +20,15 @@ Therefore this is an attempt to:
 
 
 
-<blockquote class="info">
-   <p class="heading">NEW RELEASE 📢: <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.2 <a href="https://github.com/simplefoc/Arduino-FOC/releases/tag/v2.2.2">see release</a></p>
-   <ul>
-      <li>GenericCurrentSense bugfix and testing</li>
-      <li>bugfix leonardo #170</li>
-      <li>bugfix - no index search after specifying natural direction</li>
-      <li>Low level API restructuring
-         <ul dir="auto">
-            <li>Driver API</li>
-            <li>Current sense API</li>
-         </ul>
-      </li>
-      <li>New debugging interface - <a href="https://docs.simplefoc.com/debugging">see in docs</a>
-         <ul dir="auto">
-            <li>Static class SimpleFOCDebug</li>
-         </ul>
-      </li>
-      <li>CurrentSense API change - added method <code class="highlighter-rouge">linkDriver()</code> - <a href="https://docs.simplefoc.com/current_sense">see in docs</a></li>
-      <li>Low-side current sensing - <a href="https://docs.simplefoc.com/low_side_current_sense">see in docs</a>
-         <ul dir="auto">
-            <li>ESP32 generic support for multiple motors</li>
-            <li>Added low-side current sensing support for stm32 - only one motor
-            <ul dir="auto">
-               <li>f1 family</li>
-               <li>f4 family</li>
-               <li>g4 family</li>
-            </ul>
-            </li>
-         </ul>
-      </li>
-      <li>New appraoch for current estimation for torque control using voltage - <a href="https://docs.simplefoc.com/voltage_torque_mode">see in docs </a>
-         <ul dir="auto">
-            <li>Support for motor KV rating - back emf estimation</li>
-            <li>Using motor phase resistance</li>
-         </ul>
-      </li>
-      <li>KV rating and phase resistance used for open-loop current limiting as well - <a href="https://docs.simplefoc.com/open_loop_motion_control">see in docs </a> </li>
-   </ul>
-</blockquote>
+> FUTURE RELEASE : <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.3
+> - stm32 low-side current sensing 
+>    - g4 supported
+>    - thoroughly tested f1/f4/g4
+> - bugfixing
+>    - leonardo
+>    - mega2560
 
-## Arduino *SimpleFOClibrary* v2.2
+## Arduino *SimpleFOClibrary* v2.2.2
 
 <p align="">
 <a href="https://youtu.be/Y5kLeqTc6Zk">

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 ### A Cross-Platform FOC implementation for BLDC and Stepper motors<br> based on the Arduino IDE and PlatformIO 
 
 ![Library Compile](https://github.com/simplefoc/Arduino-FOC/workflows/Library%20Compile/badge.svg)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/simplefoc/arduino-foc)
+![GitHub Release Date](https://img.shields.io/github/release-date/simplefoc/arduino-foc?color=blue)
+![GitHub commits since tagged version](https://img.shields.io/github/commits-since/simplefoc/arduino-foc/latest/dev)
+![GitHub commit activity (branch)](https://img.shields.io/github/commit-activity/m/simplefoc/arduino-foc/dev)
+
 [![arduino-library-badge](https://www.ardu-badge.com/badge/Simple%20FOC.svg?)](https://www.ardu-badge.com/badge/Simple%20FOC.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![status](https://joss.theoj.org/papers/4382445f249e064e9f0a7f6c1bb06b1d/status.svg)](https://joss.theoj.org/papers/4382445f249e064e9f0a7f6c1bb06b1d)
+
 
 We live in very exciting times 😃! BLDC motors are entering the hobby community more and more and many great projects have already emerged leveraging their far superior dynamics and power capabilities. BLDC motors have numerous advantages over regular DC motors but they have one big disadvantage, the complexity of control. Even though it has become relatively easy to design and manufacture PCBs and create our own hardware solutions for driving BLDC motors the proper low-cost solutions are yet to come. One of the reasons for this is the apparent complexity of writing the BLDC driving algorithms, Field oriented control (FOC) being an example of one of the most efficient ones.
 The solutions that can be found on-line are almost exclusively very specific for certain hardware configuration and the microcontroller architecture used.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Therefore this is an attempt to:
 > NEXT RELEASE 📢: <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.2 
 > - GenericCurrentSense bugfix and testing
 > - bugfix leonardo #170
+> - bugfix - no index search after specifying natural direction
 > - Odrive example code see `examples/hardware_specific/odrive_example`
 > - Low level API restructuring
 >    - Driver API

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Therefore this is an attempt to:
 
 > NEXT RELEASE 📢: <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.2.2 
 > - GenericCurrentSense bugfix and testing
+> - bugfix leonardo #170
 > - Odrive example code see `examples/hardware_specific/odrive_example`
 > - Low level API restructuring
 >    - Driver API

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Therefore this is an attempt to:
 - 🎯 Demystify FOC algorithm and make a robust but simple Arduino library: [Arduino *SimpleFOClibrary*](https://docs.simplefoc.com/arduino_simplefoc_library_showcase)
   - <i>Support as many <b>motor + sensor + driver + mcu</b> combinations out there</i>
 - 🎯 Develop a modular FOC supporting BLDC driver boards:
+   - ***NEW*** 📢: *Minimalistic* BLDC driver (<3Amps) :   [<span class="simple">Simple<b>FOC</b>Mini</span> ](https://github.com/simplefoc/SimpleFOCMini).
    - *Low-power* gimbal driver (<5Amps) :  [*Arduino Simple**FOC**Shield*](https://docs.simplefoc.com/arduino_simplefoc_shield_showcase).
-   - ***NEW*** 📢: *Medium-power* BLDC driver (<30Amps): [Arduino <span class="simple">Simple<b>FOC</b>PowerShield</span> ](https://github.com/simplefoc/Arduino-SimpleFOC-PowerShield).
+   - *Medium-power* BLDC driver (<30Amps): [Arduino <span class="simple">Simple<b>FOC</b>PowerShield</span> ](https://github.com/simplefoc/Arduino-SimpleFOC-PowerShield).
    - See also [@byDagor](https://github.com/byDagor)'s *fully-integrated* ESP32 based board: [Dagor Brushless Controller](https://github.com/byDagor/Dagor-Brushless-Controller)
 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Therefore this is an attempt to:
 > - bugfixing
 >    - leonardo
 >    - mega2560
+>    - inline current sense without driver #188
 > - `initFOC` fails if current sense not initialised
 >    - driver and cs have to be well initialised for `initFOC` to start
 >    - `cs.init()` and `driver.init()` return `1` if well initialised and `0` if failed 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Therefore this is an attempt to:
 > - bugfixing
 >    - leonardo
 >    - mega2560
-
+> - `initFOC` fails if current sense not initialised
+>    - driver and cs have to be well initialised for `initFOC` to start
+>    - `cs.init()` and `driver.init()` return `1` if well initialised and `0` if failed 
 ## Arduino *SimpleFOClibrary* v2.2.2
 
 <p align="">

--- a/examples/hardware_specific_examples/DRV8302_driver/stm32_current_control_low_side/stm32_current_control_low_side.ino
+++ b/examples/hardware_specific_examples/DRV8302_driver/stm32_current_control_low_side/stm32_current_control_low_side.ino
@@ -1,0 +1,167 @@
+/**
+ * Comprehensive BLDC motor control example using encoder and the DRV8302 board
+ *
+ * Using serial terminal user can send motor commands and configure the motor and FOC in real-time:
+ * - configure PID controller constants
+ * - change motion control loops
+ * - monitor motor variabels
+ * - set target values
+ * - check all the configuration values
+ *
+ * check the https://docs.simplefoc.com for full list of motor commands
+ *
+ */
+#include <SimpleFOC.h>
+
+// DRV8302 pins connections
+// don't forget to connect the common ground pin
+#define INH_A PA8
+#define INH_B PA9
+#define INH_C PA10
+
+#define EN_GATE PB7
+#define M_PWM PB4
+#define M_OC PB3
+#define OC_ADJ PB6
+#define OC_GAIN PB5
+
+#define IOUTA PA0
+#define IOUTB PA1
+#define IOUTC PA2
+
+// Motor instance
+BLDCMotor motor = BLDCMotor(7);
+BLDCDriver3PWM driver = BLDCDriver3PWM(INH_A, INH_B, INH_C, EN_GATE);
+
+// DRV8302 board has 0.005Ohm shunt resistors and the gain of 12.22 V/V
+LowsideCurrentSense cs = LowsideCurrentSense(0.005f, 12.22f, IOUTA, IOUTB, IOUTC);
+
+// encoder instance
+Encoder encoder = Encoder(PB14, PB15, 2048);
+
+// Interrupt routine intialisation
+// channel A and B callbacks
+void doA(){encoder.handleA();}
+void doB(){encoder.handleB();}
+
+
+// commander interface
+Commander command = Commander(Serial);
+void onMotor(char* cmd){ command.motor(&motor, cmd); }
+
+void setup() {
+
+  // initialize encoder sensor hardware
+  encoder.init();
+  encoder.enableInterrupts(doA, doB);
+  // link the motor to the sensor
+  motor.linkSensor(&encoder);
+
+  // DRV8302 specific code
+  // M_OC  - enable overcurrent protection
+  pinMode(M_OC,OUTPUT);
+  digitalWrite(M_OC,LOW);
+  // M_PWM  - enable 3pwm mode
+  pinMode(M_PWM,OUTPUT);
+  digitalWrite(M_PWM,HIGH);
+  // OD_ADJ - set the maximum overcurrent limit possible
+  // Better option would be to use voltage divisor to set exact value
+  pinMode(OC_ADJ,OUTPUT);
+  digitalWrite(OC_ADJ,HIGH);
+  pinMode(OC_GAIN,OUTPUT);
+  digitalWrite(OC_GAIN,LOW);
+
+
+  // driver config
+  // power supply voltage [V]
+  driver.voltage_power_supply = 19;
+  driver.pwm_frequency = 15000; // suggested under 18khz
+  driver.init();
+  // link the motor and the driver
+  motor.linkDriver(&driver);
+  // link current sense and the driver
+  cs.linkDriver(&driver);
+
+  // align voltage
+  motor.voltage_sensor_align = 0.5;
+  
+  // control loop type and torque mode 
+  motor.torque_controller = TorqueControlType::voltage;
+  motor.controller = MotionControlType::torque;
+  motor.motion_downsample = 0.0;
+  
+  // velocity loop PID
+  motor.PID_velocity.P = 0.2;
+  motor.PID_velocity.I = 5.0;
+  // Low pass filtering time constant 
+  motor.LPF_velocity.Tf = 0.02;
+  // angle loop PID
+  motor.P_angle.P = 20.0;
+  // Low pass filtering time constant 
+  motor.LPF_angle.Tf = 0.0;
+  // current q loop PID 
+  motor.PID_current_q.P = 3.0;
+  motor.PID_current_q.I = 100.0;
+  // Low pass filtering time constant 
+  motor.LPF_current_q.Tf = 0.02;
+  // current d loop PID
+  motor.PID_current_d.P = 3.0;
+  motor.PID_current_d.I = 100.0;
+  // Low pass filtering time constant 
+  motor.LPF_current_d.Tf = 0.02;
+
+  // Limits 
+  motor.velocity_limit = 100.0; // 100 rad/s velocity limit
+  motor.voltage_limit = 12.0;   // 12 Volt limit 
+  motor.current_limit = 2.0;    // 2 Amp current limit
+
+
+  // use monitoring with serial for motor init
+  // monitoring port
+  Serial.begin(115200);
+  // comment out if not needed
+  motor.useMonitoring(Serial);
+  motor.monitor_variables = _MON_CURR_Q | _MON_CURR_D; // monitor the two currents d and q
+  motor.monitor_downsample = 0;
+
+  // initialise motor
+  motor.init();
+
+  cs.init();
+  // driver 8302 has inverted gains on all channels
+  cs.gain_a *=-1;
+  cs.gain_b *=-1;
+  cs.gain_c *=-1;
+  motor.linkCurrentSense(&cs);
+  
+  // align encoder and start FOC
+  motor.initFOC();
+
+  // set the inital target value
+  motor.target = 0;
+
+  // define the motor id
+  command.add('M', onMotor, "motor");
+
+  Serial.println(F("Full control example: "));
+  Serial.println(F("Run user commands to configure and the motor (find the full command list in docs.simplefoc.com) \n "));
+  Serial.println(F("Initial motion control loop is voltage loop."));
+  Serial.println(F("Initial target voltage 2V."));
+
+  _delay(1000);
+}
+
+
+void loop() {
+  // iterative setting FOC phase voltage
+  motor.loopFOC();
+
+  // iterative function setting the outter loop target
+  motor.move();
+
+  // monitoring the state variables
+  motor.monitor();
+
+  // user communication
+  command.run();
+}

--- a/examples/hardware_specific_examples/Odrive_examples/odrive_example_encoder/odrive_example_encoder.ino
+++ b/examples/hardware_specific_examples/Odrive_examples/odrive_example_encoder/odrive_example_encoder.ino
@@ -21,6 +21,7 @@
 // Odrive M0 encoder pinout
 #define M0_ENC_A PB4
 #define M0_ENC_B PB5
+#define M0_ENC_Z PC9
 
 
 // Odrive M1 motor pinout
@@ -36,6 +37,7 @@
 // Odrive M1 encoder pinout
 #define M1_ENC_A PB6
 #define M1_ENC_B PB7
+#define M1_ENC_Z PC15
 
 // M1 & M2 common enable pin
 #define EN_GATE PB12
@@ -59,11 +61,12 @@ void doMotor(char* cmd) { command.motor(&motor, cmd); }
 // current sensing on B and C phases, phase A not connected
 LowsideCurrentSense current_sense = LowsideCurrentSense(0.0005f, 10.0f, _NC, M0_IB, M0_IC);
 
-Encoder encoder = Encoder(M0_ENC_A, M0_ENC_B, 500);
+Encoder encoder = Encoder(M0_ENC_A, M0_ENC_B, 500,M0_ENC_Z);
 // Interrupt routine intialisation
 // channel A and B callbacks
 void doA(){encoder.handleA();}
 void doB(){encoder.handleB();}
+void doI(){encoder.handleIndex();}
 
 void setup(){
 
@@ -80,7 +83,7 @@ void setup(){
 
   // initialize encoder sensor hardware
   encoder.init();
-  encoder.enableInterrupts(doA, doB); 
+  encoder.enableInterrupts(doA, doB, doI); 
   // link the motor to the sensor
   motor.linkSensor(&encoder);
   

--- a/examples/hardware_specific_examples/Odrive_examples/odrive_example_spi/odrive_example_spi.ino
+++ b/examples/hardware_specific_examples/Odrive_examples/odrive_example_spi/odrive_example_spi.ino
@@ -21,6 +21,7 @@
 // Odrive M0 encoder pinout
 #define M0_ENC_A PB4
 #define M0_ENC_B PB5
+#define M0_ENC_Z PC9
 
 
 // Odrive M1 motor pinout
@@ -36,6 +37,7 @@
 // Odrive M1 encoder pinout
 #define M1_ENC_A PB6
 #define M1_ENC_B PB7
+#define M1_ENC_Z PC15
 
 // M1 & M2 common enable pin
 #define EN_GATE PB12

--- a/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
@@ -20,7 +20,7 @@ BLDCDriver3PWM driver = BLDCDriver3PWM(9, 5, 6, 8);
 //StepperDriver4PWM driver = StepperDriver4PWM(9, 5, 10, 6,  8);
 
 // encoder instance
-Encoder encoder = Encoder(2, 3, 8192);
+Encoder sensor = Encoder(2, 3, 8192);
 
 // Interrupt routine intialisation
 // channel A and B callbacks

--- a/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
@@ -49,7 +49,8 @@ void setup() {
   motor.linkSensor(&sensor);
 
   // driver config
-  // power supply voltage [V]
+  // IMPORTANT!
+  // make sure to set the correct power supply voltage [V]
   driver.voltage_power_supply = 12;
   driver.init();
   // link driver
@@ -58,9 +59,6 @@ void setup() {
   // aligning voltage
   motor.voltage_sensor_align = 3;
   
-  // choose FOC modulation (optional)
-  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
-
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;
 

--- a/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
@@ -1,0 +1,104 @@
+/**
+ * 
+ * Find KV rating for motor with encoder
+ *
+ * Motor KV rating is defiend as the increase of the motor velocity expressed in rotations per minute [rpm] per each 1 Volt int voltage control mode.
+ * 
+ * This example will set your motor in the torque control mode using voltage and set 1 volt to the motor. By reading the velocity it will calculat the motors KV rating.
+ * - To make this esimation more credible you can try increasing the target voltage (or decrease in some cases) 
+ * - The KV rating should be realatively static number - it should not change considerably with the increase in the voltage
+ *
+ */
+#include <SimpleFOC.h>
+
+
+// BLDC motor & driver instance
+BLDCMotor motor = BLDCMotor(11);
+BLDCDriver3PWM driver = BLDCDriver3PWM(9, 5, 6, 8);
+// Stepper motor & driver instance
+//StepperMotor motor = StepperMotor(50);
+//StepperDriver4PWM driver = StepperDriver4PWM(9, 5, 10, 6,  8);
+
+// encoder instance
+Encoder encoder = Encoder(2, 3, 8192);
+
+// Interrupt routine intialisation
+// channel A and B callbacks
+void doA(){encoder.handleA();}
+void doB(){encoder.handleB();}
+
+
+// voltage set point variable
+float target_voltage = 1;
+
+// instantiate the commander
+Commander command = Commander(Serial);
+void doTarget(char* cmd) { command.scalar(&target_voltage, cmd); }
+void calcKV(char* cmd) { 
+  // calculate the KV
+  Serial.println(motor.shaft_velocity/motor.target*30.0f/_PI);
+
+}
+
+void setup() { 
+  
+  // initialize encoder sensor hardware
+  sensor.init();
+  sensor.enableInterrupts(doA, doB, doC); 
+  // link the motor to the sensor
+  motor.linkSensor(&sensor);
+
+  // driver config
+  // power supply voltage [V]
+  driver.voltage_power_supply = 12;
+  driver.init();
+  // link driver
+  motor.linkDriver(&driver);
+
+  // aligning voltage
+  motor.voltage_sensor_align = 3;
+  
+  // choose FOC modulation (optional)
+  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
+
+  // set motion control loop to be used
+  motor.controller = MotionControlType::torque;
+
+  // use monitoring with serial 
+  Serial.begin(115200);
+  // comment out if not needed
+  motor.useMonitoring(Serial);
+
+  // initialize motor
+  motor.init();
+  // align sensor and start FOC
+  motor.initFOC();
+
+  // add target command T
+  command.add('T', doTarget, "target voltage");
+  command.add('K', calcKV, "calculate KV rating");
+
+  Serial.println(F("Motor ready."));
+  Serial.println(F("Set the target voltage : - commnad T"));
+  Serial.println(F("Calculate the motor KV : - command K"));
+  _delay(1000);
+}
+
+
+void loop() {
+
+  // main FOC algorithm function
+  // the faster you run this function the better
+  // Arduino UNO loop  ~1kHz
+  // Bluepill loop ~10kHz 
+  motor.loopFOC();
+
+  // Motion control function
+  // velocity, position or voltage (defined in motor.controller)
+  // this function can be run at much lower frequency than loopFOC() function
+  // You can also use motor.move() and set the motor.target in the code
+  motor.move(target_voltage);
+
+  // user communication
+  command.run();
+}

--- a/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/encoder/find_kv_rating/find_kv_rating.ino
@@ -24,8 +24,8 @@ Encoder encoder = Encoder(2, 3, 8192);
 
 // Interrupt routine intialisation
 // channel A and B callbacks
-void doA(){encoder.handleA();}
-void doB(){encoder.handleB();}
+void doA(){sensor.handleA();}
+void doB(){sensor.handleB();}
 
 
 // voltage set point variable
@@ -44,7 +44,7 @@ void setup() {
   
   // initialize encoder sensor hardware
   sensor.init();
-  sensor.enableInterrupts(doA, doB, doC); 
+  sensor.enableInterrupts(doA, doB); 
   // link the motor to the sensor
   motor.linkSensor(&sensor);
 

--- a/examples/utils/calibration/find_kv_rating/hall_sensor/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/hall_sensor/find_kv_rating/find_kv_rating.ino
@@ -46,7 +46,8 @@ void setup() {
   motor.linkSensor(&sensor);
 
   // driver config
-  // power supply voltage [V]
+  // IMPORTANT!
+  // make sure to set the correct power supply voltage [V]
   driver.voltage_power_supply = 12;
   driver.init();
   // link driver
@@ -54,9 +55,6 @@ void setup() {
 
   // aligning voltage
   motor.voltage_sensor_align = 3;
-  
-  // choose FOC modulation (optional)
-  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;

--- a/examples/utils/calibration/find_kv_rating/hall_sensor/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/hall_sensor/find_kv_rating/find_kv_rating.ino
@@ -1,0 +1,101 @@
+/**
+ * 
+ * Find KV rating for motor with Hall sensors
+ *
+ * Motor KV rating is defiend as the increase of the motor velocity expressed in rotations per minute [rpm] per each 1 Volt int voltage control mode.
+ * 
+ * This example will set your motor in the torque control mode using voltage and set 1 volt to the motor. By reading the velocity it will calculat the motors KV rating.
+ * - To make this esimation more credible you can try increasing the target voltage (or decrease in some cases) 
+ * - The KV rating should be realatively static number - it should not change considerably with the increase in the voltage
+ */
+#include <SimpleFOC.h>
+
+
+// BLDC motor & driver instance
+BLDCMotor motor = BLDCMotor(11);
+BLDCDriver3PWM driver = BLDCDriver3PWM(9, 5, 6, 8);
+
+// hall sensor instance
+HallSensor sensor = HallSensor(2, 3, 4, 11);
+
+// Interrupt routine intialisation
+// channel A and B callbacks
+void doA(){sensor.handleA();}
+void doB(){sensor.handleB();}
+void doC(){sensor.handleC();}
+
+
+// voltage set point variable
+float target_voltage = 1;
+
+// instantiate the commander
+Commander command = Commander(Serial);
+void doTarget(char* cmd) { command.scalar(&target_voltage, cmd); }
+void calcKV(char* cmd) { 
+  // calculate the KV
+  Serial.println(motor.shaft_velocity/motor.target*30.0f/_PI);
+
+}
+
+void setup() { 
+  
+  // initialize encoder sensor hardware
+  sensor.init();
+  sensor.enableInterrupts(doA, doB, doC); 
+  // link the motor to the sensor
+  motor.linkSensor(&sensor);
+
+  // driver config
+  // power supply voltage [V]
+  driver.voltage_power_supply = 12;
+  driver.init();
+  // link driver
+  motor.linkDriver(&driver);
+
+  // aligning voltage
+  motor.voltage_sensor_align = 3;
+  
+  // choose FOC modulation (optional)
+  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
+
+  // set motion control loop to be used
+  motor.controller = MotionControlType::torque;
+
+  // use monitoring with serial 
+  Serial.begin(115200);
+  // comment out if not needed
+  motor.useMonitoring(Serial);
+
+  // initialize motor
+  motor.init();
+  // align sensor and start FOC
+  motor.initFOC();
+
+  // add target command T
+  command.add('T', doTarget, "target voltage");
+  command.add('K', calcKV, "calculate KV rating");
+
+  Serial.println(F("Motor ready."));
+  Serial.println(F("Set the target voltage : - commnad T"));
+  Serial.println(F("Calculate the motor KV : - command K"));
+  _delay(1000);
+}
+
+
+void loop() {
+
+  // main FOC algorithm function
+  // the faster you run this function the better
+  // Arduino UNO loop  ~1kHz
+  // Bluepill loop ~10kHz 
+  motor.loopFOC();
+
+  // Motion control function
+  // velocity, position or voltage (defined in motor.controller)
+  // this function can be run at much lower frequency than loopFOC() function
+  // You can also use motor.move() and set the motor.target in the code
+  motor.move(target_voltage);
+
+  // user communication
+  command.run();
+}

--- a/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
@@ -39,7 +39,6 @@ void setup() {
   
   // initialize encoder sensor hardware
   sensor.init();
-  sensor.enableInterrupts(doA, doB, doC); 
   // link the motor to the sensor
   motor.linkSensor(&sensor);
 

--- a/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
@@ -1,0 +1,99 @@
+/**
+ * Find KV rating for motor with magnetic sensors
+ *
+ * Motor KV rating is defiend as the increase of the motor velocity expressed in rotations per minute [rpm] per each 1 Volt int voltage control mode.
+ * 
+ * This example will set your motor in the torque control mode using voltage and set 1 volt to the motor. By reading the velocity it will calculat the motors KV rating.
+ * - To make this esimation more credible you can try increasing the target voltage (or decrease in some cases) 
+ * - The KV rating should be realatively static number - it should not change considerably with the increase in the voltage
+ */
+#include <SimpleFOC.h>
+
+// magnetic sensor instance - SPI
+MagneticSensorSPI sensor = MagneticSensorSPI(AS5147_SPI, 10);
+// magnetic sensor instance - I2C
+// MagneticSensorI2C sensor = MagneticSensorI2C(AS5600_I2C);
+// magnetic sensor instance - analog output
+// MagneticSensorAnalog sensor = MagneticSensorAnalog(A1, 14, 1020);
+
+// BLDC motor & driver instance
+BLDCMotor motor = BLDCMotor(11);
+BLDCDriver3PWM driver = BLDCDriver3PWM(9, 5, 6, 8);
+// Stepper motor & driver instance
+//StepperMotor motor = StepperMotor(50);
+//StepperDriver4PWM driver = StepperDriver4PWM(9, 5, 10, 6,  8);
+
+// voltage set point variable
+float target_voltage = 1;
+
+// instantiate the commander
+Commander command = Commander(Serial);
+void doTarget(char* cmd) { command.scalar(&target_voltage, cmd); }
+void calcKV(char* cmd) { 
+  // calculate the KV
+  Serial.println(motor.shaft_velocity/motor.target*30.0f/_PI);
+
+}
+
+void setup() { 
+  
+  // initialize encoder sensor hardware
+  sensor.init();
+  sensor.enableInterrupts(doA, doB, doC); 
+  // link the motor to the sensor
+  motor.linkSensor(&sensor);
+
+  // driver config
+  // power supply voltage [V]
+  driver.voltage_power_supply = 12;
+  driver.init();
+  // link driver
+  motor.linkDriver(&driver);
+
+  // aligning voltage
+  motor.voltage_sensor_align = 3;
+  
+  // choose FOC modulation (optional)
+  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
+
+  // set motion control loop to be used
+  motor.controller = MotionControlType::torque;
+
+  // use monitoring with serial 
+  Serial.begin(115200);
+  // comment out if not needed
+  motor.useMonitoring(Serial);
+
+  // initialize motor
+  motor.init();
+  // align sensor and start FOC
+  motor.initFOC();
+
+  // add target command T
+  command.add('T', doTarget, "target voltage");
+  command.add('K', calcKV, "calculate KV rating");
+
+  Serial.println(F("Motor ready."));
+  Serial.println(F("Set the target voltage : - commnad T"));
+  Serial.println(F("Calculate the motor KV : - command K"));
+  _delay(1000);
+}
+
+
+void loop() {
+
+  // main FOC algorithm function
+  // the faster you run this function the better
+  // Arduino UNO loop  ~1kHz
+  // Bluepill loop ~10kHz 
+  motor.loopFOC();
+
+  // Motion control function
+  // velocity, position or voltage (defined in motor.controller)
+  // this function can be run at much lower frequency than loopFOC() function
+  // You can also use motor.move() and set the motor.target in the code
+  motor.move(target_voltage);
+
+  // user communication
+  command.run();
+}

--- a/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
+++ b/examples/utils/calibration/find_kv_rating/magnetic_sensor/find_kv_rating/find_kv_rating.ino
@@ -43,7 +43,8 @@ void setup() {
   motor.linkSensor(&sensor);
 
   // driver config
-  // power supply voltage [V]
+  // IMPORTANT!
+  // make sure to set the correct power supply voltage [V]
   driver.voltage_power_supply = 12;
   driver.init();
   // link driver
@@ -51,9 +52,6 @@ void setup() {
 
   // aligning voltage
   motor.voltage_sensor_align = 3;
-  
-  // choose FOC modulation (optional)
-  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Simple FOC
-version=2.2.2
+version=2.2.3
 author=Simplefoc <info@simplefoc.com>
 maintainer=Simplefoc <info@simplefoc.com>
 sentence=A library demistifying FOC for BLDC motors

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -121,7 +121,15 @@ int  BLDCMotor::initFOC( float zero_electric_offset, Direction _sensor_direction
   // and checks the direction of measuremnt.
   _delay(500);
   if(exit_flag){
-    if(current_sense) exit_flag *= alignCurrentSense();
+    if(current_sense){ 
+      if (!current_sense->initialized) {
+        motor_status = FOCMotorStatus::motor_calib_failed;
+        SIMPLEFOC_DEBUG("MOT: Init FOC error, current sense not initialized");
+        exit_flag = 0;
+      }else{
+        exit_flag *= alignCurrentSense();
+      }
+    }
     else SIMPLEFOC_DEBUG("MOT: No current sense.");
   }
 

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -13,7 +13,7 @@ BLDCMotor::BLDCMotor(int pp, float _R, float _KV)
   // save phase resistance number
   phase_resistance = _R;
   // save back emf constant KV = 1/KV
-  K_bemf = _isset(_KV) ? 1.0f/_KV/_RPM_TO_RADS : NOT_SET;
+  KV_rating = _KV;
 
   // torque control type is voltage by default
   torque_controller = TorqueControlType::voltage;
@@ -344,9 +344,9 @@ void BLDCMotor::move(float new_target) {
   if(!enabled) return;
   // set internal target variable
   if(_isset(new_target)) target = new_target;
-
-  // calculate the back-emf voltage if K_bemf available
-  if (_isset(K_bemf)) voltage_bemf = K_bemf*shaft_velocity;
+  
+  // calculate the back-emf voltage if KV_rating available U_bemf = vel*(1/KV)
+  if (_isset(KV_rating)) voltage_bemf = shaft_velocity/KV_rating/_RPM_TO_RADS;
   // estimate the motor current if phase reistance available and current_sense not available
   if(!current_sense && _isset(phase_resistance)) current.q = (voltage.q - voltage_bemf)/phase_resistance;
 

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -4,7 +4,7 @@
 // BLDCMotor( int pp , float R)
 // - pp            - pole pair number
 // - R             - motor phase resistance
-// - KV            - motor kv rating
+// - KV            - motor kv rating (rmp/v)
 BLDCMotor::BLDCMotor(int pp, float _R, float _KV)
 : FOCMotor()
 {
@@ -13,7 +13,7 @@ BLDCMotor::BLDCMotor(int pp, float _R, float _KV)
   // save phase resistance number
   phase_resistance = _R;
   // save back emf constant KV = 1/KV
-  K_bemf = _isset(_KV) ? 1.0/_KV : NOT_SET;
+  K_bemf = _isset(_KV) ? 1.0f/_KV/_RPM_TO_RADS : NOT_SET;
 
   // torque control type is voltage by default
   torque_controller = TorqueControlType::voltage;

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -162,12 +162,13 @@ int BLDCMotor::alignSensor() {
   int exit_flag = 1; //success
   SIMPLEFOC_DEBUG("MOT: Align sensor.");
 
+  // check if sensor needs zero search
+  if(sensor->needsSearch()) exit_flag = absoluteZeroSearch();
+  // stop init if not found index
+  if(!exit_flag) return exit_flag;
+
   // if unknown natural direction
   if(!_isset(sensor_direction)){
-    // check if sensor needs zero search
-    if(sensor->needsSearch()) exit_flag = absoluteZeroSearch();
-    // stop init if not found index
-    if(!exit_flag) return exit_flag;
 
     // find natural direction
     // move one electrical revolution forward

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -636,9 +636,11 @@ float BLDCMotor::velocityOpenloop(float target_velocity){
 
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) 
-    Uq = _constrain(current_limit*phase_resistance + voltage_bemf,-voltage_limit, voltage_limit);
-
+  if(_isset(phase_resistance)){
+    Uq = _constrain(current_limit*phase_resistance + fabs(voltage_bemf),-voltage_limit, voltage_limit);
+    // recalculate the current  
+    current.q = (Uq - fabs(voltage_bemf))/phase_resistance;
+  }
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   setPhaseVoltage(Uq,  0, _electricalAngle(shaft_angle, pole_pairs));
 
@@ -674,8 +676,11 @@ float BLDCMotor::angleOpenloop(float target_angle){
 
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) 
-    Uq = _constrain(current_limit*phase_resistance + voltage_bemf,-voltage_limit, voltage_limit);
+  if(_isset(phase_resistance)){
+    Uq = _constrain(current_limit*phase_resistance + fabs(voltage_bemf),-voltage_limit, voltage_limit);
+    // recalculate the current  
+    current.q = (Uq - fabs(voltage_bemf))/phase_resistance;
+  }
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   // sensor precision: this calculation is OK due to the normalisation
   setPhaseVoltage(Uq,  0, _electricalAngle(_normalizeAngle(shaft_angle), pole_pairs));

--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -78,7 +78,7 @@ class BLDCMotor: public FOCMotor
     * @param Ud Current voltage in d axis to set to the motor
     * @param angle_el current electrical angle of the motor
     */
-    void setPhaseVoltage(float Uq, float Ud, float angle_el);
+    void setPhaseVoltage(float Uq, float Ud, float angle_el) override;
 
   private:
     // FOC methods 

--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -19,7 +19,7 @@ class BLDCMotor: public FOCMotor
      BLDCMotor class constructor
      @param pp pole pairs number
      @param R  motor phase resistance
-     @param KV  motor KV rating (1/K_bemf)
+     @param KV  motor KV rating (1/K_bemf) - rpm/V
      */ 
     BLDCMotor(int pp,  float R = NOT_SET, float KV = NOT_SET);
     

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -377,8 +377,11 @@ float StepperMotor::velocityOpenloop(float target_velocity){
 
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) 
-    Uq = _constrain(current_limit*phase_resistance + voltage_bemf,-voltage_limit, voltage_limit);
+  if(_isset(phase_resistance)){
+    Uq = _constrain(current_limit*phase_resistance + fabs(voltage_bemf),-voltage_limit, voltage_limit);
+    // recalculate the current  
+    current.q = (Uq - fabs(voltage_bemf))/phase_resistance;
+  }
 
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   setPhaseVoltage(Uq,  0, _electricalAngle(shaft_angle, pole_pairs));
@@ -412,8 +415,11 @@ float StepperMotor::angleOpenloop(float target_angle){
 
   // use voltage limit or current limit
   float Uq = voltage_limit;
-  if(_isset(phase_resistance)) 
-    Uq = _constrain(current_limit*phase_resistance + voltage_bemf,-voltage_limit, voltage_limit);
+  if(_isset(phase_resistance)){
+    Uq = _constrain(current_limit*phase_resistance + fabs(voltage_bemf),-voltage_limit, voltage_limit);
+    // recalculate the current  
+    current.q = (Uq - fabs(voltage_bemf))/phase_resistance;
+  }
   // set the maximal allowed voltage (voltage_limit) with the necessary angle
   setPhaseVoltage(Uq,  0, _electricalAngle((shaft_angle), pole_pairs));
 

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -5,7 +5,7 @@
 // StepperMotor(int pp)
 // - pp            - pole pair number
 // - R             - motor phase resistance
-// - KV            - motor kv rating
+// - KV            - motor kv rating (rmp/v)
 StepperMotor::StepperMotor(int pp, float _R, float _KV)
 : FOCMotor()
 {
@@ -14,7 +14,7 @@ StepperMotor::StepperMotor(int pp, float _R, float _KV)
   // save phase resistance number
   phase_resistance = _R;
   // save back emf constant KV = 1/KV
-  K_bemf = _isset(_KV) ? 1.0/_KV : NOT_SET;
+  K_bemf = _isset(_KV) ? 1.0f/_KV/_RPM_TO_RADS : NOT_SET;
 
   // torque control type is voltage by default
   // current and foc_current not supported yet

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -13,8 +13,8 @@ StepperMotor::StepperMotor(int pp, float _R, float _KV)
   pole_pairs = pp;
   // save phase resistance number
   phase_resistance = _R;
-  // save back emf constant KV = 1/KV
-  K_bemf = _isset(_KV) ? 1.0f/_KV/_RPM_TO_RADS : NOT_SET;
+  // save back emf constant KV = 1/K_bemf
+  KV_rating = _KV;
 
   // torque control type is voltage by default
   // current and foc_current not supported yet
@@ -282,8 +282,8 @@ void StepperMotor::move(float new_target) {
   // set internal target variable
   if(_isset(new_target) ) target = new_target;
 
-  // calculate the back-emf voltage if K_bemf available
-  if (_isset(K_bemf)) voltage_bemf = K_bemf*shaft_velocity;
+  // calculate the back-emf voltage if KV_rating available U_bemf = vel*(1/KV)
+  if (_isset(KV_rating)) voltage_bemf = shaft_velocity/KV_rating/_RPM_TO_RADS;
   // estimate the motor current if phase reistance available and current_sense not available
   if(!current_sense && _isset(phase_resistance)) current.q = (voltage.q - voltage_bemf)/phase_resistance;
 

--- a/src/StepperMotor.h
+++ b/src/StepperMotor.h
@@ -24,7 +24,7 @@ class StepperMotor: public FOCMotor
       StepperMotor class constructor
       @param pp  pole pair number 
       @param R  motor phase resistance
-      @param KV  motor KV rating (1/K_bemf)
+      @param KV  motor KV rating (1/K_bemf) - rpm/V
     */
     StepperMotor(int pp,  float R = NOT_SET, float KV = NOT_SET);
 

--- a/src/StepperMotor.h
+++ b/src/StepperMotor.h
@@ -78,10 +78,7 @@ class StepperMotor: public FOCMotor
     
     float	Ualpha,Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
-  private:
-  
-    // FOC methods 
-    /**
+  /**
     * Method using FOC to set Uq to the motor at the optimal angle
     * Heart of the FOC algorithm
     * 
@@ -89,8 +86,10 @@ class StepperMotor: public FOCMotor
     * @param Ud Current voltage in d axis to set to the motor
     * @param angle_el current electrical angle of the motor
     */
-    void setPhaseVoltage(float Uq, float Ud , float angle_el);
+    void setPhaseVoltage(float Uq, float Ud, float angle_el) override;
 
+  private:
+  
     /** Sensor alignment to electrical 0 angle of the motor */
     int alignSensor();
     /** Motor and sensor alignment to the sensors absolute 0 angle  */

--- a/src/common/base_classes/CurrentSense.h
+++ b/src/common/base_classes/CurrentSense.h
@@ -28,7 +28,7 @@ class CurrentSense{
     // variables
     bool skip_align = false; //!< variable signaling that the phase current direction should be verified during initFOC()
     
-    BLDCDriver* driver; //!< driver link
+    BLDCDriver* driver = nullptr; //!< driver link
     bool initialized = false; // true if current sense was successfully initialized   
     void* params = 0; //!< pointer to hardware specific parameters of current sensing
     

--- a/src/common/base_classes/CurrentSense.h
+++ b/src/common/base_classes/CurrentSense.h
@@ -29,6 +29,7 @@ class CurrentSense{
     bool skip_align = false; //!< variable signaling that the phase current direction should be verified during initFOC()
     
     BLDCDriver* driver; //!< driver link
+    bool initialized = false; // true if current sense was successfully initialized   
     void* params = 0; //!< pointer to hardware specific parameters of current sensing
     
     /**

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -127,6 +127,16 @@ class FOCMotor
      */
     virtual void move(float target = NOT_SET)=0;
 
+    /**
+    * Method using FOC to set Uq to the motor at the optimal angle
+    * Heart of the FOC algorithm
+    * 
+    * @param Uq Current voltage in q axis to set to the motor
+    * @param Ud Current voltage in d axis to set to the motor
+    * @param angle_el current electrical angle of the motor
+    */
+    virtual void setPhaseVoltage(float Uq, float Ud, float angle_el)=0;
+    
     // State calculation methods 
     /** Shaft angle calculation in radians [rad] */
     float shaftAngle();
@@ -135,6 +145,7 @@ class FOCMotor
      * It implements low pass filtering
      */
     float shaftVelocity();
+
 
 
     /** 

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -161,7 +161,7 @@ class FOCMotor
     // motor physical parameters
     float	phase_resistance; //!< motor phase resistance
     int pole_pairs;//!< motor pole pairs number
-    float K_bemf; //!< motor back emf constant (1/KV)
+    float KV_rating; //!< motor KV rating
 
     // limiting variables
     float voltage_limit; //!< Voltage limitting variable - global limit

--- a/src/common/foc_utils.h
+++ b/src/common/foc_utils.h
@@ -5,7 +5,9 @@
 
 // sign function
 #define _sign(a) ( ( (a) < 0 )  ?  -1   : ( (a) > 0 ) )
+#ifndef _round
 #define _round(x) ((x)>=0?(long)((x)+0.5f):(long)((x)-0.5f))
+#endif
 #define _constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define _sqrt(a) (_sqrtApprox(a))
 #define _isset(a) ( (a) != (NOT_SET) )

--- a/src/common/foc_utils.h
+++ b/src/common/foc_utils.h
@@ -24,6 +24,7 @@
 #define _2PI 6.28318530718f
 #define _3PI_2 4.71238898038f
 #define _PI_6 0.52359877559f
+#define _RPM_TO_RADS 0.10471975512f
 
 #define NOT_SET -12345.0
 #define _HIGH_IMPEDANCE 0

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -224,9 +224,9 @@ void Commander::motor(FOCMotor* motor, char* user_command) {
     case CMD_KV_RATING:
       printVerbose(F("Motor KV: "));
       if(!GET){
-        motor->K_bemf = 1.0f/value/_RPM_TO_RADS;
+        motor->KV_rating = value;
       }
-      if(_isset(motor->K_bemf)) println(1.0f/motor->K_bemf/_RPM_TO_RADS);
+      if(_isset(motor->KV_rating)) println(motor->KV_rating);
       else println(0);
       break;
     case CMD_SENSOR:

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -224,9 +224,9 @@ void Commander::motor(FOCMotor* motor, char* user_command) {
     case CMD_KV_RATING:
       printVerbose(F("Motor KV: "));
       if(!GET){
-        motor->K_bemf = 1.0f/value;
+        motor->K_bemf = 1.0f/value/_RPM_TO_RADS;
       }
-      if(_isset(motor->K_bemf)) println(1.0f/motor->K_bemf);
+      if(_isset(motor->K_bemf)) println(1.0f/motor->K_bemf/_RPM_TO_RADS);
       else println(0);
       break;
     case CMD_SENSOR:

--- a/src/current_sense/GenericCurrentSense.cpp
+++ b/src/current_sense/GenericCurrentSense.cpp
@@ -13,6 +13,8 @@ int GenericCurrentSense::init(){
     if(initCallback != nullptr) initCallback();
     // calibrate zero offsets
     calibrateOffsets();
+    // set the initialized flag
+    initialized = (params!=SIMPLEFOC_CURRENT_SENSE_INIT_FAILED);
     // return success
     return 1;
 }

--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -21,8 +21,11 @@ InlineCurrentSense::InlineCurrentSense(float _shunt_resistor, float _gain, int _
 
 // Inline sensor init function
 int InlineCurrentSense::init(){
+    // if no linked driver its fine in this case 
+    // at least for init()
+    void* drv_params = driver ? driver->params : nullptr;
     // configure ADC variables
-    params = _configureADCInline(driver->params,pinA,pinB,pinC);
+    params = _configureADCInline(drv_params,pinA,pinB,pinC);
     // if init failed return fail
     if (params == SIMPLEFOC_CURRENT_SENSE_INIT_FAILED) return 0; 
     // calibrate zero offsets

--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -69,95 +69,130 @@ PhaseCurrent_s InlineCurrentSense::getPhaseCurrents(){
 // 3 - success but gains inverted
 // 4 - success but pins reconfigured and gains inverted
 int InlineCurrentSense::driverAlign(float voltage){
+    
     int exit_flag = 1;
     if(skip_align) return exit_flag;
 
-    // set phase A active and phases B and C down
-    driver->setPwm(voltage, 0, 0);
-    _delay(200);
-    PhaseCurrent_s c = getPhaseCurrents();
-    // read the current 100 times ( arbitrary number )
-    for (int i = 0; i < 100; i++) {
-        PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6f + 0.4f*c1.a;
-        c.b = c.b*0.6f + 0.4f*c1.b;
-        c.c = c.c*0.6f + 0.4f*c1.c;
-        _delay(3);
-    }
-    driver->setPwm(0, 0, 0);
-    // align phase A
-    float ab_ratio = fabs(c.a / c.b);
-    float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
-    if( ab_ratio > 1.5f ){ // should be ~2
-        gain_a *= _sign(c.a);
-    }else if( ab_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and B
-        int tmp_pinA = pinA;
-        pinA = pinB;
-        pinB = tmp_pinA;
-        gain_a *= _sign(c.b);
-        exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and C
-        int tmp_pinA = pinA;
-        pinA = pinC;
-        pinC= tmp_pinA;
-        gain_a *= _sign(c.c);
-        exit_flag = 2;// signal that pins have been switched
-    }else{
-        // error in current sense - phase either not measured or bad connection
-        return 0;
+    if(_isset(pinA)){
+        // set phase A active and phases B and C down
+        driver->setPwm(voltage, 0, 0);
+        _delay(2000);
+        PhaseCurrent_s c = getPhaseCurrents();
+        // read the current 100 times ( arbitrary number )
+        for (int i = 0; i < 100; i++) {
+            PhaseCurrent_s c1 = getPhaseCurrents();
+            c.a = c.a*0.6f + 0.4f*c1.a;
+            c.b = c.b*0.6f + 0.4f*c1.b;
+            c.c = c.c*0.6f + 0.4f*c1.c;
+            _delay(3);
+        }
+        driver->setPwm(0, 0, 0);
+        // align phase A
+        float ab_ratio = c.b ? fabs(c.a / c.b) : 0;
+        float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
+        if(_isset(pinB) && ab_ratio > 1.5f ){ // should be ~2
+            gain_a *= _sign(c.a);
+        }else if(_isset(pinC) && ac_ratio > 1.5f ){ // should be ~2
+            gain_a *= _sign(c.a);
+        }else if(_isset(pinB) && ab_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and B
+            int tmp_pinA = pinA;
+            pinA = pinB;
+            pinB = tmp_pinA;
+            gain_a *= _sign(c.b);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and C
+            int tmp_pinA = pinA;
+            pinA = pinC;
+            pinC= tmp_pinA;
+            gain_a *= _sign(c.c);
+            exit_flag = 2;// signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }
     }
 
-    // set phase B active and phases A and C down
-    driver->setPwm(0, voltage, 0);
-    _delay(200);
-    c = getPhaseCurrents();
-    // read the current 50 times
-    for (int i = 0; i < 100; i++) {
-        PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6f + 0.4f*c1.a;
-        c.b = c.b*0.6f + 0.4f*c1.b;
-        c.c = c.c*0.6f + 0.4f*c1.c;
-        _delay(3);
-    }
-    driver->setPwm(0, 0, 0);
-    float ba_ratio = fabs(c.b/c.a);
-    float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
-     if( ba_ratio > 1.5f ){ // should be ~2
-        gain_b *= _sign(c.b);
-    }else if( ba_ratio < 0.7f ){ // it should be ~0.5
-        // switch phase A and B
-        int tmp_pinB = pinB;
-        pinB = pinA;
-        pinA = tmp_pinB;
-        gain_b *= _sign(c.a);
-        exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and C
-        int tmp_pinB = pinB;
-        pinB = pinC;
-        pinC = tmp_pinB;
-        gain_b *= _sign(c.c);
-        exit_flag = 2; // signal that pins have been switched
-    }else{
-        // error in current sense - phase either not measured or bad connection
-        return 0;
+    if(_isset(pinB)){
+        // set phase B active and phases A and C down
+        driver->setPwm(0, voltage, 0);
+        _delay(200);
+        PhaseCurrent_s c = getPhaseCurrents();
+        // read the current 50 times
+        for (int i = 0; i < 100; i++) {
+            PhaseCurrent_s c1 = getPhaseCurrents();
+            c.a = c.a*0.6 + 0.4f*c1.a;
+            c.b = c.b*0.6 + 0.4f*c1.b;
+            c.c = c.c*0.6 + 0.4f*c1.c;
+            _delay(3);
+        }
+        driver->setPwm(0, 0, 0);
+        float ba_ratio = c.a ? fabs(c.b / c.a) : 0;
+        float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
+        if(_isset(pinA) && ba_ratio > 1.5f ){ // should be ~2
+            gain_b *= _sign(c.b);
+        }else if(_isset(pinC) && bc_ratio > 1.5f ){ // should be ~2
+            gain_b *= _sign(c.b);
+        }else if(_isset(pinA) && ba_ratio < 0.7f ){ // it should be ~0.5
+            // switch phase A and B
+            int tmp_pinB = pinB;
+            pinB = pinA;
+            pinA = tmp_pinB;
+            gain_b *= _sign(c.a);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and C
+            int tmp_pinB = pinB;
+            pinB = pinC;
+            pinC = tmp_pinB;
+            gain_b *= _sign(c.c);
+            exit_flag = 2; // signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }   
     }
 
     // if phase C measured
     if(_isset(pinC)){
-        // set phase B active and phases A and C down
+        // set phase C active and phases A and B down
         driver->setPwm(0, 0, voltage);
         _delay(200);
-        c = getPhaseCurrents();
+        PhaseCurrent_s c = getPhaseCurrents();
         // read the adc voltage 500 times ( arbitrary number )
-        for (int i = 0; i < 50; i++) {
+        for (int i = 0; i < 100; i++) {
             PhaseCurrent_s c1 = getPhaseCurrents();
-            c.c = (c.c+c1.c)/50.0f;
+            c.a = c.a*0.6 + 0.4f*c1.a;
+            c.b = c.b*0.6 + 0.4f*c1.b;
+            c.c = c.c*0.6 + 0.4f*c1.c;
+            _delay(3);
         }
         driver->setPwm(0, 0, 0);
-        gain_c *= _sign(c.c);
+        float ca_ratio = c.a ? fabs(c.c / c.a) : 0;
+        float cb_ratio = c.b ? fabs(c.c / c.b) : 0;
+        if(_isset(pinA) && ca_ratio > 1.5f ){ // should be ~2
+            gain_c *= _sign(c.c);
+        }else if(_isset(pinB) && cb_ratio > 1.5f ){ // should be ~2
+            gain_c *= _sign(c.c);
+        }else if(_isset(pinA) && ca_ratio < 0.7f ){ // it should be ~0.5
+            // switch phase A and C
+            int tmp_pinC = pinC;
+            pinC = pinA;
+            pinA = tmp_pinC;
+            gain_c *= _sign(c.a);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinB) && cb_ratio < 0.7f ){ // should be ~0.5
+            // switch phase B and C
+            int tmp_pinC = pinC;
+            pinC = pinB;
+            pinB = tmp_pinC;
+            gain_c *= _sign(c.b);
+            exit_flag = 2; // signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }   
     }
 
     if(gain_a < 0 || gain_b < 0 || gain_c < 0) exit_flag +=2;
@@ -167,5 +202,6 @@ int InlineCurrentSense::driverAlign(float voltage){
     // 2 - success but pins reconfigured
     // 3 - success but gains inverted
     // 4 - success but pins reconfigured and gains inverted
+
     return exit_flag;
 }

--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -27,6 +27,8 @@ int InlineCurrentSense::init(){
     if (params == SIMPLEFOC_CURRENT_SENSE_INIT_FAILED) return 0; 
     // calibrate zero offsets
     calibrateOffsets();
+    // set the initialized flag
+    initialized = (params!=SIMPLEFOC_CURRENT_SENSE_INIT_FAILED);
     // return success
     return 1;
 }

--- a/src/current_sense/LowsideCurrentSense.cpp
+++ b/src/current_sense/LowsideCurrentSense.cpp
@@ -34,7 +34,7 @@ int LowsideCurrentSense::init(){
 }
 // Function finding zero offsets of the ADC
 void LowsideCurrentSense::calibrateOffsets(){    
-    const int calibration_rounds = 10000;
+    const int calibration_rounds = 1000;
 
     // find adc offset = zero current voltage
     offset_ia = 0;

--- a/src/current_sense/LowsideCurrentSense.cpp
+++ b/src/current_sense/LowsideCurrentSense.cpp
@@ -34,7 +34,7 @@ int LowsideCurrentSense::init(){
 }
 // Function finding zero offsets of the ADC
 void LowsideCurrentSense::calibrateOffsets(){    
-    const int calibration_rounds = 1000;
+    const int calibration_rounds = 10000;
 
     // find adc offset = zero current voltage
     offset_ia = 0;
@@ -43,9 +43,9 @@ void LowsideCurrentSense::calibrateOffsets(){
     // read the adc voltage 1000 times ( arbitrary number )
     for (int i = 0; i < calibration_rounds; i++) {
         _startADC3PinConversionLowSide();
-        if(_isset(pinA)) offset_ia += _readADCVoltageLowSide(pinA, params);
-        if(_isset(pinB)) offset_ib += _readADCVoltageLowSide(pinB, params);
-        if(_isset(pinC)) offset_ic += _readADCVoltageLowSide(pinC, params);
+        if(_isset(pinA)) offset_ia += (_readADCVoltageLowSide(pinA, params));
+        if(_isset(pinB)) offset_ib += (_readADCVoltageLowSide(pinB, params));
+        if(_isset(pinC)) offset_ic += (_readADCVoltageLowSide(pinC, params));
         _delay(1);
     }
     // calculate the mean offsets
@@ -77,92 +77,126 @@ int LowsideCurrentSense::driverAlign(float voltage){
     int exit_flag = 1;
     if(skip_align) return exit_flag;
 
-    // set phase A active and phases B and C down
-    driver->setPwm(voltage, 0, 0);
-    _delay(2000);
-    PhaseCurrent_s c = getPhaseCurrents();
-    // read the current 100 times ( arbitrary number )
-    for (int i = 0; i < 100; i++) {
-        PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6f + 0.4f*c1.a;
-        c.b = c.b*0.6f + 0.4f*c1.b;
-        c.c = c.c*0.6f + 0.4f*c1.c;
-        _delay(3);
-    }
-    driver->setPwm(0, 0, 0);
-    // align phase A
-    float ab_ratio = fabs(c.a / c.b);
-    float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
-    if( ab_ratio > 1.5f ){ // should be ~2
-        gain_a *= _sign(c.a);
-    }else if( ab_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and B
-        int tmp_pinA = pinA;
-        pinA = pinB;
-        pinB = tmp_pinA;
-        gain_a *= _sign(c.b);
-        exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and C
-        int tmp_pinA = pinA;
-        pinA = pinC;
-        pinC= tmp_pinA;
-        gain_a *= _sign(c.c);
-        exit_flag = 2;// signal that pins have been switched
-    }else{
-        // error in current sense - phase either not measured or bad connection
-        return 0;
+    if(_isset(pinA)){
+        // set phase A active and phases B and C down
+        driver->setPwm(voltage, 0, 0);
+        _delay(2000);
+        PhaseCurrent_s c = getPhaseCurrents();
+        // read the current 100 times ( arbitrary number )
+        for (int i = 0; i < 100; i++) {
+            PhaseCurrent_s c1 = getPhaseCurrents();
+            c.a = c.a*0.6f + 0.4f*c1.a;
+            c.b = c.b*0.6f + 0.4f*c1.b;
+            c.c = c.c*0.6f + 0.4f*c1.c;
+            _delay(3);
+        }
+        driver->setPwm(0, 0, 0);
+        // align phase A
+        float ab_ratio = c.b ? fabs(c.a / c.b) : 0;
+        float ac_ratio = c.c ? fabs(c.a / c.c) : 0;
+        if(_isset(pinB) && ab_ratio > 1.5f ){ // should be ~2
+            gain_a *= _sign(c.a);
+        }else if(_isset(pinC) && ac_ratio > 1.5f ){ // should be ~2
+            gain_a *= _sign(c.a);
+        }else if(_isset(pinB) && ab_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and B
+            int tmp_pinA = pinA;
+            pinA = pinB;
+            pinB = tmp_pinA;
+            gain_a *= _sign(c.b);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinC) &&  ac_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and C
+            int tmp_pinA = pinA;
+            pinA = pinC;
+            pinC= tmp_pinA;
+            gain_a *= _sign(c.c);
+            exit_flag = 2;// signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }
     }
 
-    // set phase B active and phases A and C down
-    driver->setPwm(0, voltage, 0);
-    _delay(200);
-    c = getPhaseCurrents();
-    // read the current 50 times
-    for (int i = 0; i < 100; i++) {
-        PhaseCurrent_s c1 = getPhaseCurrents();
-        c.a = c.a*0.6 + 0.4f*c1.a;
-        c.b = c.b*0.6 + 0.4f*c1.b;
-        c.c = c.c*0.6 + 0.4f*c1.c;
-        _delay(3);
-    }
-    driver->setPwm(0, 0, 0);
-    float ba_ratio = fabs(c.b/c.a);
-    float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
-     if( ba_ratio > 1.5f ){ // should be ~2
-        gain_b *= _sign(c.b);
-    }else if( ba_ratio < 0.7f ){ // it should be ~0.5
-        // switch phase A and B
-        int tmp_pinB = pinB;
-        pinB = pinA;
-        pinA = tmp_pinB;
-        gain_b *= _sign(c.a);
-        exit_flag = 2; // signal that pins have been switched
-    }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
-        // switch phase A and C
-        int tmp_pinB = pinB;
-        pinB = pinC;
-        pinC = tmp_pinB;
-        gain_b *= _sign(c.c);
-        exit_flag = 2; // signal that pins have been switched
-    }else{
-        // error in current sense - phase either not measured or bad connection
-        return 0;
+    if(_isset(pinB)){
+        // set phase B active and phases A and C down
+        driver->setPwm(0, voltage, 0);
+        _delay(200);
+        PhaseCurrent_s c = getPhaseCurrents();
+        // read the current 50 times
+        for (int i = 0; i < 100; i++) {
+            PhaseCurrent_s c1 = getPhaseCurrents();
+            c.a = c.a*0.6 + 0.4f*c1.a;
+            c.b = c.b*0.6 + 0.4f*c1.b;
+            c.c = c.c*0.6 + 0.4f*c1.c;
+            _delay(3);
+        }
+        driver->setPwm(0, 0, 0);
+        float ba_ratio = c.a ? fabs(c.b / c.a) : 0;
+        float bc_ratio = c.c ? fabs(c.b / c.c) : 0;
+        if(_isset(pinA) && ba_ratio > 1.5f ){ // should be ~2
+            gain_b *= _sign(c.b);
+        }else if(_isset(pinC) && bc_ratio > 1.5f ){ // should be ~2
+            gain_b *= _sign(c.b);
+        }else if(_isset(pinA) && ba_ratio < 0.7f ){ // it should be ~0.5
+            // switch phase A and B
+            int tmp_pinB = pinB;
+            pinB = pinA;
+            pinA = tmp_pinB;
+            gain_b *= _sign(c.a);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinC) && bc_ratio < 0.7f ){ // should be ~0.5
+            // switch phase A and C
+            int tmp_pinB = pinB;
+            pinB = pinC;
+            pinC = tmp_pinB;
+            gain_b *= _sign(c.c);
+            exit_flag = 2; // signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }   
     }
 
     // if phase C measured
     if(_isset(pinC)){
-        // set phase B active and phases A and C down
+        // set phase C active and phases A and B down
         driver->setPwm(0, 0, voltage);
         _delay(200);
-        c = getPhaseCurrents();
+        PhaseCurrent_s c = getPhaseCurrents();
         // read the adc voltage 500 times ( arbitrary number )
-        for (int i = 0; i < 50; i++) {
+        for (int i = 0; i < 100; i++) {
             PhaseCurrent_s c1 = getPhaseCurrents();
-            c.c = (c.c+c1.c)/50.0f;
+            c.a = c.a*0.6 + 0.4f*c1.a;
+            c.b = c.b*0.6 + 0.4f*c1.b;
+            c.c = c.c*0.6 + 0.4f*c1.c;
+            _delay(3);
         }
         driver->setPwm(0, 0, 0);
-        gain_c *= _sign(c.c);
+        float ca_ratio = c.a ? fabs(c.c / c.a) : 0;
+        float cb_ratio = c.b ? fabs(c.c / c.b) : 0;
+        if(_isset(pinA) && ca_ratio > 1.5f ){ // should be ~2
+            gain_c *= _sign(c.c);
+        }else if(_isset(pinB) && cb_ratio > 1.5f ){ // should be ~2
+            gain_c *= _sign(c.c);
+        }else if(_isset(pinA) && ca_ratio < 0.7f ){ // it should be ~0.5
+            // switch phase A and C
+            int tmp_pinC = pinC;
+            pinC = pinA;
+            pinA = tmp_pinC;
+            gain_c *= _sign(c.a);
+            exit_flag = 2; // signal that pins have been switched
+        }else if(_isset(pinB) && cb_ratio < 0.7f ){ // should be ~0.5
+            // switch phase B and C
+            int tmp_pinC = pinC;
+            pinC = pinB;
+            pinB = tmp_pinC;
+            gain_c *= _sign(c.b);
+            exit_flag = 2; // signal that pins have been switched
+        }else{
+            // error in current sense - phase either not measured or bad connection
+            return 0;
+        }   
     }
 
     if(gain_a < 0 || gain_b < 0 || gain_c < 0) exit_flag +=2;

--- a/src/current_sense/LowsideCurrentSense.cpp
+++ b/src/current_sense/LowsideCurrentSense.cpp
@@ -29,6 +29,8 @@ int LowsideCurrentSense::init(){
     _driverSyncLowSide(driver->params, params);
     // calibrate zero offsets
     calibrateOffsets();
+    // set the initialized flag
+    initialized = (params!=SIMPLEFOC_CURRENT_SENSE_INIT_FAILED);
     // return success
     return 1;
 }

--- a/src/current_sense/LowsideCurrentSense.h
+++ b/src/current_sense/LowsideCurrentSense.h
@@ -40,6 +40,9 @@ class LowsideCurrentSense: public CurrentSense{
     // LowPassFilter lpf_b{DEF_LPF_PER_PHASE_CURRENT_SENSE_Tf}; //!<  current B low pass filter
     // LowPassFilter lpf_c{DEF_LPF_PER_PHASE_CURRENT_SENSE_Tf}; //!<  current C low pass filter
 
+    float offset_ia; //!< zero current A voltage value (center of the adc reading)
+    float offset_ib; //!< zero current B voltage value (center of the adc reading)
+    float offset_ic; //!< zero current C voltage value (center of the adc reading)
   private:
 
     // hardware variables
@@ -56,9 +59,6 @@ class LowsideCurrentSense: public CurrentSense{
      *  Function finding zero offsets of the ADC
      */
     void calibrateOffsets();
-    float offset_ia; //!< zero current A voltage value (center of the adc reading)
-    float offset_ib; //!< zero current B voltage value (center of the adc reading)
-    float offset_ic; //!< zero current C voltage value (center of the adc reading)
 
 };
 

--- a/src/current_sense/hardware_specific/atmega_mcu.cpp
+++ b/src/current_sense/hardware_specific/atmega_mcu.cpp
@@ -16,8 +16,8 @@
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   

--- a/src/current_sense/hardware_specific/due_mcu.cpp
+++ b/src/current_sense/hardware_specific/due_mcu.cpp
@@ -10,8 +10,8 @@
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   GenericCurrentSenseParams* params = new GenericCurrentSenseParams {

--- a/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
@@ -1,6 +1,6 @@
 #include "esp32_adc_driver.h"
 
-#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) 
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32S3)
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
@@ -68,7 +68,6 @@ int adc_read_index[2]={0};
 
 // function reading an ADC value and returning the read voltage
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
-  uint32_t raw_adc;
 
   mcpwm_unit_t unit = ((ESP32MCPWMCurrentSenseParams*)cs_params)->mcpwm_unit;
   int buffer_index = ((ESP32MCPWMCurrentSenseParams*)cs_params)->buffer_index;

--- a/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
@@ -38,8 +38,8 @@ float _readADCVoltageInline(const int pinA, const void* cs_params){
 void* _configureADCInline(const void* driver_params, const int pinA, const int pinB, const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   ESP32MCPWMCurrentSenseParams* params = new ESP32MCPWMCurrentSenseParams {
@@ -87,12 +87,12 @@ void* _configureADCLowSide(const void* driver_params, const int pinA,const int p
   
   mcpwm_unit_t unit = ((ESP32MCPWMDriverParams*)driver_params)->mcpwm_unit;
   int index_start = adc_pin_count[unit];
-  adc_pins[unit][adc_pin_count[unit]++] = pinA;
-  adc_pins[unit][adc_pin_count[unit]++] = pinB;
+  if( _isset(pinA) ) adc_pins[unit][adc_pin_count[unit]++] = pinA;
+  if( _isset(pinB) ) adc_pins[unit][adc_pin_count[unit]++] = pinB;
   if( _isset(pinC) ) adc_pins[unit][adc_pin_count[unit]++] = pinC;
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   ESP32MCPWMCurrentSenseParams* params = new ESP32MCPWMCurrentSenseParams {

--- a/src/current_sense/hardware_specific/esp32/esp32s_adc_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32s_adc_driver.cpp
@@ -1,0 +1,257 @@
+#include "esp32_adc_driver.h"
+
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) && (defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "rom/ets_sys.h"
+#include "esp_attr.h"
+#include "esp_intr.h"
+#include "soc/rtc_io_reg.h"
+#include "soc/rtc_cntl_reg.h"
+#include "soc/sens_reg.h"
+
+static uint8_t __analogAttenuation = 3;//11db
+static uint8_t __analogWidth = 3;//12 bits
+static uint8_t __analogCycles = 8;
+static uint8_t __analogSamples = 0;//1 sample
+static uint8_t __analogClockDiv = 1;
+
+// Width of returned answer ()
+static uint8_t __analogReturnedWidth = 12;
+
+void __analogSetWidth(uint8_t bits){
+    if(bits < 9){
+        bits = 9;
+    } else if(bits > 12){
+        bits = 12;
+    }
+    __analogReturnedWidth = bits;
+    __analogWidth = bits - 9;
+    // SET_PERI_REG_BITS(SENS_SAR_START_FORCE_REG, SENS_SAR1_BIT_WIDTH, __analogWidth, SENS_SAR1_BIT_WIDTH_S);
+    // SET_PERI_REG_BITS(SENS_SAR_READER1_CTRL_REG, SENS_SAR1_SAMPLE_BIT, __analogWidth, SENS_SAR1_SAMPLE_BIT_S);
+
+    // SET_PERI_REG_BITS(SENS_SAR_START_FORCE_REG, SENS_SAR2_BIT_WIDTH, __analogWidth, SENS_SAR2_BIT_WIDTH_S);
+    // SET_PERI_REG_BITS(SENS_SAR_READER2_CTRL_REG, SENS_SAR2_SAMPLE_BIT, __analogWidth, SENS_SAR2_SAMPLE_BIT_S);
+}
+
+void __analogSetCycles(uint8_t cycles){
+    __analogCycles = cycles;
+    // SET_PERI_REG_BITS(SENS_SAR_READER1_CTRL_REG, SENS_SAR1_SAMPLE_CYCLE, __analogCycles, SENS_SAR1_SAMPLE_CYCLE_S);
+    // SET_PERI_REG_BITS(SENS_SAR_READER2_CTRL_REG, SENS_SAR2_SAMPLE_CYCLE, __analogCycles, SENS_SAR2_SAMPLE_CYCLE_S);
+}
+
+void __analogSetSamples(uint8_t samples){
+    if(!samples){
+        return;
+    }
+    __analogSamples = samples - 1;
+    SET_PERI_REG_BITS(SENS_SAR_READER1_CTRL_REG, SENS_SAR1_SAMPLE_NUM, __analogSamples, SENS_SAR1_SAMPLE_NUM_S);
+    SET_PERI_REG_BITS(SENS_SAR_READER2_CTRL_REG, SENS_SAR2_SAMPLE_NUM, __analogSamples, SENS_SAR2_SAMPLE_NUM_S);
+}
+
+void __analogSetClockDiv(uint8_t clockDiv){
+    if(!clockDiv){
+        return;
+    }
+    __analogClockDiv = clockDiv;
+    SET_PERI_REG_BITS(SENS_SAR_READER1_CTRL_REG, SENS_SAR1_CLK_DIV, __analogClockDiv, SENS_SAR1_CLK_DIV_S);
+    SET_PERI_REG_BITS(SENS_SAR_READER2_CTRL_REG, SENS_SAR2_CLK_DIV, __analogClockDiv, SENS_SAR2_CLK_DIV_S);
+}
+
+void __analogSetAttenuation(uint8_t attenuation)
+{
+    __analogAttenuation = attenuation & 3;
+    uint32_t att_data = 0;
+    int i = 10;
+    while(i--){
+        att_data |= __analogAttenuation << (i * 2);
+    }
+    WRITE_PERI_REG(SENS_SAR_ATTEN1_REG, att_data & 0xFFFF);//ADC1 has 8 channels
+    WRITE_PERI_REG(SENS_SAR_ATTEN2_REG, att_data);
+}
+
+void IRAM_ATTR __analogInit(){
+    static bool initialized = false;
+    if(initialized){
+        return;
+    }
+
+    __analogSetAttenuation(__analogAttenuation);
+    __analogSetCycles(__analogCycles);
+    __analogSetSamples(__analogSamples + 1);//in samples
+    __analogSetClockDiv(__analogClockDiv);
+    __analogSetWidth(__analogWidth + 9);//in bits
+
+    SET_PERI_REG_MASK(SENS_SAR_READER1_CTRL_REG, SENS_SAR1_DATA_INV);
+    SET_PERI_REG_MASK(SENS_SAR_READER2_CTRL_REG, SENS_SAR2_DATA_INV);
+
+    SET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_START_FORCE_M); //SAR ADC1 controller (in RTC) is started by SW
+    SET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_SAR1_EN_PAD_FORCE_M); //SAR ADC1 pad enable bitmap is controlled by SW
+    SET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_START_FORCE_M); //SAR ADC2 controller (in RTC) is started by SW
+    SET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_SAR2_EN_PAD_FORCE_M); //SAR ADC2 pad enable bitmap is controlled by SW
+
+    CLEAR_PERI_REG_MASK(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR_M); //force XPD_SAR=0, use XPD_FSM
+    SET_PERI_REG_BITS(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_AMP, 0x2, SENS_FORCE_XPD_AMP_S); //force XPD_AMP=0
+
+    CLEAR_PERI_REG_MASK(SENS_SAR_AMP_CTRL3_REG, 0xfff << SENS_AMP_RST_FB_FSM_S);  //clear FSM
+    SET_PERI_REG_BITS(SENS_SAR_AMP_CTRL1_REG, SENS_SAR_AMP_WAIT1, 0x1, SENS_SAR_AMP_WAIT1_S);
+    SET_PERI_REG_BITS(SENS_SAR_AMP_CTRL1_REG, SENS_SAR_AMP_WAIT2, 0x1, SENS_SAR_AMP_WAIT2_S);
+    SET_PERI_REG_BITS(SENS_SAR_POWER_XPD_SAR_REG, SENS_SAR_AMP_WAIT3, 0x1, SENS_SAR_AMP_WAIT3_S);
+    while (GET_PERI_REG_BITS2(SENS_SAR_SLAVE_ADDR1_REG, 0x7, SENS_SARADC_MEAS_STATUS_S) != 0); //wait det_fsm==
+
+    initialized = true;
+}
+
+void __analogSetPinAttenuation(uint8_t pin, uint8_t attenuation)
+{
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0 || attenuation > 3){
+        return ;
+    }
+    __analogInit();
+    if(channel > 7){
+        SET_PERI_REG_BITS(SENS_SAR_ATTEN2_REG, 3, attenuation, ((channel - 10) * 2));
+    } else {
+        SET_PERI_REG_BITS(SENS_SAR_ATTEN1_REG, 3, attenuation, (channel * 2));
+    }
+}
+
+bool IRAM_ATTR __adcAttachPin(uint8_t pin){
+
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0){
+        return false;//not adc pin
+    }
+
+    int8_t pad = digitalPinToTouchChannel(pin);
+    if(pad >= 0){
+        uint32_t touch = READ_PERI_REG(SENS_SAR_TOUCH_CONF_REG);
+        if(touch & (1 << pad)){
+            touch &= ~((1 << (pad + SENS_TOUCH_OUTEN_S)));
+            WRITE_PERI_REG(SENS_SAR_TOUCH_CONF_REG, touch);
+        }
+    } else if(pin == 25){
+        CLEAR_PERI_REG_MASK(RTC_IO_PAD_DAC1_REG, RTC_IO_PDAC1_XPD_DAC | RTC_IO_PDAC1_DAC_XPD_FORCE); //stop dac1
+    } else if(pin == 26){
+        CLEAR_PERI_REG_MASK(RTC_IO_PAD_DAC2_REG, RTC_IO_PDAC2_XPD_DAC | RTC_IO_PDAC2_DAC_XPD_FORCE); //stop dac2
+    }
+
+    pinMode(pin, ANALOG);
+
+    __analogInit();
+    return true;
+}
+
+bool IRAM_ATTR __adcStart(uint8_t pin){
+
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0){
+        return false;//not adc pin
+    }
+
+    if(channel > 9){
+        channel -= 10;
+        CLEAR_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_START_SAR_M);
+        SET_PERI_REG_BITS(SENS_SAR_MEAS2_CTRL2_REG, SENS_SAR2_EN_PAD, (1 << channel), SENS_SAR2_EN_PAD_S);
+        SET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_START_SAR_M);
+    } else {
+        CLEAR_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_START_SAR_M);
+        SET_PERI_REG_BITS(SENS_SAR_MEAS1_CTRL2_REG, SENS_SAR1_EN_PAD, (1 << channel), SENS_SAR1_EN_PAD_S);
+        SET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_START_SAR_M);
+    }
+    return true;
+}
+
+bool IRAM_ATTR __adcBusy(uint8_t pin){
+
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0){
+        return false;//not adc pin
+    }
+
+    if(channel > 7){
+        return (GET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_DONE_SAR) == 0);
+    }
+    return (GET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_DONE_SAR) == 0);
+}
+
+uint16_t IRAM_ATTR __adcEnd(uint8_t pin)
+{
+
+    uint16_t value = 0;
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0){
+        return 0;//not adc pin
+    }
+    if(channel > 7){
+        while (GET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_DONE_SAR) == 0); //wait for conversion
+        value = GET_PERI_REG_BITS2(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_DATA_SAR, SENS_MEAS2_DATA_SAR_S);
+    } else {
+        while (GET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_DONE_SAR) == 0); //wait for conversion
+        value = GET_PERI_REG_BITS2(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_DATA_SAR, SENS_MEAS1_DATA_SAR_S);
+    }
+
+    // Shift result if necessary
+    uint8_t from = __analogWidth + 9;
+    if (from == __analogReturnedWidth) {
+        return value;
+    }
+    if (from > __analogReturnedWidth) {
+        return value >> (from - __analogReturnedWidth);
+    }
+    return value << (__analogReturnedWidth - from);
+}
+
+void __analogReadResolution(uint8_t bits)
+{
+    if(!bits || bits > 16){
+        return;
+    }
+    __analogSetWidth(bits);         // hadware from 9 to 12
+    __analogReturnedWidth = bits;   // software from 1 to 16
+}
+
+uint16_t IRAM_ATTR adcRead(uint8_t pin)
+{
+    int8_t channel = digitalPinToAnalogChannel(pin);
+    if(channel < 0){
+        return false;//not adc pin
+    }
+
+    __analogInit();
+
+    if(channel > 9){
+        channel -= 10;
+        CLEAR_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_START_SAR_M);
+        SET_PERI_REG_BITS(SENS_SAR_MEAS2_CTRL2_REG, SENS_SAR2_EN_PAD, (1 << channel), SENS_SAR2_EN_PAD_S);
+        SET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_START_SAR_M);
+    } else {
+        CLEAR_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_START_SAR_M);
+        SET_PERI_REG_BITS(SENS_SAR_MEAS1_CTRL2_REG, SENS_SAR1_EN_PAD, (1 << channel), SENS_SAR1_EN_PAD_S);
+        SET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_START_SAR_M);
+    }
+
+    uint16_t value = 0;
+
+    if(channel > 7){
+        while (GET_PERI_REG_MASK(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_DONE_SAR) == 0); //wait for conversion
+        value = GET_PERI_REG_BITS2(SENS_SAR_MEAS2_CTRL2_REG, SENS_MEAS2_DATA_SAR, SENS_MEAS2_DATA_SAR_S);
+    } else {
+        while (GET_PERI_REG_MASK(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_DONE_SAR) == 0); //wait for conversion
+        value = GET_PERI_REG_BITS2(SENS_SAR_MEAS1_CTRL2_REG, SENS_MEAS1_DATA_SAR, SENS_MEAS1_DATA_SAR_S);
+    }
+
+    // Shift result if necessary
+    uint8_t from = __analogWidth + 9;
+    if (from == __analogReturnedWidth) {
+        return value;
+    }
+    if (from > __analogReturnedWidth) {
+        return value >> (from - __analogReturnedWidth);
+    }
+    return value << (__analogReturnedWidth - from);
+}
+
+
+#endif

--- a/src/current_sense/hardware_specific/generic_mcu.cpp
+++ b/src/current_sense/hardware_specific/generic_mcu.cpp
@@ -10,8 +10,8 @@ __attribute__((weak))  float _readADCVoltageInline(const int pinA, const void* c
 __attribute__((weak))  void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   GenericCurrentSenseParams* params = new GenericCurrentSenseParams {

--- a/src/current_sense/hardware_specific/samd/samd_mcu.cpp
+++ b/src/current_sense/hardware_specific/samd/samd_mcu.cpp
@@ -8,8 +8,9 @@
 // function reading an ADC value and returning the read voltage
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
-  pinMode(pinA, INPUT); 
-  pinMode(pinB, INPUT);
+
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   GenericCurrentSenseParams* params = new GenericCurrentSenseParams {

--- a/src/current_sense/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32_mcu.cpp
@@ -12,8 +12,8 @@
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   Stm32CurrentSenseParams* params = new Stm32CurrentSenseParams {

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
@@ -33,7 +33,7 @@ uint32_t _timerToRegularTRGO(HardwareTimer* timer){
     return ADC_EXTERNALTRIGCONV_T3_TRGO;
 #ifdef TIM8 // if defined timer 8
   else if(timer->getHandle()->Instance == TIM8) 
-    return ADC_EXTERNALTRIGINJECCONV_T8_TRGO;
+    return ADC_EXTERNALTRIGCONV_T8_TRGO;
 #endif
   else
     return _TRGO_NOT_AVAILABLE;

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -33,7 +33,7 @@ int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
 void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
 
   Stm32CurrentSenseParams* cs_params= new Stm32CurrentSenseParams {
-    .pins={0},
+    .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_F1) / (_ADC_RESOLUTION_F1)
   };
   _adc_gpio_init(cs_params, pinA,pinB,pinC);

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
@@ -78,7 +78,12 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   hadc.Init.NbrOfConversion = 1;
   hadc.Init.DMAContinuousRequests = DISABLE;
   hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  HAL_ADC_Init(&hadc);
+  if ( HAL_ADC_Init(&hadc) != HAL_OK){
+  #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init ADC!");
+  #endif
+    return -1;
+  }
   /**Configure for the selected ADC regular channel to be converted. 
   */
     
@@ -122,17 +127,32 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   // first channel
   sConfigInjected.InjectedRank = 1;
   sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[0]), PinMap_ADC));
-  HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected);
+  if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
+  #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[0]), PinMap_ADC)) );
+  #endif
+    return -1;
+  }
   // second channel
   sConfigInjected.InjectedRank = 2;
   sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[1]), PinMap_ADC));
-  HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected);
+  if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
+  #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[1]), PinMap_ADC)) );
+  #endif
+    return -1;
+  }
 
   // third channel - if exists
   if(_isset(cs_params->pins[2])){
     sConfigInjected.InjectedRank = 3;
     sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[2]), PinMap_ADC));
-    HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected);
+    if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
+    #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[2]), PinMap_ADC)) );
+    #endif
+      return -1;
+    }
   }
   
   // enable interrupt

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
@@ -8,6 +8,7 @@
 #include "../../../../common/foc_utils.h"
 #include "../../../../drivers/hardware_specific/stm32_mcu.h"
 #include "../stm32_mcu.h"
+#include "stm32f4_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
 void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
@@ -7,6 +7,7 @@
 #include "../../../hardware_api.h"
 #include "../stm32_mcu.h"
 #include "stm32f4_hal.h"
+#include "stm32f4_utils.h"
 #include "Arduino.h"
 
 
@@ -21,21 +22,10 @@ bool needs_downsample[3] = {1};
 // downsampling variable - per adc (3)
 uint8_t tim_downsample[3] = {0};
 
-int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
-  if(AdcHandle->Instance == ADC1) return 0;
-#ifdef ADC2 // if ADC2 exists
-  else if(AdcHandle->Instance == ADC2) return 1;
-#endif
-#ifdef ADC3 // if ADC3 exists
-  else if(AdcHandle->Instance == ADC3) return 2;
-#endif
-  return 0;
-}
-
 void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
 
   Stm32CurrentSenseParams* cs_params= new Stm32CurrentSenseParams {
-    .pins={0},
+    .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_F4) / (_ADC_RESOLUTION_F4)
   };
   _adc_gpio_init(cs_params, pinA,pinB,pinC);

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_utils.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_utils.cpp
@@ -1,0 +1,193 @@
+#include "stm32f4_utils.h"
+
+#if defined(STM32F4xx)
+
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin)
+{
+  uint32_t function = pinmap_function(pin, PinMap_ADC);
+  uint32_t channel = 0;
+  switch (STM_PIN_CHANNEL(function)) {
+#ifdef ADC_CHANNEL_0
+    case 0:
+      channel = ADC_CHANNEL_0;
+      break;
+#endif
+    case 1:
+      channel = ADC_CHANNEL_1;
+      break;
+    case 2:
+      channel = ADC_CHANNEL_2;
+      break;
+    case 3:
+      channel = ADC_CHANNEL_3;
+      break;
+    case 4:
+      channel = ADC_CHANNEL_4;
+      break;
+    case 5:
+      channel = ADC_CHANNEL_5;
+      break;
+    case 6:
+      channel = ADC_CHANNEL_6;
+      break;
+    case 7:
+      channel = ADC_CHANNEL_7;
+      break;
+    case 8:
+      channel = ADC_CHANNEL_8;
+      break;
+    case 9:
+      channel = ADC_CHANNEL_9;
+      break;
+    case 10:
+      channel = ADC_CHANNEL_10;
+      break;
+    case 11:
+      channel = ADC_CHANNEL_11;
+      break;
+    case 12:
+      channel = ADC_CHANNEL_12;
+      break;
+    case 13:
+      channel = ADC_CHANNEL_13;
+      break;
+    case 14:
+      channel = ADC_CHANNEL_14;
+      break;
+    case 15:
+      channel = ADC_CHANNEL_15;
+      break;
+#ifdef ADC_CHANNEL_16
+    case 16:
+      channel = ADC_CHANNEL_16;
+      break;
+#endif
+    case 17:
+      channel = ADC_CHANNEL_17;
+      break;
+#ifdef ADC_CHANNEL_18
+    case 18:
+      channel = ADC_CHANNEL_18;
+      break;
+#endif
+#ifdef ADC_CHANNEL_19
+    case 19:
+      channel = ADC_CHANNEL_19;
+      break;
+#endif
+#ifdef ADC_CHANNEL_20
+    case 20:
+      channel = ADC_CHANNEL_20;
+      break;
+    case 21:
+      channel = ADC_CHANNEL_21;
+      break;
+    case 22:
+      channel = ADC_CHANNEL_22;
+      break;
+    case 23:
+      channel = ADC_CHANNEL_23;
+      break;
+#ifdef ADC_CHANNEL_24
+    case 24:
+      channel = ADC_CHANNEL_24;
+      break;
+    case 25:
+      channel = ADC_CHANNEL_25;
+      break;
+    case 26:
+      channel = ADC_CHANNEL_26;
+      break;
+#ifdef ADC_CHANNEL_27
+    case 27:
+      channel = ADC_CHANNEL_27;
+      break;
+    case 28:
+      channel = ADC_CHANNEL_28;
+      break;
+    case 29:
+      channel = ADC_CHANNEL_29;
+      break;
+    case 30:
+      channel = ADC_CHANNEL_30;
+      break;
+    case 31:
+      channel = ADC_CHANNEL_31;
+      break;
+#endif
+#endif
+#endif
+    default:
+      _Error_Handler("ADC: Unknown adc channel", (int)(STM_PIN_CHANNEL(function)));
+      break;
+  }
+  return channel;
+}
+
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc_ex.h#L179
+uint32_t _timerToInjectedTRGO(HardwareTimer* timer){
+  if(timer->getHandle()->Instance == TIM1)  
+    return ADC_EXTERNALTRIGINJECCONV_T1_TRGO;
+#ifdef TIM2 // if defined timer 2
+  else if(timer->getHandle()->Instance == TIM2) 
+    return ADC_EXTERNALTRIGINJECCONV_T2_TRGO;
+#endif
+#ifdef TIM4 // if defined timer 4
+  else if(timer->getHandle()->Instance == TIM4) 
+    return ADC_EXTERNALTRIGINJECCONV_T4_TRGO;
+#endif
+#ifdef TIM5 // if defined timer 5
+  else if(timer->getHandle()->Instance == TIM5) 
+    return ADC_EXTERNALTRIGINJECCONV_T5_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc.h#L331
+uint32_t _timerToRegularTRGO(HardwareTimer* timer){
+  if(timer->getHandle()->Instance == TIM2)  
+    return ADC_EXTERNALTRIGCONV_T2_TRGO;
+#ifdef TIM3 // if defined timer 3
+  else if(timer->getHandle()->Instance == TIM3) 
+    return ADC_EXTERNALTRIGCONV_T3_TRGO;
+#endif
+#ifdef TIM8 // if defined timer 8
+  else if(timer->getHandle()->Instance == TIM8) 
+    return ADC_EXTERNALTRIGCONV_T8_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+
+int _adcToIndex(ADC_TypeDef *AdcHandle){
+  if(AdcHandle == ADC1) return 0;
+#ifdef ADC2 // if ADC2 exists
+  else if(AdcHandle == ADC2) return 1;
+#endif
+#ifdef ADC3 // if ADC3 exists
+  else if(AdcHandle == ADC3) return 2;
+#endif
+#ifdef ADC4 // if ADC4 exists
+  else if(AdcHandle == ADC4) return 3;
+#endif
+#ifdef ADC5 // if ADC5 exists
+  else if(AdcHandle == ADC5) return 4;
+#endif
+  return 0;
+}
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
+  return _adcToIndex(AdcHandle->Instance);
+}
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_utils.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_utils.h
@@ -1,0 +1,34 @@
+
+#ifndef STM32F4_UTILS_HAL
+#define STM32F4_UTILS_HAL
+
+#include "Arduino.h"
+
+#if defined(STM32F4xx)
+
+#define _TRGO_NOT_AVAILABLE 12345
+
+
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin);
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc_ex.h#L179
+uint32_t _timerToInjectedTRGO(HardwareTimer* timer);
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc.h#L331
+uint32_t _timerToRegularTRGO(HardwareTimer* timer);
+
+// function returning index of the ADC instance
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle);
+int _adcToIndex(ADC_TypeDef *AdcHandle);
+
+#endif
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -3,104 +3,32 @@
 #if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
 
 #include "../../../../communication/SimpleFOCDebug.h"
-#define _TRGO_NOT_AVAILABLE 12345
 
-#define SIMPLEFOC_STM32_DEBUG
-
-// timer to injected TRGO
-// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc_ex.h#L217
-uint32_t _timerToInjectedTRGO(HardwareTimer* timer){
-  if(timer->getHandle()->Instance == TIM1)  
-    return ADC_EXTERNALTRIGINJEC_T1_TRGO;
-#ifdef TIM2 // if defined timer 2
-  else if(timer->getHandle()->Instance == TIM2) 
-    return ADC_EXTERNALTRIGINJEC_T2_TRGO;
-#endif
-#ifdef TIM3 // if defined timer 3
-  else if(timer->getHandle()->Instance == TIM3) 
-    return ADC_EXTERNALTRIGINJEC_T3_TRGO;
-#endif
-#ifdef TIM4 // if defined timer 4
-  else if(timer->getHandle()->Instance == TIM4) 
-    return ADC_EXTERNALTRIGINJEC_T4_TRGO;
-#endif
-#ifdef TIM6 // if defined timer 6
-  else if(timer->getHandle()->Instance == TIM6) 
-    return ADC_EXTERNALTRIGINJEC_T6_TRGO;
-#endif
-#ifdef TIM7 // if defined timer 7
-  else if(timer->getHandle()->Instance == TIM7) 
-    return ADC_EXTERNALTRIGINJEC_T7_TRGO;
-#endif
-#ifdef TIM8 // if defined timer 8
-  else if(timer->getHandle()->Instance == TIM8) 
-    return ADC_EXTERNALTRIGINJEC_T8_TRGO;
-#endif
-#ifdef TIM15 // if defined timer 15
-  else if(timer->getHandle()->Instance == TIM15) 
-    return ADC_EXTERNALTRIGINJEC_T15_TRGO;
-#endif
-#ifdef TIM20 // if defined timer 15
-  else if(timer->getHandle()->Instance == TIM20) 
-    return ADC_EXTERNALTRIGINJEC_T20_TRGO;
-#endif
-  else
-    return _TRGO_NOT_AVAILABLE;
-}
-
-// timer to regular TRGO
-// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc.h#L519
-uint32_t _timerToRegularTRGO(HardwareTimer* timer){
-  if(timer->getHandle()->Instance == TIM1)  
-    return ADC_EXTERNALTRIG_T1_TRGO;
-#ifdef TIM2 // if defined timer 2
-  else if(timer->getHandle()->Instance == TIM2) 
-    return ADC_EXTERNALTRIG_T2_TRGO;
-#endif
-#ifdef TIM3 // if defined timer 3
-  else if(timer->getHandle()->Instance == TIM3) 
-    return ADC_EXTERNALTRIG_T3_TRGO;
-#endif
-#ifdef TIM4 // if defined timer 4
-  else if(timer->getHandle()->Instance == TIM4) 
-    return ADC_EXTERNALTRIG_T4_TRGO;
-#endif
-#ifdef TIM6 // if defined timer 6
-  else if(timer->getHandle()->Instance == TIM6) 
-    return ADC_EXTERNALTRIG_T6_TRGO;
-#endif
-#ifdef TIM7 // if defined timer 7
-  else if(timer->getHandle()->Instance == TIM7) 
-    return ADC_EXTERNALTRIG_T7_TRGO;
-#endif
-#ifdef TIM8 // if defined timer 8
-  else if(timer->getHandle()->Instance == TIM8) 
-    return ADC_EXTERNALTRIG_T7_TRGO;
-#endif
-#ifdef TIM15 // if defined timer 15
-  else if(timer->getHandle()->Instance == TIM15) 
-    return ADC_EXTERNALTRIG_T15_TRGO;
-#endif
-#ifdef TIM20 // if defined timer 15
-  else if(timer->getHandle()->Instance == TIM20) 
-    return ADC_EXTERNALTRIG_T20_TRGO;
-#endif
-  else
-    return _TRGO_NOT_AVAILABLE;
-}
+//#define SIMPLEFOC_STM32_DEBUG
 
 ADC_HandleTypeDef hadc;
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
 {
   ADC_InjectionConfTypeDef sConfigInjected;
-  /**Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion) 
+ 
+  // check if all pins belong to the same ADC
+  ADC_TypeDef* adc_pin1 = (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[0]), PinMap_ADC);
+  ADC_TypeDef* adc_pin2 = (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[1]), PinMap_ADC);
+  ADC_TypeDef* adc_pin3 = _isset(cs_params->pins[2]) ? (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[2]), PinMap_ADC) : nullptr;
+ if ( (adc_pin1 != adc_pin2) || ( (adc_pin3) && (adc_pin1 != adc_pin3) )){
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: Analog pins dont belong to the same ADC!");
+#endif
+  return -1;
+ }
+
+
+ /**Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion) 
   */
   hadc.Instance = (ADC_TypeDef *)pinmap_peripheral(analogInputToPinName(cs_params->pins[0]), PinMap_ADC);
-  SIMPLEFOC_DEBUG("here  adc_init!");
   
   if(hadc.Instance == ADC1) {
-    SIMPLEFOC_DEBUG("adc1");
 #ifdef __HAL_RCC_ADC1_CLK_ENABLE
     __HAL_RCC_ADC1_CLK_ENABLE();
 #endif
@@ -110,7 +38,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   }
 #ifdef ADC2
   else if (hadc.Instance == ADC2) {
-    SIMPLEFOC_DEBUG("adc2");
 #ifdef __HAL_RCC_ADC2_CLK_ENABLE
     __HAL_RCC_ADC2_CLK_ENABLE();
 #endif
@@ -121,7 +48,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
 #endif
 #ifdef ADC3
   else if (hadc.Instance == ADC3) {
-    SIMPLEFOC_DEBUG("adc3");
 #ifdef __HAL_RCC_ADC3_CLK_ENABLE
     __HAL_RCC_ADC3_CLK_ENABLE();
 #endif
@@ -133,49 +59,71 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
 #endif
   } 
 #endif
+#ifdef ADC4
+  else if (hadc.Instance == ADC4) {
+#ifdef __HAL_RCC_ADC4_CLK_ENABLE
+    __HAL_RCC_ADC4_CLK_ENABLE();
+#endif
+#ifdef __HAL_RCC_ADC34_CLK_ENABLE
+    __HAL_RCC_ADC34_CLK_ENABLE();
+#endif
+#if defined(ADC345_COMMON)
+    __HAL_RCC_ADC345_CLK_ENABLE();
+#endif
+  }
+#endif
+#ifdef ADC5
+  else if (hadc.Instance == ADC5) {
+#if defined(ADC345_COMMON)
+    __HAL_RCC_ADC345_CLK_ENABLE();
+#endif
+  }
+#endif
   else{
 #ifdef SIMPLEFOC_STM32_DEBUG
     SIMPLEFOC_DEBUG("STM32-CS: ERR: Pin does not belong to any ADC!");
 #endif
     return -1; // error not a valid ADC instance
   }
-  
-  SIMPLEFOC_DEBUG("here  configure start!");
+
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: Using ADC: ", _adcToIndex(&hadc)+1);
+#endif
+
   hadc.Init.ClockPrescaler =  ADC_CLOCK_SYNC_PCLK_DIV4;
   hadc.Init.Resolution = ADC_RESOLUTION_12B;
-  // hadc.Init.ScanConvMode = ADC_SCAN_ENABLE;
-  // hadc.Init.ContinuousConvMode = DISABLE;
-  // hadc.Init.LowPowerAutoWait = DISABLE;
-  // hadc.Init.GainCompensation = 0;
-  // hadc.Init.DiscontinuousConvMode = DISABLE;
-  // hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-  // hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START; // for now
-  // hadc.Init.DataAlign = ADC_DATAALIGN_RIGHT;
-  // hadc.Init.NbrOfConversion = 1;
-  // hadc.Init.DMAContinuousRequests = DISABLE;
-  // hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  // hadc.Init.Overrun = ADC_OVR_DATA_PRESERVED;
+  hadc.Init.ScanConvMode = ADC_SCAN_ENABLE;
+  hadc.Init.ContinuousConvMode = DISABLE;
+  hadc.Init.LowPowerAutoWait = DISABLE;
+  hadc.Init.GainCompensation = 0;
+  hadc.Init.DiscontinuousConvMode = DISABLE;
+  hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+  hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START; // for now
+  hadc.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+  hadc.Init.NbrOfConversion = 2;
+  hadc.Init.DMAContinuousRequests = DISABLE;
+  hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+  hadc.Init.Overrun = ADC_OVR_DATA_PRESERVED;
   if ( HAL_ADC_Init(&hadc) != HAL_OK){
 #ifdef SIMPLEFOC_STM32_DEBUG
     SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init ADC!");
 #endif
     return -1;
   }
-  /**Configure for the selected ADC regular channel to be converted. 
-  */
     
   /**Configures for the selected ADC injected channel its corresponding rank in the sequencer and its sample time 
     */
   sConfigInjected.InjectedNbrOfConversion = _isset(cs_params->pins[2]) ? 3 : 2;
   sConfigInjected.InjectedSamplingTime = ADC_SAMPLETIME_2CYCLES_5;
   sConfigInjected.ExternalTrigInjecConvEdge = ADC_EXTERNALTRIGINJECCONV_EDGE_RISING;  
-  // sConfigInjected.AutoInjectedConv = DISABLE;
-  // sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
-  // sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
-  // sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
-  // sConfigInjected.InjectedOffset = 0;
+  sConfigInjected.AutoInjectedConv = DISABLE;
+  sConfigInjected.InjectedSingleDiff = ADC_SINGLE_ENDED;
+  sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
+  sConfigInjected.InjectedOffsetNumber = ADC_OFFSET_NONE;
+  sConfigInjected.InjectedOffset = 0;
+  sConfigInjected.InjecOversamplingMode = DISABLE;
+  sConfigInjected.QueueInjectedContext = DISABLE;
 
-  SIMPLEFOC_DEBUG("here  timer search start!");
   // automating TRGO flag finding - hardware specific
   uint8_t tim_num = 0;
   while(driver_params->timers[tim_num] != NP && tim_num < 6){
@@ -198,49 +146,75 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
 #endif
     return -1;
   }
-  // display which timer is being used
-#ifdef SIMPLEFOC_STM32_DEBUG
-    // it would be better to use the getTimerNumber from driver
-    SIMPLEFOC_DEBUG("STM32-CS: injected trigger for timer index: ", get_timer_index(cs_params->timer_handle->getHandle()->Instance) + 1);
-#endif
 
-  SIMPLEFOC_DEBUG("here  timer search done!");
-  SIMPLEFOC_DEBUG("here  injected config done!");
 
   // first channel
   sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1;
-  sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[0]), PinMap_ADC));
+  sConfigInjected.InjectedChannel = _getADCChannel(analogInputToPinName(cs_params->pins[0]));
   if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
 #ifdef SIMPLEFOC_STM32_DEBUG
-    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[0]), PinMap_ADC)) );
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)_getADCChannel(analogInputToPinName(cs_params->pins[0])) );
 #endif
     return -1;
   }
+
   // second channel
   sConfigInjected.InjectedRank = ADC_INJECTED_RANK_2;
-  sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[1]), PinMap_ADC));
+  sConfigInjected.InjectedChannel = _getADCChannel(analogInputToPinName(cs_params->pins[1]));
   if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
 #ifdef SIMPLEFOC_STM32_DEBUG
-    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[1]), PinMap_ADC)) );
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)_getADCChannel(analogInputToPinName(cs_params->pins[1]))) ;
 #endif
     return -1;
   }
+
   // third channel - if exists
   if(_isset(cs_params->pins[2])){
     sConfigInjected.InjectedRank = ADC_INJECTED_RANK_3;
-    sConfigInjected.InjectedChannel = STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[2]), PinMap_ADC));
+    sConfigInjected.InjectedChannel = _getADCChannel(analogInputToPinName(cs_params->pins[2]));
     if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
 #ifdef SIMPLEFOC_STM32_DEBUG
-      SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)STM_PIN_CHANNEL(pinmap_function(analogInputToPinName(cs_params->pins[2]), PinMap_ADC)) );
+      SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)_getADCChannel(analogInputToPinName(cs_params->pins[2]))) ;
 #endif
       return -1;
     }
   }
   
-  SIMPLEFOC_DEBUG("here  injected config done!");
-  // enable interrupt
-  HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-  HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+
+ 
+  if(hadc.Instance == ADC1) {
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+  }
+#ifdef ADC2
+  else if (hadc.Instance == ADC2) {
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+  }
+#endif
+#ifdef ADC3
+  else if (hadc.Instance == ADC3) {
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC3_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC3_IRQn);
+  } 
+#endif
+#ifdef ADC4
+  else if (hadc.Instance == ADC4) {
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC4_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC4_IRQn);
+  } 
+#endif
+#ifdef ADC5
+  else if (hadc.Instance == ADC5) {
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC5_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC5_IRQn);
+  } 
+#endif
   
   cs_params->adc_handle = &hadc;
   return 0;
@@ -268,6 +242,26 @@ extern "C" {
   {
       HAL_ADC_IRQHandler(&hadc);
   }
+#ifdef ADC3
+  void ADC3_IRQHandler(void)
+  {
+      HAL_ADC_IRQHandler(&hadc);
+  }
+#endif
+
+#ifdef ADC4
+  void ADC4_IRQHandler(void)
+  {
+      HAL_ADC_IRQHandler(&hadc);
+  }
+#endif
+
+#ifdef ADC5
+  void ADC5_IRQHandler(void)
+  {
+      HAL_ADC_IRQHandler(&hadc);
+  }
+#endif
 }
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
@@ -9,6 +9,7 @@
 #include "../../../../common/foc_utils.h"
 #include "../../../../drivers/hardware_specific/stm32_mcu.h"
 #include "../stm32_mcu.h"
+#include "stm32g4_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
 void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_utils.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_utils.cpp
@@ -1,0 +1,237 @@
+#include "stm32g4_utils.h"
+
+#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
+
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin)
+{
+  uint32_t function = pinmap_function(pin, PinMap_ADC);
+  uint32_t channel = 0;
+  switch (STM_PIN_CHANNEL(function)) {
+#ifdef ADC_CHANNEL_0
+    case 0:
+      channel = ADC_CHANNEL_0;
+      break;
+#endif
+    case 1:
+      channel = ADC_CHANNEL_1;
+      break;
+    case 2:
+      channel = ADC_CHANNEL_2;
+      break;
+    case 3:
+      channel = ADC_CHANNEL_3;
+      break;
+    case 4:
+      channel = ADC_CHANNEL_4;
+      break;
+    case 5:
+      channel = ADC_CHANNEL_5;
+      break;
+    case 6:
+      channel = ADC_CHANNEL_6;
+      break;
+    case 7:
+      channel = ADC_CHANNEL_7;
+      break;
+    case 8:
+      channel = ADC_CHANNEL_8;
+      break;
+    case 9:
+      channel = ADC_CHANNEL_9;
+      break;
+    case 10:
+      channel = ADC_CHANNEL_10;
+      break;
+    case 11:
+      channel = ADC_CHANNEL_11;
+      break;
+    case 12:
+      channel = ADC_CHANNEL_12;
+      break;
+    case 13:
+      channel = ADC_CHANNEL_13;
+      break;
+    case 14:
+      channel = ADC_CHANNEL_14;
+      break;
+    case 15:
+      channel = ADC_CHANNEL_15;
+      break;
+#ifdef ADC_CHANNEL_16
+    case 16:
+      channel = ADC_CHANNEL_16;
+      break;
+#endif
+    case 17:
+      channel = ADC_CHANNEL_17;
+      break;
+#ifdef ADC_CHANNEL_18
+    case 18:
+      channel = ADC_CHANNEL_18;
+      break;
+#endif
+#ifdef ADC_CHANNEL_19
+    case 19:
+      channel = ADC_CHANNEL_19;
+      break;
+#endif
+#ifdef ADC_CHANNEL_20
+    case 20:
+      channel = ADC_CHANNEL_20;
+      break;
+    case 21:
+      channel = ADC_CHANNEL_21;
+      break;
+    case 22:
+      channel = ADC_CHANNEL_22;
+      break;
+    case 23:
+      channel = ADC_CHANNEL_23;
+      break;
+#ifdef ADC_CHANNEL_24
+    case 24:
+      channel = ADC_CHANNEL_24;
+      break;
+    case 25:
+      channel = ADC_CHANNEL_25;
+      break;
+    case 26:
+      channel = ADC_CHANNEL_26;
+      break;
+#ifdef ADC_CHANNEL_27
+    case 27:
+      channel = ADC_CHANNEL_27;
+      break;
+    case 28:
+      channel = ADC_CHANNEL_28;
+      break;
+    case 29:
+      channel = ADC_CHANNEL_29;
+      break;
+    case 30:
+      channel = ADC_CHANNEL_30;
+      break;
+    case 31:
+      channel = ADC_CHANNEL_31;
+      break;
+#endif
+#endif
+#endif
+    default:
+      _Error_Handler("ADC: Unknown adc channel", (int)(STM_PIN_CHANNEL(function)));
+      break;
+  }
+  return channel;
+}
+
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc_ex.h#L217
+uint32_t _timerToInjectedTRGO(HardwareTimer* timer){
+  if(timer->getHandle()->Instance == TIM1)  
+    return ADC_EXTERNALTRIGINJEC_T1_TRGO;
+#ifdef TIM2 // if defined timer 2
+  else if(timer->getHandle()->Instance == TIM2) 
+    return ADC_EXTERNALTRIGINJEC_T2_TRGO;
+#endif
+#ifdef TIM3 // if defined timer 3
+  else if(timer->getHandle()->Instance == TIM3) 
+    return ADC_EXTERNALTRIGINJEC_T3_TRGO;
+#endif
+#ifdef TIM4 // if defined timer 4
+  else if(timer->getHandle()->Instance == TIM4) 
+    return ADC_EXTERNALTRIGINJEC_T4_TRGO;
+#endif
+#ifdef TIM6 // if defined timer 6
+  else if(timer->getHandle()->Instance == TIM6) 
+    return ADC_EXTERNALTRIGINJEC_T6_TRGO;
+#endif
+#ifdef TIM7 // if defined timer 7
+  else if(timer->getHandle()->Instance == TIM7) 
+    return ADC_EXTERNALTRIGINJEC_T7_TRGO;
+#endif
+#ifdef TIM8 // if defined timer 8
+  else if(timer->getHandle()->Instance == TIM8) 
+    return ADC_EXTERNALTRIGINJEC_T8_TRGO;
+#endif
+#ifdef TIM15 // if defined timer 15
+  else if(timer->getHandle()->Instance == TIM15) 
+    return ADC_EXTERNALTRIGINJEC_T15_TRGO;
+#endif
+#ifdef TIM20 // if defined timer 15
+  else if(timer->getHandle()->Instance == TIM20) 
+    return ADC_EXTERNALTRIGINJEC_T20_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc.h#L519
+uint32_t _timerToRegularTRGO(HardwareTimer* timer){
+  if(timer->getHandle()->Instance == TIM1)  
+    return ADC_EXTERNALTRIG_T1_TRGO;
+#ifdef TIM2 // if defined timer 2
+  else if(timer->getHandle()->Instance == TIM2) 
+    return ADC_EXTERNALTRIG_T2_TRGO;
+#endif
+#ifdef TIM3 // if defined timer 3
+  else if(timer->getHandle()->Instance == TIM3) 
+    return ADC_EXTERNALTRIG_T3_TRGO;
+#endif
+#ifdef TIM4 // if defined timer 4
+  else if(timer->getHandle()->Instance == TIM4) 
+    return ADC_EXTERNALTRIG_T4_TRGO;
+#endif
+#ifdef TIM6 // if defined timer 6
+  else if(timer->getHandle()->Instance == TIM6) 
+    return ADC_EXTERNALTRIG_T6_TRGO;
+#endif
+#ifdef TIM7 // if defined timer 7
+  else if(timer->getHandle()->Instance == TIM7) 
+    return ADC_EXTERNALTRIG_T7_TRGO;
+#endif
+#ifdef TIM8 // if defined timer 8
+  else if(timer->getHandle()->Instance == TIM8) 
+    return ADC_EXTERNALTRIG_T7_TRGO;
+#endif
+#ifdef TIM15 // if defined timer 15
+  else if(timer->getHandle()->Instance == TIM15) 
+    return ADC_EXTERNALTRIG_T15_TRGO;
+#endif
+#ifdef TIM20 // if defined timer 15
+  else if(timer->getHandle()->Instance == TIM20) 
+    return ADC_EXTERNALTRIG_T20_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+
+int _adcToIndex(ADC_TypeDef *AdcHandle){
+  if(AdcHandle == ADC1) return 0;
+#ifdef ADC2 // if ADC2 exists
+  else if(AdcHandle == ADC2) return 1;
+#endif
+#ifdef ADC3 // if ADC3 exists
+  else if(AdcHandle == ADC3) return 2;
+#endif
+#ifdef ADC4 // if ADC4 exists
+  else if(AdcHandle == ADC4) return 3;
+#endif
+#ifdef ADC5 // if ADC5 exists
+  else if(AdcHandle == ADC5) return 4;
+#endif
+  return 0;
+}
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
+  return _adcToIndex(AdcHandle->Instance);
+}
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_utils.h
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_utils.h
@@ -1,0 +1,34 @@
+
+#ifndef STM32G4_UTILS_HAL
+#define STM32G4_UTILS_HAL
+
+#include "Arduino.h"
+
+#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
+
+#define _TRGO_NOT_AVAILABLE 12345
+
+
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin);
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc_ex.h#L217
+uint32_t _timerToInjectedTRGO(HardwareTimer* timer);
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/6588dee03382e73ed42c4a5e473900ab3b79d6e4/system/Drivers/STM32G4xx_HAL_Driver/Inc/stm32g4xx_hal_adc.h#L519
+uint32_t _timerToRegularTRGO(HardwareTimer* timer);
+
+// function returning index of the ADC instance
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle);
+int _adcToIndex(ADC_TypeDef *AdcHandle);
+
+#endif
+
+#endif

--- a/src/current_sense/hardware_specific/teensy_mcu.cpp
+++ b/src/current_sense/hardware_specific/teensy_mcu.cpp
@@ -9,8 +9,8 @@
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){
   _UNUSED(driver_params);
 
-  pinMode(pinA, INPUT);
-  pinMode(pinB, INPUT);
+  if( _isset(pinA) ) pinMode(pinA, INPUT);
+  if( _isset(pinB) ) pinMode(pinB, INPUT);
   if( _isset(pinC) ) pinMode(pinC, INPUT);
 
   GenericCurrentSenseParams* params = new GenericCurrentSenseParams {

--- a/src/drivers/hardware_specific/atmega2560_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega2560_mcu.cpp
@@ -146,8 +146,8 @@ void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, cons
   ret_flag += _configureComplementaryPair(pinC_h, pinC_l);
   if (ret_flag!=0) return SIMPLEFOC_DRIVER_INIT_FAILED;
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pinA_h,, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
-    .pwm_frequency = pwm_frequency
+    .pins = { pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency,
     .dead_zone = dead_zone
   };
   return params;

--- a/src/drivers/hardware_specific/atmega32u4_mcu.cpp
+++ b/src/drivers/hardware_specific/atmega32u4_mcu.cpp
@@ -158,8 +158,8 @@ void* _configure6PWM(long pwm_frequency, float dead_zone, const int pinA_h, cons
   ret_flag += _configureComplementaryPair(pinC_h, pinC_l);
   if (ret_flag!=0) return SIMPLEFOC_DRIVER_INIT_FAILED;
   GenericDriverParams* params = new GenericDriverParams {
-    .pins = { pinA_h,, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
-    .pwm_frequency = pwm_frequency
+    .pins = { pinA_h, pinA_l, pinB_h, pinB_l, pinC_h, pinC_l },
+    .pwm_frequency = pwm_frequency,
     .dead_zone = dead_zone
   };
   return params;

--- a/src/drivers/hardware_specific/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32_mcu.cpp
@@ -4,6 +4,9 @@
 
 #if defined(_STM32_DEF_)
 
+
+//#define SIMPLEFOC_STM32_DEBUG
+
 #ifdef SIMPLEFOC_STM32_DEBUG
 void printTimerCombination(int numPins, PinMap* timers[], int score);
 int getTimerNumber(int timerIndex);


### PR DESCRIPTION
Now, that all the ADC stuff for the B-G431B-ESC1 board is in hardware specific files anyway, I see no value in not supporting the additional ADC channels for the bus voltage, temp sensor and poti. The code for these was proposed long time ago already by @HoeckDK on the SimpleFOC community forum. To read e.g. the temp sensor of the board, apply this PR and the call 

float Temp = _readADCVoltageInline(A_TEMPERATURE, currentSense.params);

It would be cool if this PR was accepted, this would safe me quite some time to apply it to all new versions over and over again...