### PR TITLE
Expose last wire.endTransmission code

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Please do not hesitate to leave an issue if you have problems/advices/suggestion
 
 Pull requests are welcome, but let's first discuss them in [community forum](https://community.simplefoc.com)!
 
-If you'd like to contribute to this porject but you are not very familiar with github, don't worry, let us know either by posting at the community forum , by posting a github issue or at our discord server.
+If you'd like to contribute to this project but you are not very familiar with github, don't worry, let us know either by posting at the community forum , by posting a github issue or at our discord server.
+
+If you are familiar, we accept pull requests to the dev branch!
 
 ## Arduino code example
 This is a simple Arduino code example implementing the velocity control program of a BLDC motor with encoder. 

--- a/src/sensors/MagneticSensorI2C.cpp
+++ b/src/sensors/MagneticSensorI2C.cpp
@@ -95,7 +95,7 @@ int MagneticSensorI2C::read(uint8_t angle_reg_msb) {
   // notify the device that is aboout to be read
 	wire->beginTransmission(chip_address);
 	wire->write(angle_reg_msb);
-  wire->endTransmission(false);
+  currWireError = wire->endTransmission(false);
 
   // read the data msb and lsb
 	wire->requestFrom(chip_address, (uint8_t)2);

--- a/src/sensors/MagneticSensorI2C.h
+++ b/src/sensors/MagneticSensorI2C.h
@@ -51,6 +51,9 @@ class MagneticSensorI2C: public Sensor{
     /** experimental function to check and fix SDA locked LOW issues */
     int checkBus(byte sda_pin , byte scl_pin );
 
+    /** current error code from Wire endTransmission() call **/
+    uint8_t currWireError = 0;
+
   private:
     float cpr; //!< Maximum range of the magnetic sensor
     uint16_t lsb_used; //!< Number of bits used in LSB register


### PR DESCRIPTION
Hey there!

I was wondering if we could somehow gain access to the error codes returned by the Wire library on endTransmission().

I noticed that when my AS5048B is somehow disconnected, the motor locks up at full voltage/torque. In my case, the motor got hot pretty quickly, and the 3D printer holder melted a bit. With the suggested code, I was now able to solve this by entering an error state:
```
  if (sensor.error)
  {
    Serial.println("Wire error");
    motor_error = true;
    motor.disable();
    driver.disable();
  }
```

What do you think?