### PR TITLE
Add missing '\r' character sending to Commander

### DIFF
--- a/src/communication/Commander.cpp
+++ b/src/communication/Commander.cpp
@@ -592,7 +592,7 @@ bool Commander::isSentinel(char ch)
     return true;
   else if (ch == '\r')
   {
-      printVerbose(F("Warn: \\r detected! \n"));
+      printVerbose(F("Warn: \\r detected! \r\n"));
       return true; // lets still consider it to end the line...
   }
   return false;


### PR DESCRIPTION
Hello,

The default Arduino way to print a new line is to write two characters, `\r\n`. However, there is code in the Commander class that only uses the `\n` for the new line. In my case (definitely it depends on the OS and terminal program) it leads to incorrect behavior, something like this:

```
?
Warn: \r detected!
                   A: command A
B: command B
```

So I just replaced `\n` with `\r\n`