### PR TITLE
Change init logic - remove params from initFOC

### DIFF
--- a/examples/utils/calibration/find_sensor_offset_and_direction/find_sensor_offset_and_direction.ino
+++ b/examples/utils/calibration/find_sensor_offset_and_direction/find_sensor_offset_and_direction.ino
@@ -2,8 +2,9 @@
  * Simple example intended to help users find the zero offset and natural direction of the sensor. 
  * 
  * These values can further be used to avoid motor and sensor alignment procedure. 
- * 
- * motor.initFOC(zero_offset, sensor_direction);
+ * To use these values add them to the code:");
+ *    motor.sensor_direction=Direction::CW; // or Direction::CCW
+ *    motor.zero_electric_angle=1.2345;     // use the real value!
  * 
  * This will only work for abosolute value sensors - magnetic sensors. 
  * Bypassing the alignment procedure is not possible for the encoders and for the current implementation of the Hall sensors. 
@@ -44,6 +45,9 @@ void setup() {
   // set motion control loop to be used
   motor.controller = MotionControlType::torque;
 
+  // force direction search - because default is CW
+  motor.sensor_direction = Direction::UNKNOWN;
+
   // initialize motor
   motor.init();
   // align sensor and start FOC
@@ -54,9 +58,16 @@ void setup() {
   Serial.println("Sensor zero offset is:");
   Serial.println(motor.zero_electric_angle, 4);
   Serial.println("Sensor natural direction is: ");
-  Serial.println(motor.sensor_direction == 1 ? "Direction::CW" : "Direction::CCW");
+  Serial.println(motor.sensor_direction == Direction::CW ? "Direction::CW" : "Direction::CCW");
 
-  Serial.println("To use these values provide them to the: motor.initFOC(offset, direction)");
+  Serial.println("To use these values add them to the code:");
+  Serial.print("   motor.sensor_direction=");
+  Serial.print(motor.sensor_direction == Direction::CW ? "Direction::CW" : "Direction::CCW");
+  Serial.println(";");
+  Serial.print("   motor.zero_electric_angle=");
+  Serial.print(motor.zero_electric_angle, 4);
+  Serial.println(";");
+
   _delay(1000);
   Serial.println("If motor is not moving the alignment procedure was not successfull!!");
 }

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -126,20 +126,13 @@ void BLDCMotor::enable()
   FOC functions
 */
 // FOC initialization function
-int  BLDCMotor::initFOC( float zero_electric_offset, Direction _sensor_direction) {
+int  BLDCMotor::initFOC() {
   int exit_flag = 1;
 
   motor_status = FOCMotorStatus::motor_calibrating;
 
   // align motor if necessary
   // alignment necessary for encoders!
-  if(_isset(zero_electric_offset)){
-    // abosolute zero offset provided - no need to align
-    zero_electric_angle = zero_electric_offset;
-    // set the sensor direction - default CW
-    sensor_direction = _sensor_direction;
-  }
-
   // sensor and motor alignment - can be skipped
   // by setting motor.sensor_direction and motor.zero_electric_angle
   _delay(500);

--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -213,7 +213,7 @@ int BLDCMotor::alignSensor() {
   if(!exit_flag) return exit_flag;
 
   // if unknown natural direction
-  if(!_isset(sensor_direction)){
+  if(sensor_direction==Direction::UNKNOWN){
 
     // find natural direction
     // move one electrical revolution forward

--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -49,7 +49,7 @@ class BLDCMotor: public FOCMotor
      * Function initializing FOC algorithm
      * and aligning sensor's and motors' zero position 
      */  
-    int initFOC( float zero_electric_offset = NOT_SET , Direction sensor_direction = Direction::CW) override;
+    int initFOC() override;
     /**
      * Function running FOC algorithm in real-time
      * it calculates the gets motor angle and sets the appropriate voltages 

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -92,20 +92,13 @@ void StepperMotor::enable()
   FOC functions
 */
 // FOC initialization function
-int  StepperMotor::initFOC( float zero_electric_offset, Direction _sensor_direction ) {
+int  StepperMotor::initFOC() {
   int exit_flag = 1;
   
   motor_status = FOCMotorStatus::motor_calibrating;
 
   // align motor if necessary
   // alignment necessary for encoders!
-  if(_isset(zero_electric_offset)){
-    // abosolute zero offset provided - no need to align
-    zero_electric_angle = zero_electric_offset;
-    // set the sensor direction - default CW
-    sensor_direction = _sensor_direction;
-  }
-
   // sensor and motor alignment - can be skipped
   // by setting motor.sensor_direction and motor.zero_electric_angle
   _delay(500);

--- a/src/StepperMotor.h
+++ b/src/StepperMotor.h
@@ -54,12 +54,8 @@ class StepperMotor: public FOCMotor
      * and aligning sensor's and motors' zero position 
      * 
      * - If zero_electric_offset parameter is set the alignment procedure is skipped
-     * 
-     * @param zero_electric_offset value of the sensors absolute position electrical offset in respect to motor's electrical 0 position.
-     * @param sensor_direction  sensor natural direction - default is CW
-     *
      */  
-    int initFOC( float zero_electric_offset = NOT_SET , Direction sensor_direction = Direction::CW) override;
+    int initFOC() override;
     /**
      * Function running FOC algorithm in real-time
      * it calculates the gets motor angle and sets the appropriate voltages 

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -109,7 +109,7 @@ class FOCMotor
      * @param sensor_direction  sensor natural direction - default is CW
      *
      */  
-    virtual int initFOC( float zero_electric_offset = NOT_SET , Direction sensor_direction = Direction::CW)=0; 
+    virtual int initFOC(float zero_electric_offset = NOT_SET , Direction sensor_direction = Direction::CW)=0; 
     /**
      * Function running FOC algorithm in real-time
      * it calculates the gets motor angle and sets the appropriate voltages 
@@ -209,7 +209,7 @@ class FOCMotor
     // sensor related variabels
     float sensor_offset; //!< user defined sensor zero offset
     float zero_electric_angle = NOT_SET;//!< absolute zero electric angle - if available
-    int sensor_direction = NOT_SET; //!< if sensor_direction == Direction::CCW then direction will be flipped to CW
+    Direction sensor_direction = Direction::UNKNOWN; //!< if sensor_direction == Direction::CCW then direction will be flipped to CW
 
     /**
      * Function providing BLDCMotor class with the 

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -104,12 +104,8 @@ class FOCMotor
      * and aligning sensor's and motors' zero position 
      * 
      * - If zero_electric_offset parameter is set the alignment procedure is skipped
-     * 
-     * @param zero_electric_offset value of the sensors absolute position electrical offset in respect to motor's electrical 0 position.
-     * @param sensor_direction  sensor natural direction - default is CW
-     *
      */  
-    virtual int initFOC(float zero_electric_offset = NOT_SET , Direction sensor_direction = Direction::CW)=0; 
+    virtual int initFOC()=0;
     /**
      * Function running FOC algorithm in real-time
      * it calculates the gets motor angle and sets the appropriate voltages 
@@ -209,7 +205,7 @@ class FOCMotor
     // sensor related variabels
     float sensor_offset; //!< user defined sensor zero offset
     float zero_electric_angle = NOT_SET;//!< absolute zero electric angle - if available
-    Direction sensor_direction = Direction::UNKNOWN; //!< if sensor_direction == Direction::CCW then direction will be flipped to CW
+    Direction sensor_direction = Direction::CW; //!< default is CW. if sensor_direction == Direction::CCW then direction will be flipped compared to CW. Set to UNKNOWN to set by calibration
 
     /**
      * Function providing BLDCMotor class with the 

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -593,6 +593,7 @@ bool Commander::isSentinel(char ch)
   else if (ch == '\r')
   {
       printVerbose(F("Warn: \\r detected! \n"));
+      return true; // lets still consider it to end the line...
   }
   return false;
 }


### PR DESCRIPTION
This is an API change: I propose to remove the params from initFOC.

If you look at the way it works now, the semantics are actually quite complicated - with int being used internally but Direction enum in the params, and the params overwriting the values potentially already set in the object. There's also no way to set direction without also setting the zero angle via the params.

All in all this is quite complex (and has led me to be bug-hunting for the second time now :-( ) so I propose the following change (in this PR):
- the Direction enum is now used internally also instead of int for sensor_direction (this not only has the advantage of clarity, but also gives this field a well-defined size since the enum is defined as uint8_t).
- the params are simply removed from initFOC() - the semantics are now simple: if you want to set the zero angle or direction, then just do so like all the other fields: 
```
motor.zero_electric_angle = 0.1234; 
motor.sensor_direction = Direction:CCW;
```
if you set them before the initFOC() then the calibration will be skipped. Simple.
- the default Direction:CW and angle NOT_SET are set in the FOCMotor base class, as the initial field values.

I've updated the one example I could find referring to this. If you agree to this change, then I'll update the docs accordingly.




Another small change in this PR: \r is added to the isSentinel() characters, to make things work right even if the user sets the wrong EOL in his console...