### PR TITLE
Velocity Calculation rework

### DIFF
--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -29,8 +29,8 @@ float Sensor::getVelocity() {
     }
     if (Ts < min_elapsed_time) return velocity; // don't update velocity if deltaT is too small
 
-    float current_angle = 0;
-    float prev_angle = 0;
+    float current_angle = 0.0f;
+    float prev_angle = 0.0f;
     // Avoid floating point precision loss for large full_rotations
     // this is likely optional
     if (full_rotations == vel_full_rotations) {
@@ -43,7 +43,7 @@ float Sensor::getVelocity() {
     const float delta_angle = current_angle - prev_angle;
 
     // floating point equality checks are bad, so instead we check that the angle change is very small
-    if (fabsf(delta_angle) < 1e-8f) {
+    if (fabsf(delta_angle) > 1e-8f) {
         velocity = delta_angle / Ts;
 
         vel_angle_prev = angle_prev;

--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -19,6 +19,7 @@ void Sensor::update() {
  /** get current angular velocity (rad/s) */
 float Sensor::getVelocity() {
     // calculate sample time
+    // if timestamps were unsigned, we could get rid of this section, unsigned overflow handles it correctly
     float Ts = (angle_prev_ts - vel_angle_prev_ts)*1e-6f;
     if (Ts < 0.0f) {    // handle micros() overflow - we need to reset vel_angle_prev_ts
         vel_angle_prev = angle_prev;
@@ -28,10 +29,28 @@ float Sensor::getVelocity() {
     }
     if (Ts < min_elapsed_time) return velocity; // don't update velocity if deltaT is too small
 
-    velocity = ( (float)(full_rotations - vel_full_rotations)*_2PI + (angle_prev - vel_angle_prev) ) / Ts;
-    vel_angle_prev = angle_prev;
-    vel_full_rotations = full_rotations;
-    vel_angle_prev_ts = angle_prev_ts;
+    float current_angle = 0;
+    float prev_angle = 0;
+    // Avoid floating point precision loss for large full_rotations
+    // this is likely optional
+    if (full_rotations == vel_full_rotations) {
+        current_angle = angle_prev;
+        prev_angle = vel_angle_prev;
+    } else {
+        current_angle = (float) full_rotations * _2PI + angle_prev;
+        prev_angle = (float) vel_full_rotations * _2PI + vel_angle_prev;
+    }
+    const float delta_angle = current_angle - prev_angle;
+
+    // floating point equality checks are bad, so instead we check that the angle change is very small
+    if (fabsf(delta_angle) < 1e-8f) {
+        velocity = delta_angle / Ts;
+
+        vel_angle_prev = angle_prev;
+        vel_full_rotations = full_rotations;
+        vel_angle_prev_ts = angle_prev_ts;
+    }
+    
     return velocity;
 }
 


### PR DESCRIPTION
Seeing the relatively frequent questions and problems associated with noisy velocity measurements on the discord server, what do you think about a change like this to the velocity calculation? 

The idea being that currently when we make a call to `getVelocity()`, if the angle change is zero then we get a zero velocity, if we have a non-zero angle change it appears as a very high velocity because all of that change is accounted for in one cycle. Because our loop can often run many cycles between angle changes. This shows up (unfiltered) as a series of zero velocity measurements with large single sample spikes, this is obviously nonphysical. The current fix to this is to heavily filter the velocity signal, which introduces a large phase loss in the control system.

This change only updates the velocity if an angle change is observed and otherwise reports the previous velocity. This results in a closer approximation to a continuous signal.

One degenerate case that is not handled is if the motor comes to a complete and total stop, the velocity will not be reported as zero. Practically, this doesn't seem like a problem because the reported velocity will be very small, very few motors will come to an absolute stop for any long period of time, and a floating point zero value (vs very small non-zero) isn't actually very useful.

This change is currently untested on hardware.