### PR TITLE
Add a MotionControlMode::angle_nocascade which uses a single PID for angle control

### DIFF
--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -29,7 +29,8 @@ enum MotionControlType : uint8_t {
   velocity          = 0x01,     //!< Velocity motion control
   angle             = 0x02,     //!< Position/angle motion control
   velocity_openloop = 0x03,
-  angle_openloop    = 0x04
+  angle_openloop    = 0x04,
+  angle_nocascade   = 0x05      //!< Position/angle motion control without velocity cascade
 };
 
 /**


### PR DESCRIPTION
As discussed here: https://community.simplefoc.com/t/motor-oscillates-when-in-cascaded-position-velocity-control-loop/4194

I've tested this and it works quite nicely. I imagine some people might find it useful.