### PR TITLE
Set STM32 timer prescaler based on timer clock frequency

### DIFF
--- a/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.cpp
@@ -414,7 +414,7 @@ void _alignTimersNew() {
   // enable timer clock
   for (int i=0; i<numTimers; i++) {
     timers[i]->pause();
-    timers[i]->refresh();
+    // timers[i]->refresh();
     #ifdef SIMPLEFOC_STM32_DEBUG
       SIMPLEFOC_DEBUG("STM32-DRV: Restarting timer ", getTimerNumber(get_timer_index(timers[i]->getHandle()->Instance)));
     #endif

--- a/src/drivers/hardware_specific/stm32/stm32_mcu.h
+++ b/src/drivers/hardware_specific/stm32/stm32_mcu.h
@@ -28,5 +28,8 @@ typedef struct STM32DriverParams {
 void _stopTimers(HardwareTimer **timers_to_stop, int timer_num=6);
 void _startTimers(HardwareTimer **timers_to_start, int timer_num=6);
 
+// timer query functions
+bool _getPwmState(void* params);
+
 #endif
 #endif


### PR DESCRIPTION
This commit adds a function which calculates the correct timer prescaler value based on the actual timer clock frequency and sets it. This is necessary because some stm32duino clock configs, specifically the nucleo-f746zg, set things up such that the timers have an input frequency that differs by 2x. Families other than F7 also allow for this, but don't seem to have the same problem with the default configs.
![image](https://github.com/simplefoc/Arduino-FOC/assets/6063379/ec628312-f97b-451d-8fc7-fa4e76a2a970)

HardwareTimer->setOverflow(num, HERTZ_FORMAT) attempts to deal with this, but it does so by setting TIMx->ARR to a value that differs by 2x, instead of setting the prescaler. For some PWM frequencies this leads to an off-by-one error in ARR between the different timers(with the 2x factor taken into account). The values I observed with the aforementioned f746 were 

```
TIM1->ARR = 1349 (2698)
TIM4->ARR = 2699
```

This new function finds the lowest timer frequency for all timers, then calculates the prescaler value for each timer that's required to make the counter frequency match. It also calculates the correct overflow value for this frequency and sets it with HT->setOverflow(num, TICK_FORMAT), which does not reset the prescaler value. This method does require that no further calls to setOverflow are made with HERTZ_FORMAT, otherwise the prescaler value will be overwritten.

Additionally this change also adds the _getPwmState function, in anticipation of merging HFI support, as well as adding the STM32F7 family to the list of defines in _getInternalSourceTrigger. The F7 family timer interconnections appear to mirror the F4 family.
pg713 of RM0385 rev8 (STM32F74xx and F75xx reference manual)
![image](https://github.com/simplefoc/Arduino-FOC/assets/6063379/d362035a-8ab5-414b-b19c-021bcea382bc)
pg794
![image](https://github.com/simplefoc/Arduino-FOC/assets/6063379/f7daf0a3-2b41-4607-89bb-3094756a2ff4)


So far I've tested this on the F746 nucleo + SFOC shield and it works as expected. I haven't tested further on other targets.