### PR TITLE
Use interrupt if no repetition counter

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
@@ -124,12 +124,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected);
   }
   
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
-  // enable interrupt
-  HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-  HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  #endif
-  
   cs_params->adc_handle = &hadc;
 
   return 0;
@@ -153,14 +147,11 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
 
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
       HAL_ADC_IRQHandler(&hadc);
   }
-  
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -69,20 +69,20 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
     cs_params->timer_handle->getHandle()->Instance->CNT =  cs_params->timer_handle->getHandle()->Instance->ARR;
     // remember that this timer has repetition counter - no need to downasmple
     needs_downsample[_adcToIndex(cs_params->adc_handle)] = 0;
+  }else{
+    if(!use_adc_interrupt){
+      // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
+      use_adc_interrupt = 1;
+      #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
+      #endif
+    }
   }
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
 
   // Start the adc calibration
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle);
-  
-  if( !use_adc_interrupt && !IS_TIM_REPETITION_COUNTER_INSTANCE(cs_params->timer_handle->getHandle()->Instance)){
-    // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
-    use_adc_interrupt = 1;
-    #ifdef SIMPLEFOC_STM32_DEBUG
-    SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
-    #endif
-  }
 
   // start the adc 
   if(use_adc_interrupt){

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -19,6 +19,12 @@ bool needs_downsample[3] = {1};
 // downsampling variable - per adc (3)
 uint8_t tim_downsample[3] = {0};
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+uint8_t use_adc_interrupt = 1;
+#else
+uint8_t use_adc_interrupt = 0;
+#endif
+
 int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
   if(AdcHandle->Instance == ADC1) return 0;
 #ifdef ADC2 // if ADC2 exists
@@ -70,12 +76,24 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   // Start the adc calibration
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle);
   
+  if( !use_adc_interrupt && !IS_TIM_REPETITION_COUNTER_INSTANCE(cs_params->timer_handle->getHandle()->Instance)){
+    // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
+    use_adc_interrupt = 1;
+    #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
+    #endif
+  }
+
   // start the adc 
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
-  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
-  #else
-  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
-  #endif
+  if(use_adc_interrupt){
+    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+
+    HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  }else{
+    HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  }
+
 
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -86,19 +104,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
     if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
-      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+      if (use_adc_interrupt){
         return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #else 
+      }else{ 
         // an optimized way to go from i to the channel i=0 -> channel 1, i=1 -> channel 2, i=2 -> channel 3
         uint32_t channel = (i == 0) ? ADC_INJECTED_RANK_1 : (i == 1) ? ADC_INJECTED_RANK_2 : ADC_INJECTED_RANK_3;;
         return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle, channel) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #endif
+      }
     }
   } 
   return 0;
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -115,6 +132,5 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);
   }
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
@@ -135,12 +135,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     }
   }
   
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
-  // enable interrupt
-  HAL_NVIC_SetPriority(ADC_IRQn, 0, 0);
-  HAL_NVIC_EnableIRQ(ADC_IRQn);
-  #endif
-  
   cs_params->adc_handle = &hadc;
   return 0;
 }
@@ -162,13 +156,11 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC_IRQHandler(void)
   {
       HAL_ADC_IRQHandler(&hadc);
   }
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
@@ -22,6 +22,12 @@ bool needs_downsample[3] = {1};
 // downsampling variable - per adc (3)
 uint8_t tim_downsample[3] = {0};
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+uint8_t use_adc_interrupt = 1;
+#else
+uint8_t use_adc_interrupt = 0;
+#endif
+
 void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
 
   Stm32CurrentSenseParams* cs_params= new Stm32CurrentSenseParams {
@@ -55,16 +61,28 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
     cs_params->timer_handle->getHandle()->Instance->CNT =  cs_params->timer_handle->getHandle()->Instance->ARR;
     // remember that this timer has repetition counter - no need to downasmple
     needs_downsample[_adcToIndex(cs_params->adc_handle)] = 0;
+  }else{
+    if(!use_adc_interrupt){
+    // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
+    use_adc_interrupt = 1;
+    #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
+    #endif
+  }
   }
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->getHandle()->Instance, LL_TIM_TRGO_UPDATE);
 
   // start the adc
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
-  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
-  #else
-  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
-  #endif
+  if (use_adc_interrupt){
+    // enable interrupt
+    HAL_NVIC_SetPriority(ADC_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(ADC_IRQn);
+    
+    HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  }else{
+    HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  }
 
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -75,19 +93,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
     if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
-      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+      if (use_adc_interrupt){
         return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #else
+      }else{
         // an optimized way to go from i to the channel i=0 -> channel 1, i=1 -> channel 2, i=2 -> channel 3
         uint32_t channel = (i == 0) ? ADC_INJECTED_RANK_1 : (i == 1) ? ADC_INJECTED_RANK_2 : ADC_INJECTED_RANK_3;
         return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle, channel) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #endif
+      }
     }
   } 
   return 0;
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -104,6 +121,5 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);    
   }
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -180,43 +180,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     }
   }
   
