### PR TITLE
Bug-Fixes, including BLDCMotor KV init bug

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -44,7 +44,9 @@ BLDCMotor::BLDCMotor(int pp, float _R, float _KV, float _inductance)
   phase_resistance = _R;
   // save back emf constant KV = 1/KV
   // 1/sqrt(2) - rms value
-  KV_rating = _KV*_SQRT2;
+  KV_rating = NOT_SET;
+  if (_isset(_KV))
+    KV_rating = _KV*_SQRT2;
   // save phase inductance
   phase_inductance = _inductance;
 

--- a/src/current_sense/hardware_specific/rp2040/rp2040_mcu.cpp
+++ b/src/current_sense/hardware_specific/rp2040/rp2040_mcu.cpp
@@ -164,7 +164,6 @@ bool RP2040ADCEngine::init() {
      false,             // We won't see the ERR bit because of 8 bit reads; disable.
      true               // Shift each sample to 8 bits when pushing to FIFO
     );
-    samples_per_second = 20000;
     if (samples_per_second<1 || samples_per_second>=500000) {
         samples_per_second = 0;
         adc_set_clkdiv(0);

--- a/src/current_sense/hardware_specific/rp2040/rp2040_mcu.h
+++ b/src/current_sense/hardware_specific/rp2040/rp2040_mcu.h
@@ -22,6 +22,9 @@
  * Inline sensing is supported by offering a user-selectable fixed ADC sampling rate, which can be set between 500kHz and 1Hz.
  * After starting the engine it will continuously sample and provide new values at the configured rate.
  * 
+ * The default sampling rate is 20kHz, which is suitable for 2 channels assuming you a 5kHz main loop speed (a new measurement is used per
+ * main loop iteration).
+ * 
  * Low-side sensing is currently not supported.
  * 
  * The SimpleFOC PWM driver for RP2040 syncs all the slices, so the PWM trigger is applied to the first used slice. For current
@@ -74,7 +77,7 @@ public:
 
     ADCResults getLastResults(); // TODO find a better API and representation for this
 
-    int samples_per_second = 0; // leave at 0 to convert in tight loop
+    int samples_per_second = 20000; // 20kHz default (assuming 2 shunts and 5kHz loop speed), set to 0 to convert in tight loop
     float adc_conv = (SIMPLEFOC_RP2040_ADC_VDDA / SIMPLEFOC_RP2040_ADC_RESOLUTION); // conversion from raw ADC to float
 
     //int triggerPWMSlice = -1;


### PR DESCRIPTION
RP2040: move default sample rate to header
Move default sample rate of 20kHz to header file so it can be changed by users...

BLDCMotor - KV was being initialised even when _KV was set to NOT_SET