### PR TITLE
Add library.json to set libArchive  #357

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,5 @@
+{
+    "build": {
+      "libArchive": false
+    }
+}


### PR DESCRIPTION
As suggested in issue #357 - adding a library.json file to the library may solve our libarchive=true issues on PlatformIO.