### PR TITLE
Fix ESP32 compilation problems

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -59,7 +59,7 @@ jobs:
           
           - arduino-boards-fqbn: esp32:esp32:esp32s2 # esp32s2
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
-            sketch-names: bldc_driver_3pwm_standalone.ino, stepper_driver_2pwm_standalone.ino, stepper_driver_4pwm_standalone 
+            sketch-names: bldc_driver_3pwm_standalone.ino,stepper_driver_2pwm_standalone.ino,stepper_driver_4pwm_standalone.ino
             
           - arduino-boards-fqbn: esp32:esp32:esp32s3 # esp32s3
             platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -58,15 +58,15 @@ jobs:
             sketch-names: single_full_control_example.ino
           
           - arduino-boards-fqbn: esp32:esp32:esp32s2 # esp32s2
-            platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+            platform-url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
             sketch-names: bldc_driver_3pwm_standalone.ino,stepper_driver_2pwm_standalone.ino,stepper_driver_4pwm_standalone.ino
             
           - arduino-boards-fqbn: esp32:esp32:esp32s3 # esp32s3
-            platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+            platform-url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
             sketch-names: esp32_position_control.ino, esp32_i2c_dual_bus_example.ino
             
           - arduino-boards-fqbn: esp32:esp32:esp32doit-devkit-v1 # esp32 
-            platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+            platform-url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
             sketch-names: esp32_position_control.ino, esp32_i2c_dual_bus_example.ino, esp32_current_control_low_side.ino, esp32_spi_alt_example.ino
 
           - arduino-boards-fqbn: STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8 # bluepill - hs examples

--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -91,7 +91,8 @@ __attribute__((weak)) float _sqrtApprox(float number) {//low in fat
   // const float f = 1.5F; // better precision
 
   // x = number * 0.5F;
-  float y = number;
+  float y;
+  y = number;
   uint32_t i = *reinterpret_cast<uint32_t*>(&y);
   i = 0x5f375a86 - ( i >> 1 );
   y = *reinterpret_cast<float*>(&i);

--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -87,15 +87,10 @@ float _electricalAngle(float shaft_angle, int pole_pairs) {
 // https://reprap.org/forum/read.php?147,219210
 // https://en.wikipedia.org/wiki/Fast_inverse_square_root
 __attribute__((weak)) float _sqrtApprox(float number) {//low in fat
-  // float x;
-  // const float f = 1.5F; // better precision
-
-  // x = number * 0.5F;
-  float y;
-  y = number;
-  uint32_t i = *reinterpret_cast<uint32_t*>(&y);
-  i = 0x5f375a86 - ( i >> 1 );
-  y = *reinterpret_cast<float*>(&i);
-  // y = y * ( f - ( x * y * y ) ); // better precision
-  return number * y;
+  union {
+    float    f;
+    uint32_t i;
+  } y = { .f = number };
+  y.i = 0x5f375a86 - ( y.i >> 1 );
+  return number * y.f;
 }

--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -92,9 +92,9 @@ __attribute__((weak)) float _sqrtApprox(float number) {//low in fat
 
   // x = number * 0.5F;
   float y = number;
-  long i = * ( long * ) &y;
+  uint32_t i = *reinterpret_cast<uint32_t*>(&y);
   i = 0x5f375a86 - ( i >> 1 );
-  y = * ( float * ) &i;
+  y = *reinterpret_cast<float*>(&i);
   // y = y * ( f - ( x * y * y ) ); // better precision
   return number * y;
 }

--- a/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
@@ -7,6 +7,7 @@
 #include "rom/ets_sys.h"
 #include "esp_attr.h"
 //#include "esp_intr.h" deprecated
+#include "esp_intr_alloc.h"
 #include "soc/rtc_io_reg.h"
 #include "soc/rtc_cntl_reg.h"
 #include "soc/sens_reg.h"

--- a/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
@@ -6,7 +6,7 @@
 #include "freertos/task.h"
 #include "rom/ets_sys.h"
 #include "esp_attr.h"
-#include "esp_intr.h"
+//#include "esp_intr.h" deprecated
 #include "soc/rtc_io_reg.h"
 #include "soc/rtc_cntl_reg.h"
 #include "soc/sens_reg.h"

--- a/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
@@ -121,6 +121,8 @@ void _driverSyncLowSide(void* driver_params, void* cs_params){
     mcpwm_isr_register(mcpwm_unit, mcpwm1_isr_handler, NULL, ESP_INTR_FLAG_IRAM, NULL);  //Set ISR Handler
 }
 
+static void IRAM_ATTR mcpwm0_isr_handler(void*) __attribute__ ((unused));
+
 // Read currents when interrupt is triggered
 static void IRAM_ATTR mcpwm0_isr_handler(void*){
   // // high side
@@ -139,6 +141,7 @@ static void IRAM_ATTR mcpwm0_isr_handler(void*){
   // MCPWM0.int_clr.timer0_tez_int_clr = mcpwm_intr_status_0;
 }
 
+static void IRAM_ATTR mcpwm1_isr_handler(void*) __attribute__ ((unused));
 
 // Read currents when interrupt is triggered
 static void IRAM_ATTR mcpwm1_isr_handler(void*){


### PR DESCRIPTION
Fixes compiler warnings/errors, but the actual problem was the use of the dev platform rather than the stable version. Workflow files adjusted accordingly.