### PR TITLE
[WIP] Esp32 I2S-based current sense (adc) driver

### DIFF
--- a/src/current_sense/InlineCurrentSense.cpp
+++ b/src/current_sense/InlineCurrentSense.cpp
@@ -61,6 +61,7 @@ void InlineCurrentSense::calibrateOffsets(){
     offset_ic = 0;
     // read the adc voltage 1000 times ( arbitrary number )
     for (int i = 0; i < calibration_rounds; i++) {
+        _startADC3PinConversionInline();
         if(_isset(pinA)) offset_ia += _readADCVoltageInline(pinA, params);
         if(_isset(pinB)) offset_ib += _readADCVoltageInline(pinB, params);
         if(_isset(pinC)) offset_ic += _readADCVoltageInline(pinC, params);
@@ -75,6 +76,7 @@ void InlineCurrentSense::calibrateOffsets(){
 // read all three phase currents (if possible 2 or 3)
 PhaseCurrent_s InlineCurrentSense::getPhaseCurrents(){
     PhaseCurrent_s current;
+    _startADC3PinConversionInline();
     current.a = (!_isset(pinA)) ? 0 : (_readADCVoltageInline(pinA, params) - offset_ia)*gain_a;// amps
     current.b = (!_isset(pinB)) ? 0 : (_readADCVoltageInline(pinB, params) - offset_ib)*gain_b;// amps
     current.c = (!_isset(pinC)) ? 0 : (_readADCVoltageInline(pinC, params) - offset_ic)*gain_c; // amps

--- a/src/current_sense/hardware_api.h
+++ b/src/current_sense/hardware_api.h
@@ -35,6 +35,8 @@ float _readADCVoltageInline(const int pinA, const void* cs_params);
  */
 void* _configureADCInline(const void *driver_params, const int pinA,const int pinB,const int pinC = NOT_SET);
 
+void _startADC3PinConversionInline();
+
 /**
  *  function reading an ADC value and returning the read voltage
  *

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -1,0 +1,350 @@
+#include "../../hardware_api.h"
+#include "../../../drivers/hardware_api.h"
+#include "../../../drivers/hardware_specific/esp32/esp32_driver_mcpwm.h"
+
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) && !defined(SIMPLEFOC_ESP32_USELEDC)
+
+#include <soc/sens_reg.h>
+#include <soc/sens_struct.h>
+
+#include <driver/i2s.h>
+#include <soc/i2s_reg.h>
+
+#include "soc/syscon_periph.h"
+#include <soc/syscon_struct.h>
+
+#include "soc/timer_group_struct.h"
+#include "soc/timer_group_reg.h"
+
+#include <soc/soc.h>
+#include <soc/dport_reg.h>
+
+#include <soc/adc_periph.h>
+#include <driver/adc.h>
+#include <driver/rtc_io.h>
+
+
+#define BUF_LEN 5
+#define _ADC_VOLTAGE 3.3f
+#define _ADC_RESOLUTION 4095.0f
+
+#define I2S_USE_INTERRUPT false
+
+/**
+ *  I2S reading implementation by @mcells.
+ */
+
+uint32_t IRAM_ATTR adc_buffer[ADC1_CHANNEL_MAX] = {0};
+int globalActiveChannels = 0;
+int channels[ADC1_CHANNEL_MAX] = {0};
+bool running = false;
+
+#if DEBUG_ADC
+uint32_t IRAM_ATTR readscnt = 0;
+uint32_t IRAM_ATTR intcnt = 0;
+uint32_t IRAM_ATTR skipped = 0;
+uint32_t IRAM_ATTR equal = 0;
+uint32_t IRAM_ATTR currfifo = 0;
+uint32_t IRAM_ATTR lastfifo = 0;
+unsigned long IRAM_ATTR ts = 0;
+unsigned long IRAM_ATTR fifotime = 0;
+#endif
+
+// This function reads data from the I2S FIFO and processes it to obtain average readings for each channel.
+// The ADC counts get saved in uint32_t adc_buffer[].
+static void IRAM_ATTR readFiFo()
+{
+    // uint32_t readings[ADC1_CHANNEL_MAX][ADC1_CHANNEL_MAX*BUF_LEN];
+    uint32_t avgreadings[ADC1_CHANNEL_MAX] = {0};
+    uint32_t counts[ADC1_CHANNEL_MAX] = {0};
+    uint32_t fifolen = GET_PERI_REG_BITS2(I2S_FIFO_CONF_REG(0), I2S_RX_DATA_NUM_M, I2S_RX_DATA_NUM_S); // I2S0.fifo_conf.rx_data_num;
+
+#if DEBUG_ADC
+    uint32_t lastrd = 0;
+    uint32_t lasth = 0;
+    uint32_t lastl = 0;
+    uint32_t internalequal = 0;
+#endif
+
+    for (size_t i = 0; i < fifolen; i++)
+    {
+        // while(!GET_PERI_REG_MASK(I2S_INT_RAW_REG(0), I2S_RX_REMPTY_INT_RAW_M)){
+        // I2S0.in_fifo_pop.pop = 1;
+        // I2S0.in_fifo_pop.pop = 0;
+        SET_PERI_REG_MASK(I2S_INFIFO_POP_REG(0), I2S_INFIFO_POP_M);
+        CLEAR_PERI_REG_MASK(I2S_INFIFO_POP_REG(0), I2S_INFIFO_POP_M);
+
+        uint32_t rd = *(uint32_t *)(REG_I2S_BASE(0) + 0x4); // GET_PERI_REG_BITS2(I2S_FIFO_CONF_REG, I2S_RX_DATA_NUM_M, I2S_RX_DATA_NUM_S);I2S0.fifo_rd;
+
+        uint32_t highVal = rd >> 16;
+        uint32_t lowVal = rd & 0xFFFF;
+
+#if DEBUG_ADC
+    if (rd == lastrd || highVal == lastl || lowVal == lasth)
+    { //
+        internalequal++;
+        // currfifo = rd;
+        // lastfifo = lastrd;
+        // Serial.printf("\n|\nlast: ");
+        // for (int i = 31; i >= 15; i--)
+        // {
+        //   Serial.printf("%d",(lastfifo >> i ) & 1);
+        // }
+        // Serial.printf("  ");
+        // for (int i = 15; i >= 0; i--)
+        // {
+        //   Serial.printf("%d",(lastfifo >> i ) & 1);
+        // }
+
+        // Serial.printf("\ncurr: ");
+        // for (int i = 31; i >= 15; i--)
+        // {
+        //   Serial.printf("%d",(currfifo >> i ) & 1);
+        // }
+        // Serial.printf("  ");
+        // for (int i = 15; i >= 0; i--)
+        // {
+        //   Serial.printf("%d",(currfifo >> i ) & 1);
+        // }
+        // Serial.printf("\n");
+    }
+
+    lasth = highVal;
+    lastl = lowVal;
+    lastrd = rd;
+    readscnt += 2;
+#endif
+    uint32_t chan = (lowVal >> 12) & 0x07;
+    uint32_t adc_value = lowVal & 0xfff;
+    // readings[chan][counts[chan]] = adc_value;
+    avgreadings[chan] += adc_value;
+    counts[chan]++;
+
+    chan = (highVal >> 12) & 0x07;
+    adc_value = highVal & 0xfff;
+    // readings[chan][counts[chan]] = adc_value;
+    avgreadings[chan] += adc_value;
+    counts[chan]++;
+  }
+#if DEBUG_ADC
+  equal = internalequal;
+  intcnt += 1; // I2S0.fifo_conf.rx_data_num;
+#endif
+  for (int j = 0; j < ADC1_CHANNEL_MAX; j++)
+  {
+      if (counts[j] != 0)
+      {
+          adc_buffer[j] = avgreadings[j] / counts[j];
+
+          // int32_t leastdiff = 4095;
+          // uint32_t idx = 0;
+          // for (size_t k = 0; k < counts[j]; k++)
+          // {
+          //   int32_t diff = abs(int(adc_buffer[j]) - int(readings[j][k]));
+          //   if (leastdiff > diff && diff != 0)
+          //   {
+          //     leastdiff = diff;
+          //     idx = k;
+          //   }
+          // }
+          // adc_buffer[j] = readings[j][idx];
+
+          // Serial.printf(">Channel%d:%d\n", j, adc_buffer[j]);
+      }
+  }
+}
+
+
+static void IRAM_ATTR i2s_isr(void *arg)
+{
+#if DEBUG_ADC
+    unsigned long fifostart = micros();
+#endif
+
+    if (I2S0.int_st.rx_take_data) // fifo is full
+    {
+        readFiFo();
+    }
+
+    SET_PERI_REG_MASK(I2S_INT_CLR_REG(0), GET_PERI_REG_MASK(I2S_INT_ST_REG(0), 0xffff));
+    // I2S0.int_clr.val = I2S0.int_st.val;    // Clear all interrupt flags.
+
+#if DEBUG_ADC
+    fifotime = micros() - fifostart;
+#endif
+}
+
+// Contrary to its name (so it can be called by the library), this function reads the already converted values from fifo
+// and prints optional debug information.
+// When using interrupt driven sampling, it only prints debug information.
+void IRAM_ATTR _startADC3PinConversionLowSide()
+{
+#if I2S_USE_INTERRUPT != true
+    readFiFo();
+#endif
+
+#if DEBUG_ADC
+    skipped++;
+    if (skipped >= 1000)
+    {
+        skipped = 0;
+        unsigned long now = micros();
+        volatile uint32_t interr = intcnt;
+        volatile uint32_t samplesss = readscnt;
+        intcnt = 0;
+        readscnt = 0;
+
+        float readspersec = (1000000.0f * interr) / (now - ts);
+        float samplespersec = (1000000.0f * samplesss) / (now - ts);
+
+        ts = now;
+        Serial.printf(">ips:%f\n", readspersec);
+        Serial.printf(">sps:%f\n", samplespersec); // readspersec * GET_PERI_REG_BITS2(I2S_FIFO_CONF_REG(0), I2S_RX_DATA_NUM_M, I2S_RX_DATA_NUM_S)); //I2S0.fifo_conf.rx_data_num
+        Serial.printf(">fifo:%ld\n", fifotime);
+        Serial.printf(">doubles:%ld\n", equal);
+        // if(equal > 0){
+        //   volatile uint32_t aktuell = currfifo;
+        //   volatile uint32_t zuletzt = lastfifo;
+
+        // Serial.printf("\n|\nlast: ");
+        // for (int i = 31; i >= 15; i--)
+        // {
+        //   Serial.printf("%d",(zuletzt >> i ) & 1);
+        // }
+        // Serial.printf("  ");
+        // for (int i = 15; i >= 0; i--)
+        // {
+        //   Serial.printf("%d",(zuletzt >> i ) & 1);
+        // }
+
+        // Serial.printf("\ncurr: ");
+        // for (int i = 31; i >= 15; i--)
+        // {
+        //   Serial.printf("%d",(aktuell >> i ) & 1);
+        // }
+        // Serial.printf("  ");
+        // for (int i = 15; i >= 0; i--)
+        // {
+        //   Serial.printf("%d",(aktuell >> i ) & 1);
+        // }
+        // Serial.printf("\n");
+
+        // }
+
+        for (size_t i = 0; i < ADC1_CHANNEL_MAX; i++)
+        {
+            Serial.printf(">Channel%d:%d\n", i, adc_buffer[i]);
+        }
+    }
+#endif
+}
+
+// Takes the buffered adc counts and returns the coresponding float voltage for a pin.
+float IRAM_ATTR _readADCVoltageI2S(const int pin, const void *cs_params)
+{
+    float adc_voltage_conv = ((ESP32MCPWMCurrentSenseParams *)cs_params)->adc_voltage_conv;
+
+    return adc_buffer[digitalPinToAnalogChannel(pin)] * adc_voltage_conv;
+}
+
+// Sets up the I2S peripheral and ADC. Can be run multiple times to configure multiple motors.
+void* IRAM_ATTR _configureI2S(const void* driver_params, const int pinA, const int pinB, const int pinC){
+  mcpwm_unit_t unit = ((ESP32MCPWMDriverParams*)driver_params)->mcpwm_unit;
+
+  if( _isset(pinA) ) channels[digitalPinToAnalogChannel(pinA)] = 1; pinMode(pinA, GPIO_MODE_DISABLE );
+  if( _isset(pinB) ) channels[digitalPinToAnalogChannel(pinB)] = 1; pinMode(pinB, GPIO_MODE_DISABLE );
+  if( _isset(pinC) ) channels[digitalPinToAnalogChannel(pinC)] = 1; pinMode(pinC, GPIO_MODE_DISABLE );
+
+  int activeChannels = 0;
+  u_int some_channel = 0;
+  for (int i = 0; i < ADC1_CHANNEL_MAX; i++)
+  {
+      activeChannels += channels[i];
+      if (channels[i])
+      {
+          some_channel = channels[i];
+      }
+  }
+  globalActiveChannels = activeChannels;
+
+  ESP32MCPWMCurrentSenseParams *params = new ESP32MCPWMCurrentSenseParams{
+      .pins = {pinA, pinB, pinC},
+      .adc_voltage_conv = (_ADC_VOLTAGE) / (_ADC_RESOLUTION),
+  };
+
+  periph_module_reset(PERIPH_I2S0_MODULE);
+  periph_module_enable(PERIPH_I2S0_MODULE);
+
+  ESP_ERROR_CHECK(i2s_set_adc_mode(ADC_UNIT_1, (adc1_channel_t) some_channel));
+
+  // Taken from https://github.com/pycom/esp-idf-2.0/blob/master/components/bootloader_support/src/bootloader_random.c
+  // The set values are good I guess?
+  DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_I2S0_CLK_EN);
+  CLEAR_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_FORCE_START_TOP);
+  CLEAR_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_START_TOP);
+
+  SET_PERI_REG_BITS(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 3, SENS_FORCE_XPD_SAR_S);
+  SET_PERI_REG_MASK(SENS_SAR_READ_CTRL_REG, SENS_SAR1_DIG_FORCE);
+  CLEAR_PERI_REG_MASK(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
+  SET_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX);
+  SET_PERI_REG_BITS(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR_CLK_DIV, 4, SYSCON_SARADC_SAR_CLK_DIV_S);
+
+  SET_PERI_REG_BITS(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_RSTB_WAIT, 8, SYSCON_SARADC_RSTB_WAIT_S);
+  SET_PERI_REG_BITS(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_START_WAIT, 10, SYSCON_SARADC_START_WAIT_S);
+  SET_PERI_REG_BITS(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_WORK_MODE, 0, SYSCON_SARADC_WORK_MODE_S);
+  CLEAR_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR_SEL);
+  CLEAR_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_DATA_SAR_SEL);
+
+  SET_PERI_REG_BITS(I2S_SAMPLE_RATE_CONF_REG(0), I2S_RX_BCK_DIV_NUM, 20, I2S_RX_BCK_DIV_NUM_S);
+
+  SET_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG,SYSCON_SARADC_DATA_TO_I2S);
+  CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_CAMERA_EN);
+  SET_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_LCD_EN);
+  SET_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_DATA_ENABLE);
+  SET_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_START);
+  // End
+
+  I2S0.conf_chan.rx_chan_mod = 2;
+
+  I2S0.fifo_conf.rx_data_num = max(8, min(63, (globalActiveChannels * BUF_LEN) / 2));
+  I2S0.fifo_conf.dscr_en = 0; // disable dma transfer.
+
+  I2S0.int_ena.val = 0;
+
+#if I2S_USE_INTERRUPT == true
+  I2S0.int_ena.rx_take_data = 1;
+// I2S0.int_ena.rx_rempty = 1;
+#endif
+
+    // ADC setting
+    int channelnum = 0;
+    for (size_t i = 0; i < ADC1_CHANNEL_MAX; i++)
+    {
+        if (channelnum <= 4 && channels[i] == 1)
+        {
+            SYSCON.saradc_sar1_patt_tab[0] |= ((i << 4) | (ADC_WIDTH_BIT_12 << 2) | ADC_ATTEN_DB_11) << (3 - channelnum) * 8;
+            channelnum++;
+        }
+        else if (channelnum > 4 && channels[i] == 1)
+        {
+            SYSCON.saradc_sar1_patt_tab[1] |= ((i << 4) | (ADC_WIDTH_BIT_12 << 2) | ADC_ATTEN_DB_11) << (3 - channelnum) * 8;
+            channelnum++;
+        }
+    }
+
+  // Scan multiple channels.
+  SET_PERI_REG_BITS(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR1_PATT_LEN, channelnum - 1, SYSCON_SARADC_SAR1_PATT_LEN_S);
+
+  if (!running)
+  {
+#if I2S_USE_INTERRUPT == true
+      ESP_ERROR_CHECK(esp_intr_alloc(ETS_I2S0_INTR_SOURCE, ESP_INTR_FLAG_IRAM, i2s_isr, NULL, NULL));
+#endif
+
+      running = true;
+  }
+
+  return params;
+}
+
+#endif

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -156,7 +156,7 @@ void IRAM_ATTR readFiFo()
   }
 }
 
