### PR TITLE
STM32F1 Adc calibration

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -66,6 +66,10 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   }
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
+
+  // Start the adc calibration
+  HAL_ADCEx_Calibration_Start(cs_params->adc_handle);
+
   // start the adc 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
 


### PR DESCRIPTION
Adding ADC calibration for STM32F1.

**Before:**
RAM:   [=         ]   9.0% (used 4444 bytes from 49152 bytes)
Flash: [===       ]  26.6% (used 69712 bytes from 262144 bytes)

offset_ia = 1.574506
offset_ib = 1.566360

**After:**
RAM:   [=         ]   9.0% (used 4444 bytes from 49152 bytes)
Flash: [===       ]  26.8% (used 70208 bytes from 262144 bytes)

offset_ia = 1.630240
offset_ib = 1.623240

Slightly increases memory usage because of the use of an additional hal function, but should make all the adc measurements closer to reality.
The only risk I see are:
- a user has saved the phase current offsets without adc calibration in the code or in eeprom and would measure phase current with adc calibration, but I don't think it's common practice
- a user tweaked the gains to match an internal measurement, now the measurements won't match anymore
