### PR TITLE
Fix for issue #270

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,24 @@ Therefore this is an attempt to:
    - See also [@byDagor](https://github.com/byDagor)'s *fully-integrated* ESP32 based board: [Dagor Brushless Controller](https://github.com/byDagor/Dagor-Brushless-Controller)
 
 > NEXT RELEASE 📢 : <span class="simple">Simple<span class="foc">FOC</span>library</span> v2.3.0
+> - Arduino Mega 6pwm more timers supported 
+> - Arduino boards - frequency change support either 32kHz or 4kHz
+> - Arduino Uno - synched timers in 3pwm and 6pwm mode [#71](https://github.com/simplefoc/Arduino-FOC/issues/71)
 > - Teensy 3.x initial support for 6pwm
 > - Teensy 4.x initial support for 6pwm
 > - Example for v3.1 SimpleFOCShield 
+> - RP2040 compatibility for earlehillpower core [#234](https://github.com/simplefoc/Arduino-FOC/pull/234) [#236](https://github.com/simplefoc/Arduino-FOC/pull/236)
 > - More flexible monitoring API 
 >   - start, end and separator characters
 >   - decimal places (settable through commander)
+> - Added machine readable verbose mode in `Commander` [#233](https://github.com/simplefoc/Arduino-FOC/pull/233)
+> - *Simple**FOC**WebController* - Web based user interface for SimpleFOC by [@geekuillaume](https://github.com/geekuillaume) - [webcontroller.simplefoc.com](webcontroller.simplefoc.com)
+> - bugfix - `MagneticSensorPWM` multiple occasions - [#258](https://github.com/simplefoc/Arduino-FOC/pull/258)
 > - bugfix - current sense align - added offset exchange when exchanging pins
 > - bugfix - trapezoid 150 fixed
+> - bugfix - 4pwm on ESP8266 [#224](https://github.com/simplefoc/Arduino-FOC/pull/224)
+> - Additional `InlineCurrentSense` and `LowsideCurrentSense` constructor using milliVolts per Amp [#253](https://github.com/simplefoc/Arduino-FOC/pull/253)
+> - STM32L4xx current sense support by [@Triple6](https://github.com/Triple6) (discord) [#257](https://github.com/simplefoc/Arduino-FOC/pull/257)
 > - phase disable in 6pwm mode 
 >   - stm32 - software and hardware 6pwm
 >   - atmega328 
@@ -41,7 +51,7 @@ Therefore this is an attempt to:
 >   - current control through voltage torque mode enhancement
 >   - extended `BLDCMotor` and `StepperMotor` constructors to receive the inductance paramerer
 >   - can also be set using `motor.phase_inductance` or through `Commander`
-## Arduino *SimpleFOClibrary* v2.2.3
+## Arduino *SimpleFOClibrary* v2.3
 
 <p align="">
 <a href="https://youtu.be/Y5kLeqTc6Zk">
@@ -223,11 +233,3 @@ If you are interested in citing  *Simple**FOC**library* or some other component 
 }
 
 ```
-
-
-## Arduino FOC repo structure
-Branch  | Description | Status
------------- | ------------- | ------------ 
-[master](https://github.com/simplefoc/Arduino-FOC) | Stable and tested library version | ![Library Compile](https://github.com/simplefoc/Arduino-FOC/workflows/Library%20Compile/badge.svg)
-[dev](https://github.com/simplefoc/Arduino-FOC/tree/dev) | Development library version | ![Library Dev Compile](https://github.com/simplefoc/Arduino-FOC/workflows/Library%20Dev%20Compile/badge.svg?branch=dev)
-[minimal](https://github.com/simplefoc/Arduino-FOC/tree/minimal) | Minimal Arduino example with integrated library | ![MinimalBuild](https://github.com/simplefoc/Arduino-FOC/workflows/MinimalBuild/badge.svg?branch=minimal)

--- a/keywords.txt
+++ b/keywords.txt
@@ -135,6 +135,7 @@ zero_electric_angle	KEYWORD2
 verbose	KEYWORD2
 decimal_places	KEYWORD2
 phase_resistance	KEYWORD2
+phase_inductance	KEYWORD2
 modulation_centered	KEYWORD2
 
 
@@ -168,6 +169,10 @@ voltage_power_supply	KEYWORD2
 voltage_sensor_align	KEYWORD2
 velocity_index_search	KEYWORD2
 monitor_downsample	KEYWORD2
+monitor_start_char	KEYWORD2
+monitor_end_char	KEYWORD2
+monitor_separator	KEYWORD2
+monitor_decimals	KEYWORD2
 monitor_variables	KEYWORD2
 motion_downsample	KEYWORD2
 

--- a/src/common/base_classes/Sensor.h
+++ b/src/common/base_classes/Sensor.h
@@ -42,6 +42,7 @@ enum Pullup : uint8_t {
  * 
  */
 class Sensor{
+	friend class SmoothingSensor;
     public:
         /**
          * Get mechanical shaft angle in the range 0 to 2PI. This value will be as precise as possible with

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -62,7 +62,7 @@ void Commander::run(char* user_input){
   switch(id){
     case CMD_SCAN:
       for(int i=0; i < call_count; i++){
-          printMachineReadable(F("?"));
+          printMachineReadable(CMD_SCAN);
           print(call_ids[i]);
           print(":");
           if(call_label[i]) println(call_label[i]);
@@ -72,6 +72,7 @@ void Commander::run(char* user_input){
     case CMD_VERBOSE:
       if(!isSentinel(user_input[1])) verbose = (VerboseMode)atoi(&user_input[1]);
       printVerbose(F("Verb:"));
+      printMachineReadable(CMD_VERBOSE);
       switch (verbose){
       case VerboseMode::nothing:
         println(F("off!"));
@@ -88,7 +89,7 @@ void Commander::run(char* user_input){
     case CMD_DECIMAL:
       if(!isSentinel(user_input[1])) decimal_places = atoi(&user_input[1]);
       printVerbose(F("Decimal:"));
-      printMachineReadable(F("#"));
+      printMachineReadable(CMD_DECIMAL);
       println(decimal_places);
       break;
     default:

--- a/src/current_sense/LowsideCurrentSense.cpp
+++ b/src/current_sense/LowsideCurrentSense.cpp
@@ -25,7 +25,7 @@ LowsideCurrentSense::LowsideCurrentSense(float _mVpA, int _pinA, int _pinB, int 
     pinB = _pinB;
     pinC = _pinC;
 
-    volts_to_amps_ratio = _mVpA / 1000.0f; // mV to amps
+    volts_to_amps_ratio = 1000.0f / _mVpA; // mV to amps
     // gains for each phase
     gain_a = volts_to_amps_ratio;
     gain_b = volts_to_amps_ratio;

--- a/src/sensors/HallSensor.cpp
+++ b/src/sensors/HallSensor.cpp
@@ -94,8 +94,13 @@ void HallSensor::attachSectorCallback(void (*_onSectorChange)(int sector)) {
 
 
 
-float HallSensor::getSensorAngle() {
-  return getAngle();
+// Sensor update function. Safely copy volatile interrupt variables into Sensor base class state variables.
+void HallSensor::update() {
+  noInterrupts();
+  angle_prev = ((float)((electric_rotations * 6 + electric_sector) % cpr) / (float)cpr) * _2PI ;
+  full_rotations = (int32_t)((electric_rotations * 6 + electric_sector) / cpr);
+  angle_prev_ts = pulse_timestamp;
+  interrupts();
 }
 
 
@@ -104,8 +109,8 @@ float HallSensor::getSensorAngle() {
 	Shaft angle calculation
   TODO: numerical precision issue here if the electrical rotation overflows the angle will be lost
 */
-float HallSensor::getMechanicalAngle() {
-  return ((float)((electric_rotations * 6 + electric_sector) % cpr) / (float)cpr) * _2PI ;
+float HallSensor::getSensorAngle() {
+  return ((float)(electric_rotations * 6 + electric_sector) / (float)cpr) * _2PI ;
 }
 
 /*
@@ -113,35 +118,13 @@ float HallSensor::getMechanicalAngle() {
   function using mixed time and frequency measurement technique
 */
 float HallSensor::getVelocity(){
-  long last_pulse_diff = pulse_diff;
-  if (last_pulse_diff == 0 || ((long)(_micros() - pulse_timestamp) > last_pulse_diff) ) { // last velocity isn't accurate if too old
-    return 0;
-  } else {
-    float vel = direction * (_2PI / (float)cpr) / (last_pulse_diff / 1000000.0f);
-    // quick fix https://github.com/simplefoc/Arduino-FOC/issues/192
-    if(vel < -velocity_max || vel > velocity_max)  vel = 0.0f;   //if velocity is out of range then make it zero
-    return vel;
-  }
-
+  noInterrupts();
+  float vel = 0;
+  if (pulse_diff != 0 && ((long)(_micros() - pulse_timestamp) < pulse_diff*2) ) // last velocity isn't accurate if too old
+    vel = direction * (_2PI / (float)cpr) / (pulse_diff / 1000000.0f);
+  interrupts();
+  return vel;
 }
-
-
-
-float HallSensor::getAngle() {
-  return ((float)(electric_rotations * 6 + electric_sector) / (float)cpr) * _2PI ;
-}
-
-
-double HallSensor::getPreciseAngle() {
-  return ((double)(electric_rotations * 6 + electric_sector) / (double)cpr) * (double)_2PI ;
-}
-
-
-int32_t HallSensor::getFullRotations() {
-  return (int32_t)((electric_rotations * 6 + electric_sector) / cpr);
-}
-
-
 
 
 

--- a/src/sensors/HallSensor.h
+++ b/src/sensors/HallSensor.h
@@ -53,14 +53,12 @@ class HallSensor: public Sensor{
     int cpr;//!< HallSensor cpr number
 
     // Abstract functions of the Sensor class implementation
+    /** Interrupt-safe update */
+    void update() override;
     /** get current angle (rad) */
     float getSensorAngle() override;
-    float getMechanicalAngle() override;
-    float getAngle() override;
     /**  get current angular velocity (rad/s) */
     float getVelocity() override;
-    double getPreciseAngle() override;
-    int32_t getFullRotations() override;
 
     // whether last step was CW (+1) or CCW (-1).  
     Direction direction;

--- a/src/sensors/MagneticSensorPWM.cpp
+++ b/src/sensors/MagneticSensorPWM.cpp
@@ -56,8 +56,19 @@ void MagneticSensorPWM::init(){
     // initial hardware
     pinMode(pinPWM, INPUT);
     raw_count = getRawCount();
+    pulse_timestamp = _micros();
     
     this->Sensor::init(); // call base class init
+}
+
+// Sensor update function. Safely copy volatile interrupt variables into Sensor base class state variables.
+void MagneticSensorPWM::update() {
+  if (is_interrupt_based)
+    noInterrupts();
+  Sensor::update();
+  angle_prev_ts = pulse_timestamp; // Timestamp of actual sample, before the time-consuming PWM communication
+  if (is_interrupt_based)
+    interrupts();
 }
 
 // get current angle (rad)
@@ -73,6 +84,7 @@ float MagneticSensorPWM::getSensorAngle(){
 // read the raw counter of the magnetic sensor
 int MagneticSensorPWM::getRawCount(){
     if (!is_interrupt_based){ // if it's not interrupt based read the value in a blocking way
+        pulse_timestamp = _micros(); // ideally this should be done right at the rising edge of the pulse
         pulse_length_us = pulseIn(pinPWM, HIGH);
     }
     return pulse_length_us;
@@ -84,7 +96,10 @@ void MagneticSensorPWM::handlePWM() {
     unsigned long now_us = _micros();
 
     // if falling edge, calculate the pulse length
-    if (!digitalRead(pinPWM)) pulse_length_us = now_us - last_call_us;
+    if (!digitalRead(pinPWM)) {
+        pulse_length_us = now_us - last_call_us;
+        pulse_timestamp = last_call_us; // angle was sampled at the rising edge of the pulse, so use that timestamp
+    }
 
     // save the currrent timestamp for the next call
     last_call_us = now_us;

--- a/src/sensors/MagneticSensorPWM.h
+++ b/src/sensors/MagneticSensorPWM.h
@@ -32,6 +32,9 @@ class MagneticSensorPWM: public Sensor{
     void init();
 
     int pinPWM;
+    
+    // Interrupt-safe update
+    void update() override;
 
     // get current angle (rad)
     float getSensorAngle() override;
@@ -62,6 +65,7 @@ class MagneticSensorPWM: public Sensor{
     // time tracking variables
     unsigned long last_call_us;
     // unsigned long pulse_length_us;
+    unsigned long pulse_timestamp;
     
 
 };


### PR DESCRIPTION
Overhaul of interrupt-based sensors to eliminate bad readings due to interrupts modifying variables in the middle of get functions.

All sensor classes are now required to use the base class state variables, and do their angle reading once per frame in the update() function rather than using the virtual get functions to return real-time updated readings. I have chosen to make an exception for getVelocity() and allow it to access volatile variables as well, although it may be better to merge it into update() instead. Interrupts should be disabled/enabled as necessary in the update() and getVelocity() functions, and preferably nowhere else. The Arduino library provides no mechanism to restore the previous state of interrupts, so use of the unconditional enable should be kept to as few locations as possible so we can be reasonably sure that it won't be called at a time when interrupts should remain disabled.

Additional changes to specific sensors:

HallSensor: Removed the max_velocity variable because it was a quick fix for bad velocity readings that were coming from this interrupt problem, which should no longer occur. Also changed the condition for "velocity too old" from (_micros() - pulse_timestamp) > pulse_diff to (_micros() - pulse_timestamp) > pulse_diff*2, because any deceleration would cause inappropriate reporting of zero velocity.

MagneticSensorPWM: Unrelated to the interrupt problem, timestamp is now saved from the rising edge of the PWM pulse because that's when the angle was sampled, and communicating it takes a significant and variable amount of time. This gives more accurate velocity calculations, and will allow extrapolating accurate angles using the new SmoothingSensor class.

Sensor: Added friend class declaration for SmoothingSensor. Alternatively we could make prev_angle_ts public, and I could use getMechanicalAngle() and getFullRotations() to access the other state variables.