### PR TITLE
Add missing implementation for MagneticSensorI2C::AS5600

### DIFF
--- a/src/sensors/MagneticSensorI2C.cpp
+++ b/src/sensors/MagneticSensorI2C.cpp
@@ -58,6 +58,10 @@ MagneticSensorI2C::MagneticSensorI2C(MagneticSensorI2CConfig_s config){
   wire = &Wire;
 }
 
+MagneticSensorI2C MagneticSensorI2C::AS5600() {
+  return {AS5600_I2C};
+}
+
 void MagneticSensorI2C::init(TwoWire* _wire){
 
   wire = _wire;


### PR DESCRIPTION
The current declaration of `MagneticSensorI2C` already has a public static member `AS5600()`, which is however lacking an implementation. This change adds the (trivial) implementation.