-
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
-  if(hadc.Instance == ADC1) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  }
-#ifdef ADC2
-  else if (hadc.Instance == ADC2) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  }
-#endif
-#ifdef ADC3
-  else if (hadc.Instance == ADC3) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC3_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC3_IRQn);
-  } 
-#endif
-#ifdef ADC4
-  else if (hadc.Instance == ADC4) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC4_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC4_IRQn);
-  } 
-#endif
-#ifdef ADC5
-  else if (hadc.Instance == ADC5) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC5_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC5_IRQn);
-  } 
-#endif
-#endif
-  
   cs_params->adc_handle = &hadc;
   return 0;
 }
@@ -238,7 +201,6 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -265,6 +227,5 @@ extern "C" {
   }
 #endif
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
@@ -24,6 +24,11 @@ bool needs_downsample[5] = {1};
 // downsampling variable - per adc (5)
 uint8_t tim_downsample[5] = {0};
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+uint8_t use_adc_interrupt = 1;
+#else
+uint8_t use_adc_interrupt = 0;
+#endif
 
 void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
 
@@ -58,6 +63,14 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
     cs_params->timer_handle->getHandle()->Instance->CNT =  cs_params->timer_handle->getHandle()->Instance->ARR;
     // remember that this timer has repetition counter - no need to downasmple
     needs_downsample[_adcToIndex(cs_params->adc_handle)] = 0;
+  }else{
+    if(!use_adc_interrupt){
+      // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
+      use_adc_interrupt = 1;
+      #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
+      #endif
+    }
   }
   
   // set the trigger output event
@@ -66,12 +79,47 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   // Start the adc calibration
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle,ADC_SINGLE_ENDED);
 
-  // start the adc 
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
-  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
-  #else
-  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
-  #endif
+  // start the adc
+  if (use_adc_interrupt){
+    // enable interrupt
+    if(cs_params->adc_handle->Instance == ADC1) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+    }
+    #ifdef ADC2
+      else if (cs_params->adc_handle->Instance == ADC2) {
+        // enable interrupt
+        HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+      }
+    #endif
+    #ifdef ADC3
+      else if (cs_params->adc_handle->Instance == ADC3) {
+        // enable interrupt
+        HAL_NVIC_SetPriority(ADC3_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(ADC3_IRQn);
+      } 
+    #endif
+    #ifdef ADC4
+      else if (cs_params->adc_handle->Instance == ADC4) {
+        // enable interrupt
+        HAL_NVIC_SetPriority(ADC4_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(ADC4_IRQn);
+      } 
+    #endif
+    #ifdef ADC5
+      else if (cs_params->adc_handle->Instance == ADC5) {
+        // enable interrupt
+        HAL_NVIC_SetPriority(ADC5_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(ADC5_IRQn);
+      } 
+    #endif
+
+    HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  }else{
+    HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  }
   
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -82,19 +130,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
     if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
-      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+      if (use_adc_interrupt){
         return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #else
+      }else{
         // an optimized way to go from i to the channel i=0 -> channel 1, i=1 -> channel 2, i=2 -> channel 3
         uint32_t channel = (i == 0) ? ADC_INJECTED_RANK_1 : (i == 1) ? ADC_INJECTED_RANK_2 : ADC_INJECTED_RANK_3;
         return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle, channel) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #endif
+      }
     }
   } 
   return 0;
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -111,6 +158,5 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);  
   }
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
@@ -179,43 +179,6 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     }
   }
   