-
+#if I2S_USE_INTERRUPT == true
 static void IRAM_ATTR i2s_isr(void *arg)
 {
 #if DEBUG_ADC
@@ -175,7 +175,7 @@ static void IRAM_ATTR i2s_isr(void *arg)
     fifotime = micros() - fifostart;
 #endif
 }
-
+#endif
 // Contrary to its name (so it can be called by the library), this function reads the already converted values from fifo
 // and prints optional debug information.
 // When using interrupt driven sampling, it only prints debug information.

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -67,6 +67,8 @@ unsigned long IRAM_ATTR fifotime = 0;
 // The ADC counts get saved in uint32_t i2s_adc_buffer[].
 void IRAM_ATTR readFiFo()
 {
+    CLEAR_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_START); // Stop aquisition to buffer
+
     // uint32_t readings[ADC1_CHANNEL_MAX][ADC1_CHANNEL_MAX*BUF_LEN];
     uint32_t avgreadings[ADC1_CHANNEL_MAX] = {0};
     uint32_t counts[ADC1_CHANNEL_MAX] = {0};
@@ -173,6 +175,8 @@ void IRAM_ATTR readFiFo()
           // Serial.printf(">Channel%d:%d\n", j, i2s_adc_buffer[j]);
       }
   }*/
+
+  SET_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_START); // Restart aquisition to buffer
 }
 
 #if I2S_USE_INTERRUPT == true

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -14,6 +14,7 @@
 
 #include "soc/syscon_periph.h"
 #include <soc/syscon_struct.h>
