### PR TITLE
Current PI Autotuning

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -82,7 +82,16 @@ int BLDCMotor::init() {
     // current control loop controls voltage
     PID_current_q.limit = voltage_limit;
     PID_current_d.limit = voltage_limit;
+
+    if (_isset(phase_resistance) && _isset(phase_inductance)){
+      PID_current_d.P = phase_inductance * DEF_CURR_BANDWIDTH * _2PI;
+      PID_current_d.I = PID_current_d.P * phase_resistance / phase_inductance;
+      
+      PID_current_q.P = phase_inductance * DEF_CURR_BANDWIDTH * _2PI;
+      PID_current_q.I = PID_current_q.P * phase_resistance /phase_inductance;
+    }
   }
+  
   if(_isset(phase_resistance) || torque_controller != TorqueControlType::voltage){
     // velocity control loop controls current
     PID_velocity.limit = current_limit;

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -48,6 +48,21 @@ int StepperMotor::init() {
   if(voltage_sensor_align > voltage_limit) voltage_sensor_align = voltage_limit;
 
   // update the controller limits
+  if(current_sense){
+    // current control loop controls voltage
+    PID_current_q.limit = voltage_limit;
+    PID_current_d.limit = voltage_limit;
+
+    if (_isset(phase_resistance) && _isset(phase_inductance)){
+      PID_current_d.P = phase_inductance * DEF_CURR_BANDWIDTH * _2PI;
+      PID_current_d.I = PID_current_d.P * phase_resistance / phase_inductance;
+      
+      PID_current_q.P = phase_inductance * DEF_CURR_BANDWIDTH * _2PI;
+      PID_current_q.I = PID_current_q.P * phase_resistance /phase_inductance;
+    }
+  }
+
+  // update the controller limits
   if(_isset(phase_resistance)){
     // velocity control loop controls current
     PID_velocity.limit = current_limit;

--- a/src/common/defaults.h
+++ b/src/common/defaults.h
@@ -18,6 +18,7 @@
 #define DEF_PID_CURR_RAMP 1000.0f //!< default PID controller voltage ramp value
 #define DEF_PID_CURR_LIMIT (DEF_POWER_SUPPLY) //!< default PID controller voltage limit
 #define DEF_CURR_FILTER_Tf 0.01f //!< default velocity filter time constant
+#define DEF_CURR_BANDWIDTH 300.0f //!< current bandwidth
 #else
 // for stm32, due, teensy, esp32 and similar
 #define DEF_PID_CURR_P 3 //!< default PID controller P value
@@ -26,6 +27,7 @@
 #define DEF_PID_CURR_RAMP 0  //!< default PID controller voltage ramp value
 #define DEF_PID_CURR_LIMIT (DEF_POWER_SUPPLY) //!< default PID controller voltage limit
 #define DEF_CURR_FILTER_Tf 0.005f //!< default currnet filter time constant
+#define DEF_CURR_BANDWIDTH 300.0f //!< current bandwidth
 #endif
 // default current limit values
 #define DEF_CURRENT_LIM 2.0f //!< 2Amps current limit by default


### PR DESCRIPTION
Shared by @mcells from his fork https://github.com/mcells/Arduino-FOC/blob/d40c7d7fddff4c3e58b26ebd2e2cc846fddfc09e/src/HFIBLDCMotor.cpp#L71 

### if phase resistance and phase inductance are known:
Will initialize Kp and Ki for q and d current PI controllers automatically based on phase resistance, phase inductance and current bandwidth (default 300).
Needs to be adapted if Ld and Lq are available in the future.
### if not known:
Same SimpleFOC default values as before are used.
### users that have tuned their PIs
They will overwrite Kp and Ki from their code.

What if users have set phase resistance and phase inductance but were using default PI parameters ? Is their an impact ?