-
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
-  if(hadc.Instance == ADC1) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  }
-#ifdef ADC2
-  else if (hadc.Instance == ADC2) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
-  }
-#endif
-#ifdef ADC3
-  else if (hadc.Instance == ADC3) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC3_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC3_IRQn);
-  } 
-#endif
-#ifdef ADC4
-  else if (hadc.Instance == ADC4) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC4_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC4_IRQn);
-  } 
-#endif
-#ifdef ADC5
-  else if (hadc.Instance == ADC5) {
-    // enable interrupt
-    HAL_NVIC_SetPriority(ADC5_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(ADC5_IRQn);
-  } 
-#endif
-#endif
-  
   cs_params->adc_handle = &hadc;
   return 0;
 }
@@ -237,7 +200,6 @@ void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const in
   }
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -264,6 +226,5 @@ extern "C" {
   }
 #endif
 }
-#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
@@ -23,6 +23,11 @@ bool needs_downsample[5] = {1};
 // downsampling variable - per adc (5)
 uint8_t tim_downsample[5] = {0};
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+uint8_t use_adc_interrupt = 1;
+#else
+uint8_t use_adc_interrupt = 0;
+#endif
 
 void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
 
@@ -57,6 +62,14 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
     cs_params->timer_handle->getHandle()->Instance->CNT =  cs_params->timer_handle->getHandle()->Instance->ARR;
     // remember that this timer has repetition counter - no need to downasmple
     needs_downsample[_adcToIndex(cs_params->adc_handle)] = 0;
+  }else{
+    if(!use_adc_interrupt){
+      // If the timer has no repetition counter, it needs to use the interrupt to downsample for low side sensing
+      use_adc_interrupt = 1;
+      #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-CS: timer has no repetition counter, ADC interrupt has to be used");
+      #endif
+    }
   }
   
   // set the trigger output event
@@ -66,11 +79,44 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
   HAL_ADCEx_Calibration_Start(cs_params->adc_handle,ADC_SINGLE_ENDED);
   
   // start the adc
-  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
-  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
-  #else
-  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  if (use_adc_interrupt){
+    if(cs_params->adc_handle->Instance == ADC1) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+    }
+    #ifdef ADC2
+    else if (cs_params->adc_handle->Instance == ADC2) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC1_2_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC1_2_IRQn);
+    }
   #endif
+  #ifdef ADC3
+    else if (cs_params->adc_handle->Instance == ADC3) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC3_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC3_IRQn);
+    } 
+  #endif
+  #ifdef ADC4
+    else if (cs_params->adc_handle->Instance == ADC4) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC4_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC4_IRQn);
+    } 
+  #endif
+  #ifdef ADC5
+    else if (cs_params->adc_handle->Instance == ADC5) {
+      // enable interrupt
+      HAL_NVIC_SetPriority(ADC5_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(ADC5_IRQn);
+    } 
+  #endif
+  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  }else{
+  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  }
 
   // restart all the timers of the driver
   _startTimers(driver_params->timers, 6);
@@ -81,19 +127,18 @@ void _driverSyncLowSide(void* _driver_params, void* _cs_params){
 float _readADCVoltageLowSide(const int pin, const void* cs_params){
   for(int i=0; i < 3; i++){
     if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
-      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+      if (use_adc_interrupt){
         return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #else
+      }else{
         // an optimized way to go from i to the channel i=0 -> channel 1, i=1 -> channel 2, i=2 -> channel 3
         uint32_t channel = (i == 0) ? ADC_INJECTED_RANK_1 : (i == 1) ? ADC_INJECTED_RANK_2 : ADC_INJECTED_RANK_3;
         return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle,channel) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
-      #endif
+      }
     }
   } 
   return 0;
 }
 
-#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
     // calculate the instance
@@ -110,6 +155,5 @@ extern "C" {
     adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);  
   }
 }
-#endif
 
 #endif

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -382,7 +382,7 @@ void _alignTimersNew() {
   // enable timer clock
   for (int i=0; i<numTimers; i++) {
     timers[i]->pause();
-    timers[i]->refresh();
+    //timers[i]->refresh();
     #ifdef SIMPLEFOC_STM32_DEBUG
       SIMPLEFOC_DEBUG("STM32-DRV: Restarting timer ", getTimerNumber(get_timer_index(timers[i]->getHandle()->Instance)));
     #endif


### PR DESCRIPTION
This was initially saving space as the interrupt code was completely removed with the build flag, and improving the performance.
Now the interrupt is started if the timer has no repetition counter, so the interrupt code has to be there in all cases.