### PR TITLE
Stm32 adc no interrupt

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
@@ -124,9 +124,11 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected);
   }
   
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
   // enable interrupt
   HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+  #endif
   
   cs_params->adc_handle = &hadc;
 
@@ -151,6 +153,7 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
 
 }
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -158,5 +161,6 @@ extern "C" {
   }
   
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -69,9 +69,13 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 
   // Start the adc calibration
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle);
-
+  
   // start the adc 
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  #else
+  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  #endif
 
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -81,13 +85,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 // function reading an ADC value and returning the read voltage
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
-    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]) // found in the buffer
-      return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
+      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+        return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #else
+        return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle,i+1) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #endif
+    }
   } 
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -104,5 +113,6 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);
   }
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
@@ -135,9 +135,11 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     }
   }
   
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
   // enable interrupt
   HAL_NVIC_SetPriority(ADC_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(ADC_IRQn);
+  #endif
   
   cs_params->adc_handle = &hadc;
   return 0;
@@ -160,11 +162,13 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC_IRQHandler(void)
   {
       HAL_ADC_IRQHandler(&hadc);
   }
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
@@ -58,8 +58,13 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   }
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
-  // start the adc 
+
+  // start the adc
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  #else
+  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  #endif
 
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -69,13 +74,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 // function reading an ADC value and returning the read voltage
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
-    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]) // found in the buffer
-      return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
+      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+        return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #else
+        return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle,i+1) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #endif
+    }
   } 
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -92,5 +102,6 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);    
   }
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -181,7 +181,7 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   }
   
 
- 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
   if(hadc.Instance == ADC1) {
     // enable interrupt
     HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
@@ -215,6 +215,7 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     HAL_NVIC_EnableIRQ(ADC5_IRQn);
   } 
 #endif
+#endif
   
   cs_params->adc_handle = &hadc;
   return 0;
@@ -237,6 +238,7 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -263,5 +265,6 @@ extern "C" {
   }
 #endif
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
@@ -61,6 +61,10 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
+ 
+  // Start the adc calibration
+  HAL_ADCEx_Calibration_Start(cs_params->adc_handle,ADC_SINGLE_ENDED);
+
   // start the adc 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
   // restart all the timers of the driver

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
@@ -180,7 +180,7 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   }
   
 
- 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
   if(hadc.Instance == ADC1) {
     // enable interrupt
     HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
@@ -214,6 +214,7 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     HAL_NVIC_EnableIRQ(ADC5_IRQn);
   } 
 #endif
+#endif
   
   cs_params->adc_handle = &hadc;
   return 0;
@@ -236,6 +237,7 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -262,5 +264,6 @@ extern "C" {
   }
 #endif
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
@@ -65,8 +65,13 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   // Start the adc calibration
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle,ADC_SINGLE_ENDED);
   
-  // start the adc 
+  // start the adc
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  #else
+  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  #endif
+
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
 }
@@ -75,13 +80,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 // function reading an ADC value and returning the read voltage
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
-    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]) // found in the buffer
-      return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
+      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+        return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #else
+        return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle,i+1) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #endif
+    }
   } 
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -98,5 +108,6 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);  
   }
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
@@ -61,6 +61,10 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
+
+  // Start the adc calibration
+  HAL_ADCEx_Calibration_Start(cs_params->adc_handle,ADC_SINGLE_ENDED);
+  
   // start the adc 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
   // restart all the timers of the driver


### PR DESCRIPTION
On stm32, when injected adc is used, the adc samples are saved in specific register.
The implementations for F1/F4/G4/L4 use an interrupt to save injected adc values in an array.
The way simplefoc works now, this is not required as those values are accessible anytime from the registers.

I introduced a SIMPLEFOC_STM32_ADC_INTERRUPT build flag.
By default, it will remove any code related to the adc interrupt.
When SIMPLEFOC_STM32_ADC_INTERRUPT is declared, code will work as before.
The reason why I kept this code as optional is that someone my want to use this interrupt for different reasons (e.g. running loopfoc, triggering an output for the scope).

I could test this on stm32f1 only, here are the results:
Without interrupt
RAM:   [=         ]   8.9% (used 4376 bytes from 49152 bytes)
Flash: [===       ]  26.7% (used 69916 bytes from 262144 bytes)
loopfoc = 270us

With interrupt
RAM:   [=         ]   9.0% (used 4428 bytes from 49152 bytes)
Flash: [===       ]  26.8% (used 70284 bytes from 262144 bytes)
loopfoc = 290us

It is slightly reducing the code size and reducing loopfoc duration as this interrupt was stopping the loopfoc execution several times unnecessarily. 
Because of the priority of this interrupt, it might also delay the hall sensor interrupt.

Additionally this PR has the adc calibration for G4/L4 ( this was already merged for F1 and G431-ESC1).
