### PR TITLE
initFOC: remove unnecessary delay

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -151,7 +151,6 @@ int  BLDCMotor::initFOC() {
   // alignment necessary for encoders!
   // sensor and motor alignment - can be skipped
   // by setting motor.sensor_direction and motor.zero_electric_angle
-  _delay(500);
   if(sensor){
     exit_flag *= alignSensor();
     // added the shaft_angle update
@@ -165,7 +164,6 @@ int  BLDCMotor::initFOC() {
   // aligning the current sensor - can be skipped
   // checks if driver phases are the same as current sense phases
   // and checks the direction of measuremnt.
-  _delay(500);
   if(exit_flag){
     if(current_sense){ 
       if (!current_sense->initialized) {


### PR DESCRIPTION
Hey, thanks for writing simpleFOC. 
It is amazing how easy you made it conquer the otherwise complex topic of motor control!

I looked into skipping the direction and zero calibration done in `initFOC` with the `find_sensor_offset_and_direction.ino` example. This worked nicely but the function still block for a whole second which i didn't get. 
From looking a the code i don't know why the delay is needed so i removed it, and my driver-code still works (but "boots" faster). If it is needed for the calibration or something, I would suggest moving it in the `if` statements so it gets skipped when not needed.

Thanks!