### PR TITLE
compile time fix for rp2040 - include hardware/pwm.h

### DIFF
--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -7,6 +7,7 @@
 #define SIMPLEFOC_DEBUG_RP2040
 
 #include "../hardware_api.h"
+#include <hardware/pwm.h>
 
 
 // these defines determine the polarity of the PWM output. Normally, the polarity is active-high,


### PR DESCRIPTION
Without this include I get many declaration errors such as:
`error: 'pwm_gpio_to_slice_num' was not declared in this scope`
