### PR TITLE
STM32 driver improvements & PWM sensor bugfix

### DIFF
--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -28,7 +28,7 @@ class BLDCMotor: public FOCMotor
      * 
      * @param driver BLDCDriver class implementing all the hardware specific functions necessary PWM setting
      */
-    void linkDriver(BLDCDriver* driver);
+    virtual void linkDriver(BLDCDriver* driver);
 
     /** 
       * BLDCDriver link:

--- a/src/drivers/hardware_api.h
+++ b/src/drivers/hardware_api.h
@@ -6,6 +6,27 @@
 #include "../communication/SimpleFOCDebug.h"
 
 
+// these defines determine the polarity of the PWM output. Normally, the polarity is active-high,
+// i.e. a high-level PWM output is expected to switch on the MOSFET. But should your driver design
+// require inverted polarity, you can change the defines below, or set them via your build environment
+// or board definition files.
+
+// used for 1-PWM, 2-PWM, 3-PWM, and 4-PWM modes
+#ifndef SIMPLEFOC_PWM_ACTIVE_HIGH
+#define SIMPLEFOC_PWM_ACTIVE_HIGH true
+#endif
+// used for 6-PWM mode, high-side
+#ifndef SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH
+#define SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH true
+#endif
+// used for 6-PWM mode, low-side
+#ifndef SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH
+#define SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH true
+#endif
+
+
+
+
 // flag returned if driver init fails
 #define SIMPLEFOC_DRIVER_INIT_FAILED ((void*)-1)
 

--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -9,24 +9,6 @@
 #include "../hardware_api.h"
 #include "./rp2040_mcu.h"
 
-// these defines determine the polarity of the PWM output. Normally, the polarity is active-high,
-// i.e. a high-level PWM output is expected to switch on the MOSFET. But should your driver design
-// require inverted polarity, you can change the defines below, or set them via your build environment
-// or board definition files.
-
-// used for 2-PWM, 3-PWM, and 4-PWM modes
-#ifndef SIMPLEFOC_PWM_ACTIVE_HIGH
-#define SIMPLEFOC_PWM_ACTIVE_HIGH true
-#endif
-// used fof 6-PWM mode, high-side
-#ifndef SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH
-#define SIMPLEFOC_PWM_HIGHSIDE_ACTIVE_HIGH true
-#endif
-// used fof 6-PWM mode, low-side
-#ifndef SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH
-#define SIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH true
-#endif
-
 
 #define _PWM_FREQUENCY 24000
 #define _PWM_FREQUENCY_MAX 66000

--- a/src/sensors/MagneticSensorPWM.cpp
+++ b/src/sensors/MagneticSensorPWM.cpp
@@ -35,7 +35,7 @@ void MagneticSensorPWM::init(){
 float MagneticSensorPWM::getSensorAngle(){
     // raw data from sensor
     raw_count = getRawCount();
-    return( (float) (raw_count) / (float)cpr) * _2PI;
+    return( (float) (raw_count - min_raw_count) / (float)cpr) * _2PI;
 }
 
 


### PR DESCRIPTION
- add 1-PWM mode to STM32 driver
- make linkDriver() function virtual in FOCMotor so we can override it
- add polarity control via -D SIMPLEFOC_PWM_ACTIVE_HIGH=true/false to STM32 driver
- use the min_raw_count in PWM sensor