### PR TITLE
Feature: FIX 2 phase measurements resulting in bad DQ currents

### DIFF
--- a/src/common/base_classes/CurrentSense.cpp
+++ b/src/common/base_classes/CurrentSense.cpp
@@ -16,12 +16,12 @@ float CurrentSense::getDCCurrent(float motor_electrical_angle){
         // if only two measured currents
         i_alpha = current.a;  
         i_beta = _1_SQRT3 * current.a + _2_SQRT3 * current.b;
-    }if(!current.a){
+    }else if(!current.a){
         // if only two measured currents
         float a = -current.c - current.b;
         i_alpha = a;  
         i_beta = _1_SQRT3 * a + _2_SQRT3 * current.b;
-    }if(!current.b){
+    }else if(!current.b){
         // if only two measured currents
         float b = -current.a - current.c;
         i_alpha = current.a;  
@@ -62,12 +62,12 @@ DQCurrent_s CurrentSense::getFOCCurrents(float angle_el){
         // if only two measured currents
         i_alpha = current.a;  
         i_beta = _1_SQRT3 * current.a + _2_SQRT3 * current.b;
-    }if(!current.a){
+    }else if(!current.a){
         // if only two measured currents
         float a = -current.c - current.b;
         i_alpha = a;  
         i_beta = _1_SQRT3 * a + _2_SQRT3 * current.b;
-    }if(!current.b){
+    }else if(!current.b){
         // if only two measured currents
         float b = -current.a - current.c;
         i_alpha = current.a;  


### PR DESCRIPTION
inside the common/base_classes/CurrentSense.cpp there was an error with the if-else statement for both getCurrent methods. 
This leads to a very noisy DQ current if only two phase currents are measured. Either a&b or c&b lead to this issue:

![image](https://github.com/simplefoc/Arduino-FOC/assets/52048305/ca4ceaaf-0fa9-4bd9-86de-f5f079dd71ec)

after the FIX OR using a&c:

![image](https://github.com/simplefoc/Arduino-FOC/assets/52048305/0ecbbf13-3af6-4827-9e7b-2720f54d0c2a)