+#include <soc/syscon_reg.h>
 
 #include "soc/timer_group_struct.h"
 #include "soc/timer_group_reg.h"

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -296,7 +296,8 @@ void* IRAM_ATTR _configureI2S(const bool lowside, const void* driver_params, con
   periph_module_reset(PERIPH_I2S0_MODULE);
   periph_module_enable(PERIPH_I2S0_MODULE);
 
-  ESP_ERROR_CHECK(i2s_set_adc_mode(ADC_UNIT_1, (adc1_channel_t) some_channel));
+  // ESP_ERROR_CHECK(i2s_set_adc_mode(ADC_UNIT_1, (adc1_channel_t) some_channel));
+  ESP_ERROR_CHECK(i2s_set_adc_mode(ADC_UNIT_1, ADC1_CHANNEL_0));
 
   // Taken from https://github.com/pycom/esp-idf-2.0/blob/master/components/bootloader_support/src/bootloader_random.c
   // The set values are good I guess?

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -54,7 +54,7 @@ unsigned long IRAM_ATTR fifotime = 0;
 
 // This function reads data from the I2S FIFO and processes it to obtain average readings for each channel.
 // The ADC counts get saved in uint32_t i2s_adc_buffer[].
-static void IRAM_ATTR readFiFo()
+void IRAM_ATTR readFiFo()
 {
     // uint32_t readings[ADC1_CHANNEL_MAX][ADC1_CHANNEL_MAX*BUF_LEN];
     uint32_t avgreadings[ADC1_CHANNEL_MAX] = {0};

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -33,6 +33,14 @@
 
 #define I2S_USE_INTERRUPT false
 
+typedef struct ESP32MCPWMCurrentSenseParams {
+  int pins[3];
+  float adc_voltage_conv;
+  mcpwm_unit_t mcpwm_unit;
+  int buffer_index;
+} ESP32MCPWMCurrentSenseParams;
+
+
 /**
  *  I2S reading implementation by @mcells.
  */

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -242,6 +242,10 @@ void IRAM_ATTR _startADC3PinConversionLowSide()
 #endif
 }
 
+void IRAM_ATTR _startADC3PinConversionInline(){
+    _startADC3PinConversionLowSide();
+}
+
 // Takes the buffered adc counts and returns the coresponding float voltage for a pin.
 float IRAM_ATTR _readADCVoltageI2S(const int pin, const void *cs_params)
 {

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.cpp
@@ -2,6 +2,8 @@
 #include "../../../drivers/hardware_api.h"
 #include "../../../drivers/hardware_specific/esp32/esp32_driver_mcpwm.h"
 
+#include "esp32_i2s_driver.h"
+
 #if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) && !defined(SIMPLEFOC_ESP32_USELEDC)
 
 #include <soc/sens_reg.h>

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
@@ -9,6 +9,8 @@
 // The ADC counts get saved in uint32_t i2s_adc_buffer[].
 void readFiFo();
 
+void printdbg();
+
 // Contrary to its name (so it can be called by the library), this function reads the already converted values from fifo
 // and prints optional debug information.
 // When using interrupt driven sampling, it only prints debug information.

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
@@ -1,0 +1,27 @@
+#ifndef SIMPLEFOC_ESP32_HAL_I2S_DRIVER_H_ 
+#define SIMPLEFOC_ESP32_HAL_I2S_DRIVER_H_
+
+#include "Arduino.h"
+
+#if defined(ESP_H) && defined(ARDUINO_ARCH_ESP32) && defined(SOC_MCPWM_SUPPORTED) 
+
+// This function reads data from the I2S FIFO and processes it to obtain average readings for each channel.
+// The ADC counts get saved in uint32_t i2s_adc_buffer[].
+static void IRAM_ATTR readFiFo();
+
+static void IRAM_ATTR i2s_isr(void *arg);
+
+// Contrary to its name (so it can be called by the library), this function reads the already converted values from fifo
+// and prints optional debug information.
+// When using interrupt driven sampling, it only prints debug information.
+void IRAM_ATTR _startADC3PinConversionLowSide();
+void IRAM_ATTR _startADC3PinConversionInline();
+
+// Takes the buffered adc counts and returns the coresponding float voltage for a pin.
+float IRAM_ATTR _readADCVoltageI2S(const int pin, const void *cs_params);
+
+// Sets up the I2S peripheral and ADC. Can be run multiple times to configure multiple motors.
+void* IRAM_ATTR _configureI2S(const bool lowside, const void* driver_params, const int pinA, const int pinB, const int pinC);
+
+#endif /* SIMPLEFOC_ESP32_HAL_I2S_DRIVER_H_ */
+#endif /* ESP32 */

--- a/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
+++ b/src/current_sense/hardware_specific/esp32/esp32_i2s_driver.h
@@ -7,21 +7,19 @@
 
 // This function reads data from the I2S FIFO and processes it to obtain average readings for each channel.
 // The ADC counts get saved in uint32_t i2s_adc_buffer[].
-static void IRAM_ATTR readFiFo();
-
-static void IRAM_ATTR i2s_isr(void *arg);
+void readFiFo();
 
 // Contrary to its name (so it can be called by the library), this function reads the already converted values from fifo
 // and prints optional debug information.
 // When using interrupt driven sampling, it only prints debug information.
-void IRAM_ATTR _startADC3PinConversionLowSide();
-void IRAM_ATTR _startADC3PinConversionInline();
+void _startADC3PinConversionLowSide();
+void _startADC3PinConversionInline();
 
 // Takes the buffered adc counts and returns the coresponding float voltage for a pin.
-float IRAM_ATTR _readADCVoltageI2S(const int pin, const void *cs_params);
+float _readADCVoltageI2S(const int pin, const void *cs_params);
 
 // Sets up the I2S peripheral and ADC. Can be run multiple times to configure multiple motors.
-void* IRAM_ATTR _configureI2S(const bool lowside, const void* driver_params, const int pinA, const int pinB, const int pinC);
+void* _configureI2S(const bool lowside, const void* driver_params, const int pinA, const int pinB, const int pinC);
 
 #endif /* SIMPLEFOC_ESP32_HAL_I2S_DRIVER_H_ */
 #endif /* ESP32 */

--- a/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_mcu.cpp
@@ -132,9 +132,9 @@ void _driverSyncLowSide(void* driver_params, void* cs_params){
 
   // register interrupts (mcpwm number, interrupt handler, handler argument = NULL, interrupt signal/flag, return handler = NULL)
   if(mcpwm_unit == MCPWM_UNIT_0)
-    mcpwm_isr_register(mcpwm_unit, mcpwm0_isr_handler, NULL, ESP_INTR_FLAG_IRAM, NULL);  //Set ISR Handler
+    mcpwm_isr_register(mcpwm_unit, mcpwm0_isr_handler, NULL, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL1, NULL);  //Set ISR Handler
   else
-    mcpwm_isr_register(mcpwm_unit, mcpwm1_isr_handler, NULL, ESP_INTR_FLAG_IRAM, NULL);  //Set ISR Handler
+    mcpwm_isr_register(mcpwm_unit, mcpwm1_isr_handler, NULL, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL1, NULL);  //Set ISR Handler
 }
 
 static void IRAM_ATTR mcpwm0_isr_handler(void*) __attribute__ ((unused));
@@ -143,18 +143,19 @@ static void IRAM_ATTR mcpwm0_isr_handler(void*) __attribute__ ((unused));
 static void IRAM_ATTR mcpwm0_isr_handler(void*){
   // // high side
   // uint32_t mcpwm_intr_status = MCPWM0.int_st.timer0_tez_int_st;
-  
+
   // low side
   uint32_t mcpwm_intr_status = MCPWM0.int_st.timer0_tep_int_st;
   if(mcpwm_intr_status){
 #if _I2S_ADC == true
+      delayMicroseconds(2);
       readFiFo();
 #else
-    adc_buffer[0][adc_read_index[0]] = adcRead(adc_pins[0][adc_read_index[0]]);
-    adc_read_index[0]++;
-    if(adc_read_index[0] == adc_pin_count[0]) adc_read_index[0] = 0;
+      adc_buffer[0][adc_read_index[0]] = adcRead(adc_pins[0][adc_read_index[0]]);
+      adc_read_index[0]++;
+      if(adc_read_index[0] == adc_pin_count[0]) adc_read_index[0] = 0;
 #endif
-  }
+      }
   // low side
   MCPWM0.int_clr.timer0_tep_int_clr = mcpwm_intr_status;
   // high side
@@ -167,11 +168,12 @@ static void IRAM_ATTR mcpwm1_isr_handler(void*) __attribute__ ((unused));
 static void IRAM_ATTR mcpwm1_isr_handler(void*){
   // // high side
   // uint32_t mcpwm_intr_status = MCPWM1.int_st.timer0_tez_int_st;
-  
+
   // low side
   uint32_t mcpwm_intr_status = MCPWM1.int_st.timer0_tep_int_st;
   if(mcpwm_intr_status){
 #if _I2S_ADC == true
+    delayMicroseconds(2);
     readFiFo();
 #else
     adc_buffer[1][adc_read_index[1]] = adcRead(adc_pins[1][adc_read_index[1]]);


### PR DESCRIPTION
## Introduction
First, I am not certain if this is the right repo to put the code when it is ready for release, as it is quite HW-specific and has some constraints, and we already have a working current sense solution in place. Secondly, this is just referencing my developement branch, so the code has debugging options, some outdated comments and code, and is generally not very pretty.

Nonetheless, I want to get this out there for two reasons: On the one hand to possibly receive some opinions on the feasability of integrating this in the library at some point,
on the other hand, I feel this could be useful for some people, be it users of the library, or people working with the ESP32´s adc, looking for information.

## On the driver
This driver uses the (original) ESP32´s continous adc sampling mode, where the I2S peripheral connects to the adc and clocks out samples at a configurable frequency without using cpu time. 
This means that the adc sampling happens asynchronusly and non-blocking. Samples get pushed into the I2S´s 32-large FIFO automatically, where we only need to do a bit of bitshifting and save them.

This leads to the following usecases I implemented here:

- Faster sampling than the current implementation (here a fixed 1MS/s vs. about 100KS/s for the current SFOC driver)
  - The individual samples may possibly have more noise this way, but I feel performance still improves due to the higher loop rates
- Low-/Highside sensing with all phases sampled each PWM cycle, or even twice per cycle, versus sampling only one phase per PWM cycle due to time constraints
- "Sampling in the past", or more specifically: Instead of starting aquisition when an interrupt occurs (eg, at Low-/Highside center), we *stop* sampling and read out the FIFO. This approximately centers the aquired samples in the center of the waveform and avoids artifacts at low-ish duty-cycles for Low-/Highside sampling (As well as Inline, when configuring as Low-/Highside).
- We can do sensorless control using High Frequency Injection (HFI) at injection frequencies above human hearing range. This is part of the reason why I am developing this driver (apart from trying to more or less equal what is easily possible on STM32).
  - The Branch I reference in this PR is the "vanilla" version. I have [another one](https://github.com/mcells/Arduino-FOC/tree/esp32_copper_hfi) adapted slightly for @Copper280z ´s WIP [HFI fork](https://github.com/Copper280z/Arduino-FOC/tree/dual_motor) of SimpleFOC

The driver works (for me at least) and does definitely improve performance. (Loop speed and signal quality)

There are however some caveats to all this:

- This only works on the original ESP32, not on the ESP32Sx/-Hx/..., which offer other means to continously sample the adc. I don´t have any of the other ESP32 variants and am not sure if they can offer similarly high performance.
- As is, this only runs on ADC1. Using both ADC1 and ADC2 lowers resolution from 12 to 11 Bit. Using ADC2 is not really that practical anyways, due to WIFI accessing it when activated.
- You can´t use `analogRead()` on any of the ADC1 channels, as this will most probably break the setup, cause crashes, or just not work. I´ve not tried it though.
- The code could just stop working any time.
  - Reason is, most stuff is Register level, some api calls are there as well. And especially the setting up of the adc and I2S is not really documented very well. (The IDF ESP32 source code is also many abstaction layers deep, which doesn´t help *at all*) 
  - To get the latency and the processing time as low as possible required a lot of trial-and-error, as well as using effectively undocumented features, especially in the `readfifo()` method. It´s not so much voodoo, but more guesswork as to how stuff behaves in edge cases. (No help looking in the TRM, as many Registers are just mentioned and not explained)