### PR TITLE
fix some bugs in B-G431-ESC1 example

### DIFF
--- a/examples/hardware_specific_examples/B_G431B_ESC1/B_G431B_ESC1.ino
+++ b/examples/hardware_specific_examples/B_G431B_ESC1/B_G431B_ESC1.ino
@@ -5,13 +5,13 @@
 #include <SimpleFOC.h>
 
 // Motor instance
-BLDCMotor motor = BLDCMotor(11);
+BLDCMotor motor = BLDCMotor(12);
 BLDCDriver6PWM driver = BLDCDriver6PWM(A_PHASE_UH, A_PHASE_UL, A_PHASE_VH, A_PHASE_VL, A_PHASE_WH, A_PHASE_WL);
 LowsideCurrentSense currentSense = LowsideCurrentSense(0.003f, -64.0f/7.0f, A_OP1_OUT, A_OP2_OUT, A_OP3_OUT);
 
 
-// encoder instance
-Encoder encoder = Encoder(A_HALL2, A_HALL3, 2048, A_HALL1);
+// encoder instance,Hall or quadrature encoder in B-G431B-ESC1
+Encoder encoder = Encoder(A_ENCODER_A,A_ENCODER_B,5000);
 
 // Interrupt routine intialisation
 // channel A and B callbacks
@@ -54,10 +54,11 @@ void setup() {
 
   // set motion control loop to be used
   motor.controller = MotionControlType::velocity;
+  motor.torque_controller=TorqueControlType::foc_current;
+  motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
 
   // contoller configuration 
   // default parameters in defaults.h
-
   // velocity PI controller parameters
   motor.PID_velocity.P = 0.2;
   motor.PID_velocity.I = 20;
@@ -99,7 +100,7 @@ void loop() {
 
   // Motion control function
   motor.move();
-
+  motor.loopFOC();
   // function intended to be used with serial plotter to monitor motor variables
   // significantly slowing the execution down!!!!
   // motor.monitor();

--- a/examples/hardware_specific_examples/B_G431B_ESC1/build_opt.h
+++ b/examples/hardware_specific_examples/B_G431B_ESC1/build_opt.h
@@ -1,1 +1,2 @@
--DHAL_OPAMP_MODULE_ENABLED
+build_flags=-DHAL_OPAMP_MODULE_ENABLED
+lib_archive = false


### PR DESCRIPTION
Hi, I find some bugs in B-G432B-ESC1 example when I test.
1. In the loop function, we need a loopFOC() function to start the motor.
2. build_opt.h file need to add "lib_archive=false" to compile correctly in platformIO.
All changes are verified on my real hardware.
I‘m sorry, My English is not very good. I look forward to your reply. 
Wish you a happy life.