### PR TITLE
RP2040 PWM driver now supports pre-scaler

### DIFF
--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -240,6 +240,7 @@ class Commander
      */
     void motion(FOCMotor* motor, char* user_cmd, char* separator = (char *)" ");
 
+    bool isSentinel(char ch);
   private:
     // Subscribed command callback variables
     CommandCallback call_list[20];//!< array of command callback pointers - 20 is an arbitrary number
@@ -294,7 +295,6 @@ class Commander
 
 
     void printError();
-    bool isSentinel(char ch);
 };
 
 

--- a/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
@@ -30,11 +30,12 @@ void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* para
 	params->pins[index] = pin;
 	params->slice[index] = slice;
 	params->chan[index] = chan;
-	pwm_set_clkdiv_int_frac(slice, 1, 0); // fastest pwm we can get
-	pwm_set_phase_correct(slice, true);
-	uint16_t wrapvalue = ((125L * 1000L * 1000L) / pwm_frequency) / 2L - 1L;
-	if (wrapvalue < 999) wrapvalue = 999; // 66kHz, resolution 1000
-	if (wrapvalue > 12499) wrapvalue = 12499; // 20kHz, resolution 12500
+	uint32_t sysclock_hz = machine.freq();
+	uint32_t factor = 4096 * 2 * pwm_frequency;
+	uint32_t div = sysclock_hz / factor;
+	if (sysclock_hz % factor !=0) div+=1;
+	if (div < 16) div = 16;
+	uint32_t wrapvalue = sysclock_hz *16 / div / pwm_frequency - 1;
 #ifdef SIMPLEFOC_DEBUG_RP2040
 	SimpleFOCDebug::print("Configuring pin ");
 	SimpleFOCDebug::print(pin);
@@ -44,9 +45,17 @@ void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* para
 	SimpleFOCDebug::print((int)chan);
 	SimpleFOCDebug::print(" frequency ");
 	SimpleFOCDebug::print((int)pwm_frequency);
+	SimpleFOCDebug::print(" divisor ");
+	SimpleFOCDebug::print((int)(div>>4));
+	SimpleFOCDebug::print(".");
+	SimpleFOCDebug::print((int)(div&0xF));
 	SimpleFOCDebug::print(" top value ");
 	SimpleFOCDebug::println(wrapvalue);
 #endif
+	if (wrapvalue < 999)
+		SimpleFOCDebug::println("Warning: PWM resolution is low.");
+	pwm_set_clkdiv_int_frac(slice, div>>4, div&0xF);
+	pwm_set_phase_correct(slice, true);
 	pwm_set_wrap(slice, wrapvalue);
 	wrapvalues[slice] = wrapvalue;
 	if (invert) {

--- a/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
@@ -9,10 +9,11 @@
 #include "../../hardware_api.h"
 #include "./rp2040_mcu.h"
 #include "hardware/pwm.h"
+#include "hardware/clocks.h"
 
 #define _PWM_FREQUENCY 24000
 #define _PWM_FREQUENCY_MAX 66000
-#define _PWM_FREQUENCY_MIN 5000
+#define _PWM_FREQUENCY_MIN 1
 
 
 
@@ -30,12 +31,12 @@ void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* para
 	params->pins[index] = pin;
 	params->slice[index] = slice;
 	params->chan[index] = chan;
-	uint32_t sysclock_hz = machine.freq();
+	uint32_t sysclock_hz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS) * 1000;
 	uint32_t factor = 4096 * 2 * pwm_frequency;
 	uint32_t div = sysclock_hz / factor;
 	if (sysclock_hz % factor !=0) div+=1;
 	if (div < 16) div = 16;
-	uint32_t wrapvalue = sysclock_hz *16 / div / pwm_frequency - 1;
+	uint32_t wrapvalue = (sysclock_hz * 8) / div / pwm_frequency - 1;
 #ifdef SIMPLEFOC_DEBUG_RP2040
 	SimpleFOCDebug::print("Configuring pin ");
 	SimpleFOCDebug::print(pin);
@@ -50,7 +51,7 @@ void setupPWM(int pin, long pwm_frequency, bool invert, RP2040DriverParams* para
 	SimpleFOCDebug::print(".");
 	SimpleFOCDebug::print((int)(div&0xF));
 	SimpleFOCDebug::print(" top value ");
-	SimpleFOCDebug::println(wrapvalue);
+	SimpleFOCDebug::println((int)wrapvalue);
 #endif
 	if (wrapvalue < 999)
 		SimpleFOCDebug::println("Warning: PWM resolution is low.");

--- a/src/drivers/hardware_specific/rp2040/rp2040_mcu.h
+++ b/src/drivers/hardware_specific/rp2040/rp2040_mcu.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "Arduino.h"
+
 #if defined(TARGET_RP2040)
 
 


### PR DESCRIPTION
The PWM driver for RP2040 now uses the pre-scaler (which includes a fractional setting) to accurately set any desired PWM frequency between 1Hz and 66kHz. Why so low as 1Hz? To support use cases like controlling a RC-servo (possible via the SimpleDC Library DCDriver1PWM class).