### PR TITLE
Feat stm32 synctimers

### DIFF
--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -235,7 +235,7 @@ int _getInternalSourceTrigger(HardwareTimer* master, HardwareTimer* slave) { // 
 // function finds the appropriate timer source trigger for the master/slave timer combination
 // returns -1 if no trigger source is found
 // currently supports the master timers to be from TIM1 to TIM4 and TIM8
-int _getTriggerSourceRegister(HardwareTimer* master, HardwareTimer* slave) {
+int _getInternalSourceTrigger(HardwareTimer* master, HardwareTimer* slave) {
   // put master and slave in temp variables to avoid arrows
   TIM_TypeDef *TIM_master = master->getHandle()->Instance;
   TIM_TypeDef *TIM_slave = slave->getHandle()->Instance;
@@ -298,7 +298,7 @@ int _getTriggerSourceRegister(HardwareTimer* master, HardwareTimer* slave) {
 }
 #else
 // Alignment not supported for this architecture
-int _getTriggerSourceRegister(HardwareTimer* master, HardwareTimer* slave) {
+int _getInternalSourceTrigger(HardwareTimer* master, HardwareTimer* slave) {
   return -1;
 }
 #endif
@@ -343,7 +343,7 @@ void _alignTimersNew() {
         for (int slave_i=0; slave_i<numTimers; slave_i++) {
           if (i==slave_i) continue; // skip self
           // check if it has the supported internal trigger
-          triggerEvent = _getTriggerSourceRegister(timers[i],timers[slave_i]); 
+          triggerEvent = _getInternalSourceTrigger(timers[i],timers[slave_i]); 
           if(triggerEvent == -1) break; // not supported keep searching
         }
         if(triggerEvent == -1) continue; // cannot be master, keep searching
@@ -373,7 +373,7 @@ void _alignTimersNew() {
         if (slave_index == master_index)
           continue;
         // Configure the slave timer to be triggered by the master enable signal
-        LL_TIM_SetTriggerInput(timers[slave_index]->getHandle()->Instance, _getTriggerSourceRegister(timers[master_index], timers[slave_index]));
+        LL_TIM_SetTriggerInput(timers[slave_index]->getHandle()->Instance, _getInternalSourceTrigger(timers[master_index], timers[slave_index]));
         LL_TIM_SetSlaveMode(timers[slave_index]->getHandle()->Instance, LL_TIM_SLAVEMODE_TRIGGER);
       }
     }

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -204,30 +204,105 @@ void _stopTimers(HardwareTimer **timers_to_stop, int timer_num)
 }
 
 
-// function finds the appropriate timer source trigger for the master timer index provided
+#if defined(STM32G4xx)
+// function finds the appropriate timer source trigger for the master/slave timer combination
 // returns -1 if no trigger source is found
 // currently supports the master timers to be from TIM1 to TIM4 and TIM8
-int _getTriggerSourceRegister(HardwareTimer* timer) {
+int _getInternalSourceTrigger(HardwareTimer* master, HardwareTimer* slave) { // put master and slave in temp variables to avoid arrows
+  TIM_TypeDef *TIM_master = master->getHandle()->Instance;
   #if defined(TIM1) && defined(LL_TIM_TS_ITR0)
-    if (timer->getHandle()->Instance == TIM1) return LL_TIM_TS_ITR0;// return TIM_TS_ITR0;
+    if (TIM_master == TIM1) return LL_TIM_TS_ITR0;// return TIM_TS_ITR0;
   #endif
   #if defined(TIM2) &&  defined(LL_TIM_TS_ITR1)
-    if (timer->getHandle()->Instance == TIM2) return LL_TIM_TS_ITR1;//return TIM_TS_ITR1;
+    else if (TIM_master == TIM2) return LL_TIM_TS_ITR1;//return TIM_TS_ITR1;
   #endif
   #if defined(TIM3) &&  defined(LL_TIM_TS_ITR2)
-    if (timer->getHandle()->Instance == TIM3) return LL_TIM_TS_ITR2;//return TIM_TS_ITR2;
+    else if (TIM_master == TIM3) return LL_TIM_TS_ITR2;//return TIM_TS_ITR2;
   #endif  
   #if defined(TIM4) &&  defined(LL_TIM_TS_ITR3)
-    if (timer->getHandle()->Instance == TIM4) return LL_TIM_TS_ITR3;//return TIM_TS_ITR3;
+    else if (TIM_master == TIM4) return LL_TIM_TS_ITR3;//return TIM_TS_ITR3;
   #endif 
   #if defined(TIM5) &&  defined(LL_TIM_TS_ITR4)
-    if (timer->getHandle()->Instance == TIM5) return LL_TIM_TS_ITR4;//return TIM_TS_ITR4;
+    else if (TIM_master == TIM5) return LL_TIM_TS_ITR4;//return TIM_TS_ITR4;
   #endif
   #if defined(TIM8) &&  defined(LL_TIM_TS_ITR5)
-    if (timer->getHandle()->Instance == TIM8) return LL_TIM_TS_ITR5;//return TIM_TS_ITR5;
+    else if (TIM_master == TIM8) return LL_TIM_TS_ITR5;//return TIM_TS_ITR5;
   #endif
   return -1;
 }
+#elif defined(STM32F4xx) || defined(STM32F1xx) || defined(STM32L4xx)
+
+// function finds the appropriate timer source trigger for the master/slave timer combination
+// returns -1 if no trigger source is found
+// currently supports the master timers to be from TIM1 to TIM4 and TIM8
+int _getTriggerSourceRegister(HardwareTimer* master, HardwareTimer* slave) {
+  // put master and slave in temp variables to avoid arrows
+  TIM_TypeDef *TIM_master = master->getHandle()->Instance;
+  TIM_TypeDef *TIM_slave = slave->getHandle()->Instance;
+  #if defined(TIM1) && defined(LL_TIM_TS_ITR0)
+    if (TIM_master == TIM1){
+      if(TIM_slave == TIM2 || TIM_slave == TIM3 || TIM_slave == TIM4) return LL_TIM_TS_ITR0;
+      #if defined(TIM8)
+      else if(TIM_slave == TIM8) return LL_TIM_TS_ITR0;
+      #endif
+    }
+  #endif
+  #if defined(TIM2) &&  defined(LL_TIM_TS_ITR1)
+    else if (TIM_master == TIM2){
+      if(TIM_slave == TIM1 || TIM_slave == TIM3 || TIM_slave == TIM4) return LL_TIM_TS_ITR1;
+      #if defined(TIM8)
+      else if(TIM_slave == TIM8) return LL_TIM_TS_ITR1;
+      #endif
+      #if defined(TIM5)
+      else if(TIM_slave == TIM5) return LL_TIM_TS_ITR0;
+      #endif
+    }
+  #endif
+  #if defined(TIM3) &&  defined(LL_TIM_TS_ITR2)
+    else if (TIM_master == TIM3){
+      if(TIM_slave== TIM1 || TIM_slave == TIM2 || TIM_slave == TIM4) return LL_TIM_TS_ITR2;
+      #if defined(TIM5)
+      else if(TIM_slave == TIM5) return LL_TIM_TS_ITR1;
+      #endif
+    }
+  #endif  
+  #if defined(TIM4) &&  defined(LL_TIM_TS_ITR3)
+    else if (TIM_master == TIM4){
+      if(TIM_slave == TIM1 || TIM_slave == TIM2 || TIM_slave == TIM3) return LL_TIM_TS_ITR3;
+      #if defined(TIM8)
+      else if(TIM_slave == TIM8) return LL_TIM_TS_ITR2;
+      #endif
+      #if defined(TIM5)
+      else if(TIM_slave == TIM5) return LL_TIM_TS_ITR1;
+      #endif
+    }
+  #endif 
+  #if defined(TIM5) 
+    else if (TIM_master == TIM5){
+      #if !defined(STM32L4xx) // only difference between F4,F1 and L4
+      if(TIM_slave == TIM1) return LL_TIM_TS_ITR0;
+      else if(TIM_slave == TIM3) return LL_TIM_TS_ITR2;
+      #endif
+      #if defined(TIM8)
+      if(TIM_slave == TIM8) return LL_TIM_TS_ITR3;
+      #endif
+    }
+  #endif
+  #if defined(TIM8)
+    else if (TIM_master == TIM8){
+      if(TIM_slave==TIM2) return LL_TIM_TS_ITR1;
+      else if(TIM_slave ==TIM4 || TIM_slave ==TIM5) return LL_TIM_TS_ITR3;
+    }
+  #endif
+  return -1; // combination not supported
+}
+#else
+// Alignment not supported for this architecture
+int _getTriggerSourceRegister(HardwareTimer* master, HardwareTimer* slave) {
+  return -1;
+}
+#endif
+
 
 void _alignTimersNew() {
   int numTimers = 0;
@@ -256,7 +331,7 @@ void _alignTimersNew() {
   // if yes, try to align timers
   if(numTimers > 1){
     // find the master timer
-    uint8_t masterTimerIndex = 0;
+    int16_t master_index = -1;
     int triggerEvent = -1;
     for (int i=0; i<numTimers; i++) {
       // check if timer can be master
@@ -264,36 +339,42 @@ void _alignTimersNew() {
         // check if timer already configured in TRGO update mode (used for ADC triggering)
         // in that case we should not change its TRGO configuration
         if(timers[i]->getHandle()->Instance->CR2 & LL_TIM_TRGO_UPDATE) continue;
-        // check if it has the supported internal trigger
-        triggerEvent = _getTriggerSourceRegister(timers[i]); 
-        if(triggerEvent == -1) continue; // not supported keep searching
-        masterTimerIndex = i; // found the master timer
+        // check if the timer has the supported internal trigger for other timers
+        for (int slave_i=0; slave_i<numTimers; slave_i++) {
+          if (i==slave_i) continue; // skip self
+          // check if it has the supported internal trigger
+          triggerEvent = _getTriggerSourceRegister(timers[i],timers[slave_i]); 
+          if(triggerEvent == -1) break; // not supported keep searching
+        }
+        if(triggerEvent == -1) continue; // cannot be master, keep searching
+        // otherwise the master has been found, remember the index
+        master_index = i; // found the master timer
         break;
       }
     }
     
 
     // if no master timer found do not perform alignment
-    if (triggerEvent == -1) {
+    if (master_index == -1) {
       #ifdef SIMPLEFOC_STM32_DEBUG
         SIMPLEFOC_DEBUG("STM32-DRV: ERR: No master timer found, cannot align timers!");
       #endif
     }else{
       #ifdef SIMPLEFOC_STM32_DEBUG
-        SIMPLEFOC_DEBUG("STM32-DRV: Aligning PWM to master timer: ",  getTimerNumber(get_timer_index(timers[masterTimerIndex]->getHandle()->Instance)));
+        SIMPLEFOC_DEBUG("STM32-DRV: Aligning PWM to master timer: ",  getTimerNumber(get_timer_index(timers[master_index]->getHandle()->Instance)));
       #endif
       // make the master timer generate ITRGx event
       // if it was already configured in slave mode
-      LL_TIM_SetSlaveMode(timers[masterTimerIndex]->getHandle()->Instance, LL_TIM_SLAVEMODE_DISABLED );
+      LL_TIM_SetSlaveMode(timers[master_index]->getHandle()->Instance, LL_TIM_SLAVEMODE_DISABLED );
       // Configure the master  timer to send a trigger signal on enable 
-      LL_TIM_SetTriggerOutput(timers[masterTimerIndex]->getHandle()->Instance, LL_TIM_TRGO_ENABLE);
+      LL_TIM_SetTriggerOutput(timers[master_index]->getHandle()->Instance, LL_TIM_TRGO_ENABLE);
       // configure other timers to get the input trigger from the master timer
-      for (int i=0; i<numTimers; i++) {
-        if (i==masterTimerIndex)
+      for (int slave_index=0; slave_index < numTimers; slave_index++) {
+        if (slave_index == master_index)
           continue;
         // Configure the slave timer to be triggered by the master enable signal
-        LL_TIM_SetTriggerInput(timers[i]->getHandle()->Instance, triggerEvent);
-        LL_TIM_SetSlaveMode(timers[i]->getHandle()->Instance, LL_TIM_SLAVEMODE_TRIGGER);
+        LL_TIM_SetTriggerInput(timers[slave_index]->getHandle()->Instance, _getTriggerSourceRegister(timers[master_index], timers[slave_index]));
+        LL_TIM_SetSlaveMode(timers[slave_index]->getHandle()->Instance, LL_TIM_SLAVEMODE_TRIGGER);
       }
     }
   }

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -10,8 +10,6 @@
 #pragma message("")
 
 
-//#define SIMPLEFOC_STM32_DEBUG
-
 #ifdef SIMPLEFOC_STM32_DEBUG
 void printTimerCombination(int numPins, PinMap* timers[], int score);
 int getTimerNumber(int timerIndex);
@@ -210,28 +208,28 @@ void _stopTimers(HardwareTimer **timers_to_stop, int timer_num)
 // returns -1 if no trigger source is found
 // currently supports the master timers to be from TIM1 to TIM8
 int _getTriggerSourceRegister(HardwareTimer* timer) {
-  #if defined(TIM1) && TIM_TS_ITR0
+  #if defined(TIM1) && defined(LL_TIM_TS_ITR0)
     if (timer->getHandle()->Instance == TIM1) return LL_TIM_TS_ITR0;// return TIM_TS_ITR0;
   #endif
-  #if defined(TIM2) && TIM_TS_ITR1
+  #if defined(TIM2) &&  defined(LL_TIM_TS_ITR1)
     if (timer->getHandle()->Instance == TIM2) return LL_TIM_TS_ITR1;//return TIM_TS_ITR1;
   #endif
-  #if defined(TIM3) && TIM_TS_ITR2
+  #if defined(TIM3) &&  defined(LL_TIM_TS_ITR2)
     if (timer->getHandle()->Instance == TIM3) return LL_TIM_TS_ITR2;//return TIM_TS_ITR2;
   #endif  
-  #if defined(TIM4) && TIM_TS_ITR3
+  #if defined(TIM4) &&  defined(LL_TIM_TS_ITR3)
     if (timer->getHandle()->Instance == TIM4) return LL_TIM_TS_ITR3;//return TIM_TS_ITR3;
   #endif 
-  #if defined(TIM5) && TIM_TS_ITR4
+  #if defined(TIM5) &&  defined(LL_TIM_TS_ITR4)
     if (timer->getHandle()->Instance == TIM5) return LL_TIM_TS_ITR4;//return TIM_TS_ITR4;
   #endif
-  #if defined(TIM6) && TIM_TS_ITR5
+  #if defined(TIM6) &&  defined(LL_TIM_TS_ITR5)
     if (timer->getHandle()->Instance == TIM6) return LL_TIM_TS_ITR5;//return TIM_TS_ITR5;
   #endif
-  #if defined(TIM7) && TIM_TS_ITR6
+  #if defined(TIM7) &&  defined(LL_TIM_TS_ITR6)
     if (timer->getHandle()->Instance == TIM7) return LL_TIM_TS_ITR6;//return TIM_TS_ITR6;
   #endif
-  #if defined(TIM8) && TIM_TS_ITR7
+  #if defined(TIM8) &&  defined(LL_TIM_TS_ITR7)
     if (timer->getHandle()->Instance == TIM8) return LL_TIM_TS_ITR7;// return TIM_TS_ITR7;
   #endif
   return -1;
@@ -256,9 +254,9 @@ void _alignTimersNew() {
       timers[numTimers++] = timer;
   }
 
-    #ifdef SIMPLEFOC_STM32_DEBUG
-      SIMPLEFOC_DEBUG("STM32-DRV: Syncronising timers!\nTimer no. ", numTimers);
-    #endif
+  #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-DRV: Syncronising timers! Timer no. ", numTimers);
+  #endif
 
   // see if there is more then 1 timers used for the pwm
   // if yes, try to align timers

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -256,6 +256,10 @@ void _alignTimersNew() {
       timers[numTimers++] = timer;
   }
 
+    #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-DRV: Syncronising timers!\nTimer no. ", numTimers);
+    #endif
+
   // see if there is more then 1 timers used for the pwm
   // if yes, try to align timers
   if(numTimers > 1){
@@ -276,9 +280,6 @@ void _alignTimersNew() {
       }
     }
     
-    #ifdef SIMPLEFOC_STM32_DEBUG
-      SIMPLEFOC_DEBUG("STM32-DRV: aligning!");
-    #endif
 
     // if no master timer found do not perform alignment
     if (triggerEvent == -1) {

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -206,7 +206,7 @@ void _stopTimers(HardwareTimer **timers_to_stop, int timer_num)
 
 // function finds the appropriate timer source trigger for the master timer index provided
 // returns -1 if no trigger source is found
-// currently supports the master timers to be from TIM1 to TIM8
+// currently supports the master timers to be from TIM1 to TIM4 and TIM8
 int _getTriggerSourceRegister(HardwareTimer* timer) {
   #if defined(TIM1) && defined(LL_TIM_TS_ITR0)
     if (timer->getHandle()->Instance == TIM1) return LL_TIM_TS_ITR0;// return TIM_TS_ITR0;
@@ -223,14 +223,8 @@ int _getTriggerSourceRegister(HardwareTimer* timer) {
   #if defined(TIM5) &&  defined(LL_TIM_TS_ITR4)
     if (timer->getHandle()->Instance == TIM5) return LL_TIM_TS_ITR4;//return TIM_TS_ITR4;
   #endif
-  #if defined(TIM6) &&  defined(LL_TIM_TS_ITR5)
-    if (timer->getHandle()->Instance == TIM6) return LL_TIM_TS_ITR5;//return TIM_TS_ITR5;
-  #endif
-  #if defined(TIM7) &&  defined(LL_TIM_TS_ITR6)
-    if (timer->getHandle()->Instance == TIM7) return LL_TIM_TS_ITR6;//return TIM_TS_ITR6;
-  #endif
-  #if defined(TIM8) &&  defined(LL_TIM_TS_ITR7)
-    if (timer->getHandle()->Instance == TIM8) return LL_TIM_TS_ITR7;// return TIM_TS_ITR7;
+  #if defined(TIM8) &&  defined(LL_TIM_TS_ITR5)
+    if (timer->getHandle()->Instance == TIM8) return LL_TIM_TS_ITR5;//return TIM_TS_ITR5;
   #endif
   return -1;
 }


### PR DESCRIPTION
This branch proposes a code which synchronizes all the stm32 timers.
It enables using multiple timers per motor and producing sync center aligned PWM (2pwm, 3pwm, 4pwm and 6pwm). 

The proposed code will attempt to sync all the timers used for pwm (even if they are used with multiple motors).

The code works well with the low-side current sensing as well, this is especially a big change for simplefocshield based setups used with nucleos, as they usually never use only one timer for 3 pwm signals. Now they are aligned and the current measurement is much better.

Basically the code in the funciton `_alignTimersNew()` which now finds the master timer between the used timers and all the other timers are configured as slave ones that are started at the same time as the master one.  To start the slaves the master timer emits `TRGO_ENABLE` event. 
If there is no timer that can be master timer, the timers are not synchronized, and the debug error is shown (but the driver is initialised anyway).
If we use low-side current sensing at the same time, the adc sync requires` TRGO_UPDATE` (cannot trigger `TRGO_UPDATE` and `TRGO_ENABLE` at the same time) event and there, I've given the priority to the ADC code to find the timer which can trigger the `TRGO_UPDATE`. Once the timer and the ADC are configured for current sensing the timer synchronization is attempted by finding the timer between the other ones (the ones not used for sync with the ADC)  which can be the master and the others are configured to be the slaves.

This code now allows to have the trully synced software 6pwm and use it properly with low-side current sensing. 

I've just tested the code for hardware 6pwm (even with low-side current sensing) on f4, g4 and f1 boards. It seems to work as expected. 😄

Some potential "wild-west" use-cases
- This code might even enable using multiple timers per phase of the motor in 6pwm/4pwm mode. Like to use one timer for high side mosfets and other timer for low side mosfets. But that is a bit dangerous, and maybe not the best idea. 😄
- This code could enable using one ADC for two motors with low-side sensing, by syncing the timers we can use one ADC with 4 injected channels for 2 phase per motor.. Also, maybe not the best idea, but its out there 😄