### PR TITLE
bugfix for teensy 3.0-3.0, wrong check for timer 3

### DIFF
--- a/src/drivers/hardware_specific/teensy/teensy3_mcu.cpp
+++ b/src/drivers/hardware_specific/teensy/teensy3_mcu.cpp
@@ -3,7 +3,6 @@
 // if defined 
 // - Teensy 3.0 MK20DX128
 // - Teensy 3.1/3.2 MK20DX256
-// - Teensy 3.5 MK20DX128
 // - Teensy LC MKL26Z64
 // - Teensy 3.5 MK64FX512
 // - Teensy 3.6 MK66FX1M0
@@ -14,7 +13,7 @@
 #pragma message("SimpleFOC: compiling for Teensy 3.x")
 #pragma message("")
 
-// pin definition from https://github.com/PaulStoffregen/cores/blob/286511f3ec849a6c9e0ec8b73ad6a2fada52e44c/teensy3/pins_teensy.c
+// pin definition from https://github.com/PaulStoffregen/cores/blob/286511f3ec849a6c9e0ec8b73ad6a2fada52e44c/teensy3/pins_teensy.c#L627
 #if defined(__MK20DX128__)
 #define FTM0_CH0_PIN 22
 #define FTM0_CH1_PIN 23
@@ -116,7 +115,7 @@ int _findTimer( const int Ah, const int Al,  const int Bh, const int Bl, const i
       }
   }
 
-  #ifdef FTM3_SC // if the board has FTM3 timer
+#ifdef FTM3_CH0_PIN // if the board has FTM3 timer
     if((Ah == FTM3_CH0_PIN && Al == FTM3_CH1_PIN) || 
       (Ah == FTM3_CH2_PIN && Al == FTM3_CH3_PIN) ||
       (Ah == FTM3_CH4_PIN && Al == FTM3_CH5_PIN) ){
@@ -134,7 +133,7 @@ int _findTimer( const int Ah, const int Al,  const int Bh, const int Bl, const i
           }
         }
     }
-  #endif
+#endif
   
 #ifdef SIMPLEFOC_TEENSY_DEBUG
   SIMPLEFOC_DEBUG("TEENSY-DRV: ERR: Pins not on timers FTM0 or FTM3!");


### PR DESCRIPTION
Fixing the wrong condition statement for the architectures teensy 3.2 and lower. 
The issue is caused by the FTM3_SC register that is created even though the board does not have FTM3 timer ( or at least does not use it for PWM ).

https://community.simplefoc.com/t/errors-compiling-simplefoc-for-teensy-3-2/3185/2
https://community.simplefoc.com/t/errors-compiling-simplefoc-for-teensy-3-2-still-not-solved/3809