### PR TITLE
Added changes to use additional ADC channels

### DIFF
--- a/src/current_sense/hardware_specific/stm32/b_g431/b_g431_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/b_g431/b_g431_hal.cpp
@@ -95,7 +95,7 @@ void  MX_ADC1_Init(ADC_HandleTypeDef* hadc1)
   hadc1->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
   hadc1->Init.LowPowerAutoWait = DISABLE;
   hadc1->Init.ContinuousConvMode = DISABLE;
-  hadc1->Init.NbrOfConversion = 2;
+  hadc1->Init.NbrOfConversion = 5;
   hadc1->Init.DiscontinuousConvMode = DISABLE;
   hadc1->Init.ExternalTrigConv = ADC_EXTERNALTRIG_T1_TRGO;
   hadc1->Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_RISING;
@@ -130,6 +130,47 @@ void  MX_ADC1_Init(ADC_HandleTypeDef* hadc1)
   */
   sConfig.Channel = ADC_CHANNEL_3;  // ADC1_IN3 = PA2 = OP1_OUT
   sConfig.Rank = ADC_REGULAR_RANK_2;
+  if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+  {
+    SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+  }
+
+  //******************************************************************
+  // Temp, Poti ....
+  /* Configure Regular Channel (PB12, Potentiometer)
+  */
+  sConfig.Channel = ADC_CHANNEL_11;
+  sConfig.Rank = ADC_REGULAR_RANK_3;
+  sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+  sConfig.SingleDiff = ADC_SINGLE_ENDED;
+  sConfig.OffsetNumber = ADC_OFFSET_NONE;
+  sConfig.Offset = 0;
+  if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+  {
+    SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+  }
+
+  /** Configure Regular Channel (PB14, Temperature)
+  */
+  sConfig.Channel = ADC_CHANNEL_5;
+  sConfig.Rank = ADC_REGULAR_RANK_4;
+  sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+  sConfig.SingleDiff = ADC_SINGLE_ENDED;
+  sConfig.OffsetNumber = ADC_OFFSET_NONE;
+  sConfig.Offset = 0;
+  if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
+  {
+    SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");
+  }
+
+  /** Configure Regular Channel (PB14, Temperature)
+  */
+  sConfig.Channel = ADC_CHANNEL_1;
+  sConfig.Rank = ADC_REGULAR_RANK_5;
+  sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
+  sConfig.SingleDiff = ADC_SINGLE_ENDED;
+  sConfig.OffsetNumber = ADC_OFFSET_NONE;
+  sConfig.Offset = 0;
   if (HAL_ADC_ConfigChannel(hadc1, &sConfig) != HAL_OK)
   {
     SIMPLEFOC_DEBUG("HAL_ADC_ConfigChannel failed!");

--- a/src/current_sense/hardware_specific/stm32/b_g431/b_g431_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/b_g431/b_g431_mcu.cpp
@@ -10,7 +10,7 @@
 
 #define _ADC_VOLTAGE 3.3f
 #define _ADC_RESOLUTION 4096.0f
-#define ADC_BUF_LEN_1 2
+#define ADC_BUF_LEN_1 5
 #define ADC_BUF_LEN_2 1
 
 static ADC_HandleTypeDef hadc1;
@@ -37,6 +37,14 @@ float _readADCVoltageInline(const int pin, const void* cs_params){
   else if(pin == PB1) // = ADC1_IN12 = phase W (OP3_OUT) on B-G431B-ESC1
     raw_adc = adcBuffer1[0];
 #endif
+
+  else if (pin == A_POTENTIOMETER)
+    raw_adc = adcBuffer1[2];
+  else if (pin == A_TEMPERATURE)
+    raw_adc = adcBuffer1[3];
+  else if (pin == A_VBUS)
+    raw_adc = adcBuffer1[4];
+
   return raw_adc * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
 }
 


### PR DESCRIPTION
Now, that all the ADC stuff for the B-G431B-ESC1 board is in hardware specific files anyway, I see no value in not supporting the additional ADC channels for the bus voltage, temp sensor and poti. The code for these was proposed long time ago already by @HoeckDK on the SimpleFOC community forum. To read e.g. the temp sensor of the board, apply this PR and the call

float Temp = _readADCVoltageInline(A_TEMPERATURE, currentSense.params);

It would be cool if this PR was accepted, this would safe me quite some time to apply it to all new versions over and over again...