### PR TITLE
Add check to sensor

### DIFF
--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -6,6 +6,8 @@
 
 void Sensor::update() {
     float val = getSensorAngle();
+    if (val<0) // sensor angles are strictly non-negative. Negative values are used to signal errors.
+        return; // TODO signal error, e.g. via a flag and counter
     angle_prev_ts = _micros();
     float d_angle = val - angle_prev;
     // if overflow happened track it as full rotation

--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -11,10 +11,10 @@ Commander::Commander(char eol, bool echo){
 }
 
 
-void Commander::add(char id, CommandCallback onCommand, char* label ){
+void Commander::add(char id, CommandCallback onCommand, const char* label ){
   call_list[call_count] = onCommand;
   call_ids[call_count] = id;
-  call_label[call_count] = label;
+  call_label[call_count] = (char*)label;
   call_count++;
 }
 

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -91,7 +91,7 @@ class Commander
      * @param onCommand  - function pointer void function(char*)
      * @param label      - string label to be displayed when scan command sent
      */
-    void add(char id , CommandCallback onCommand, char* label = nullptr);
+    void add(char id , CommandCallback onCommand, const char* label = nullptr);
 
     // printing variables
     VerboseMode verbose = VerboseMode::user_friendly; //!< flag signaling that the commands should output user understanable text


### PR DESCRIPTION
- Check that returned angles from subclasses getSensorAngle() calls are non-negative

This allows a sensor driver to not return an angle in the case of failed CRC checks, etc by returning a negative value
Part of improvement #334 

- Remove warnings in Commander about using Strings as char* by changing type to const char* and casting to char* elsewhere