### PR TITLE
support for earlephilhower/arduino-pico

### DIFF
--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -7,6 +7,7 @@
 #define SIMPLEFOC_DEBUG_RP2040
 
 #include "../hardware_api.h"
+#include "hardware/pwm.h"
 
 
 // these defines determine the polarity of the PWM output. Normally, the polarity is active-high,


### PR DESCRIPTION
Some PWM functions (like `pwm_gpio_to_slice_num`) are not found in the scope when using arduino-pico board library from @earlephilhower. Adding `#include "hardware/pwm.h"` solve the problems for me.