### PR TITLE
Feat current sense check if TRGO set for STM32

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32_mcu.h
+++ b/src/current_sense/hardware_specific/stm32/stm32_mcu.h
@@ -3,6 +3,8 @@
 #define STM32_CURRENTSENSE_MCU_DEF
 #include "../../hardware_api.h"
 #include "../../../common/foc_utils.h"
+#include "../../../drivers/hardware_specific/stm32/stm32_mcu.h"
+#include "../../../drivers/hardware_specific/stm32/stm32_timerutils.h"
 
 #if defined(_STM32_DEF_) 
 

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.h
@@ -5,8 +5,6 @@
 
 #if defined(STM32F1xx) 
 #include "stm32f1xx_hal.h"
-#include "../../../../common/foc_utils.h"
-#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
 #include "../stm32_mcu.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.h
@@ -8,7 +8,7 @@
 #include "../stm32_mcu.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
 
 #endif
 

--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_mcu.cpp
@@ -42,7 +42,7 @@ void* _configureADCLowSide(const void* driver_params, const int pinA, const int 
     .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_F1) / (_ADC_RESOLUTION_F1)
   };
-  _adc_gpio_init(cs_params, pinA,pinB,pinC);
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   return cs_params;
 }

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
@@ -80,6 +80,13 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     uint32_t trigger_flag = _timerToInjectedTRGO(driver_params->timers_handle[tim_num++]);
     if(trigger_flag == _TRGO_NOT_AVAILABLE) continue; // timer does not have valid trgo for injected channels
 
+    // check if TRGO used already - if yes use the next timer
+    if((driver_params->timers_handle[tim_num-1]->Instance->CR2 & LL_TIM_TRGO_ENABLE) || // if used for timer sync
+       (driver_params->timers_handle[tim_num-1]->Instance->CR2 & LL_TIM_TRGO_UPDATE)) // if used for ADC sync
+      {
+      continue;
+    }
+
     // if the code comes here, it has found the timer available
     // timer does have trgo flag for injected channels  
     sConfigInjected.ExternalTrigInjecConv = trigger_flag;
@@ -95,12 +102,11 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot sync any timer to injected channels!");
   #endif
     return -1;
+  }else{
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: Using timer: ", stm32_getTimerNumber(cs_params->timer_handle->Instance));
+#endif
   }
-  // display which timer is being used
-  #ifdef SIMPLEFOC_STM32_DEBUG
-    // it would be better to use the getTimerNumber from driver
-    SIMPLEFOC_DEBUG("STM32-CS: injected trigger for timer index: ", get_timer_index(cs_params->timer_handle->Instance) + 1);
-  #endif
 
 
   // first channel

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.cpp
@@ -9,6 +9,14 @@
 
 ADC_HandleTypeDef hadc;
 
+/**
+ * Function initializing the ADC and the injected channels for the low-side current sensing
+ * 
+ * @param cs_params - current sense parameters
+ * @param driver_params - driver parameters
+ * 
+ * @return int - 0 if success 
+ */
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
 {
   ADC_InjectionConfTypeDef sConfigInjected;
@@ -145,21 +153,35 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   return 0;
 }
 
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
+/**
+ * Function to initialize the ADC GPIO pins
+ * 
+ * @param cs_params current sense parameters
+ * @param pinA pin number for phase A
+ * @param pinB pin number for phase B
+ * @param pinC pin number for phase C
+ * @return int 0 if success, -1 if error
+ */
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
 {
-  uint8_t cnt = 0;
-  if(_isset(pinA)){
-    pinmap_pinout(analogInputToPinName(pinA), PinMap_ADC);
-    cs_params->pins[cnt++] = pinA;
+  int pins[3] = {pinA, pinB, pinC};
+  const char* port_names[3] = {"A", "B", "C"};
+  for(int i=0; i<3; i++){
+    if(_isset(pins[i])){
+      // check if pin is an analog pin
+      if(pinmap_peripheral(analogInputToPinName(pins[i]), PinMap_ADC) == NP){
+#ifdef SIMPLEFOC_STM32_DEBUG
+        SimpleFOCDebug::print("STM32-CS: ERR: Pin ");
+        SimpleFOCDebug::print(port_names[i]);
+        SimpleFOCDebug::println(" does not belong to any ADC!");
+#endif
+        return -1;
+      }
+      pinmap_pinout(analogInputToPinName(pins[i]), PinMap_ADC);
+      cs_params->pins[i] = pins[i];
+    }
   }
-  if(_isset(pinB)){
-    pinmap_pinout(analogInputToPinName(pinB), PinMap_ADC);
-    cs_params->pins[cnt++] = pinB;
-  }
-  if(_isset(pinC)){ 
-    pinmap_pinout(analogInputToPinName(pinC), PinMap_ADC);
-    cs_params->pins[cnt] = pinC;
-  }
+  return 0;
 }
 
 extern "C" {

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
@@ -9,7 +9,7 @@
 #include "stm32f4_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
 
 #endif
 

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_hal.h
@@ -5,8 +5,6 @@
 
 #if defined(STM32F4xx)
 #include "stm32f4xx_hal.h"
-#include "../../../../common/foc_utils.h"
-#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
 #include "../stm32_mcu.h"
 #include "stm32f4_utils.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f4/stm32f4_mcu.cpp
@@ -34,7 +34,7 @@ void* _configureADCLowSide(const void* driver_params, const int pinA, const int 
     .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_F4) / (_ADC_RESOLUTION_F4)
   };
-  _adc_gpio_init(cs_params, pinA,pinB,pinC);
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   return cs_params;
 }

--- a/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.cpp
@@ -9,6 +9,14 @@
 
 ADC_HandleTypeDef hadc;
 
+/**
+ * Function initializing the ADC and the injected channels for the low-side current sensing
+ * 
+ * @param cs_params - current sense parameters
+ * @param driver_params - driver parameters
+ * 
+ * @return int - 0 if success 
+ */
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
 {
   ADC_InjectionConfTypeDef sConfigInjected;
@@ -159,21 +167,36 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   return 0;
 }
 
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
+
+/**
+ * Function to initialize the ADC GPIO pins
+ * 
+ * @param cs_params current sense parameters
+ * @param pinA pin number for phase A
+ * @param pinB pin number for phase B
+ * @param pinC pin number for phase C
+ * @return int 0 if success, -1 if error
+ */
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
 {
-  uint8_t cnt = 0;
-  if(_isset(pinA)){
-    pinmap_pinout(analogInputToPinName(pinA), PinMap_ADC);
-    cs_params->pins[cnt++] = pinA;
+  int pins[3] = {pinA, pinB, pinC};
+  const char* port_names[3] = {"A", "B", "C"};
+  for(int i=0; i<3; i++){
+    if(_isset(pins[i])){
+      // check if pin is an analog pin
+      if(pinmap_peripheral(analogInputToPinName(pins[i]), PinMap_ADC) == NP){
+#ifdef SIMPLEFOC_STM32_DEBUG
+        SimpleFOCDebug::print("STM32-CS: ERR: Pin ");
+        SimpleFOCDebug::print(port_names[i]);
+        SimpleFOCDebug::println(" does not belong to any ADC!");
+#endif
+        return -1;
+      }
+      pinmap_pinout(analogInputToPinName(pins[i]), PinMap_ADC);
+      cs_params->pins[i] = pins[i];
+    }
   }
-  if(_isset(pinB)){
-    pinmap_pinout(analogInputToPinName(pinB), PinMap_ADC);
-    cs_params->pins[cnt++] = pinB;
-  }
-  if(_isset(pinC)){ 
-    pinmap_pinout(analogInputToPinName(pinC), PinMap_ADC);
-    cs_params->pins[cnt] = pinC;
-  }
+  return 0;
 }
 
 #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT

--- a/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.h
@@ -8,6 +8,6 @@
 #include "stm32f7_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_hal.h
@@ -4,8 +4,6 @@
 
 #if defined(STM32F7xx)
 #include "stm32f7xx_hal.h"
-#include "../../../../common/foc_utils.h"
-#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
 #include "../stm32_mcu.h"
 #include "stm32f7_utils.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f7/stm32f7_mcu.cpp
@@ -28,7 +28,7 @@ void* _configureADCLowSide(const void* driver_params, const int pinA, const int 
     .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE) / (_ADC_RESOLUTION)
   };
-  _adc_gpio_init(cs_params, pinA,pinB,pinC);
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   return cs_params;
 }

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -8,6 +8,14 @@
 
 ADC_HandleTypeDef hadc;
 
+/**
+ * Function initializing the ADC and the injected channels for the low-side current sensing
+ * 
+ * @param cs_params - current sense parameters
+ * @param driver_params - driver parameters
+ * 
+ * @return int - 0 if success 
+ */
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
 {
   ADC_InjectionConfTypeDef sConfigInjected;
@@ -195,22 +203,37 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   return 0;
 }
 
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
+/**
+ * Function to initialize the ADC GPIO pins
+ * 
+ * @param cs_params current sense parameters
+ * @param pinA pin number for phase A
+ * @param pinB pin number for phase B
+ * @param pinC pin number for phase C
+ * @return int 0 if success, -1 if error
+ */
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
 {
-  uint8_t cnt = 0;
-  if(_isset(pinA)){
-    pinmap_pinout(analogInputToPinName(pinA), PinMap_ADC);
-    cs_params->pins[cnt++] = pinA;
+  int pins[3] = {pinA, pinB, pinC};
+  const char* port_names[3] = {"A", "B", "C"};
+  for(int i=0; i<3; i++){
+    if(_isset(pins[i])){
+      // check if pin is an analog pin
+      if(pinmap_peripheral(analogInputToPinName(pins[i]), PinMap_ADC) == NP){
+#ifdef SIMPLEFOC_STM32_DEBUG
+        SimpleFOCDebug::print("STM32-CS: ERR: Pin ");
+        SimpleFOCDebug::print(port_names[i]);
+        SimpleFOCDebug::println(" does not belong to any ADC!");
+#endif
+        return -1;
+      }
+      pinmap_pinout(analogInputToPinName(pins[i]), PinMap_ADC);
+      cs_params->pins[i] = pins[i];
+    }
   }
-  if(_isset(pinB)){
-    pinmap_pinout(analogInputToPinName(pinB), PinMap_ADC);
-    cs_params->pins[cnt++] = pinB;
-  }
-  if(_isset(pinC)){ 
-    pinmap_pinout(analogInputToPinName(pinC), PinMap_ADC);
-    cs_params->pins[cnt] = pinC;
-  }
+  return 0;
 }
+
 
 extern "C" {
   void ADC1_2_IRQHandler(void)

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -130,6 +130,13 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     uint32_t trigger_flag = _timerToInjectedTRGO(driver_params->timers_handle[tim_num++]);
     if(trigger_flag == _TRGO_NOT_AVAILABLE) continue; // timer does not have valid trgo for injected channels
 
+    // check if TRGO used already - if yes use the next timer
+    if((driver_params->timers_handle[tim_num-1]->Instance->CR2 & LL_TIM_TRGO_ENABLE) || // if used for timer sync
+       (driver_params->timers_handle[tim_num-1]->Instance->CR2 & LL_TIM_TRGO_UPDATE)) // if used for ADC sync
+      {
+      continue;
+    }
+
     // if the code comes here, it has found the timer available
     // timer does have trgo flag for injected channels  
     sConfigInjected.ExternalTrigInjecConv = trigger_flag;
@@ -145,6 +152,10 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
     SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot sync any timer to injected channels!");
 #endif
     return -1;
+  }else{
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: Using timer: ", stm32_getTimerNumber(cs_params->timer_handle->Instance));
+#endif
   }
 
 

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
@@ -6,8 +6,6 @@
 #if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
 
 #include "stm32g4xx_hal.h"
-#include "../../../../common/foc_utils.h"
-#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
 #include "../stm32_mcu.h"
 #include "stm32g4_utils.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
@@ -10,7 +10,7 @@
 #include "stm32g4_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
 
 #endif
 

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
@@ -36,7 +36,7 @@ void* _configureADCLowSide(const void* driver_params, const int pinA, const int 
     .pins={(int)NOT_SET, (int)NOT_SET, (int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_G4) / (_ADC_RESOLUTION_G4)
   };
-  _adc_gpio_init(cs_params, pinA,pinB,pinC);
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   return cs_params;
 }

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
@@ -8,6 +8,14 @@
 
 ADC_HandleTypeDef hadc;
 
+/**
+ * Function initializing the ADC and the injected channels for the low-side current sensing
+ * 
+ * @param cs_params - current sense parameters
+ * @param driver_params - driver parameters
+ * 
+ * @return int - 0 if success 
+ */
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
 {
   ADC_InjectionConfTypeDef sConfigInjected;
@@ -194,21 +202,35 @@ int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* drive
   return 0;
 }
 
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
+/**
+ * Function to initialize the ADC GPIO pins
+ * 
+ * @param cs_params current sense parameters
+ * @param pinA pin number for phase A
+ * @param pinB pin number for phase B
+ * @param pinC pin number for phase C
+ * @return int 0 if success, -1 if error
+ */
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
 {
-  uint8_t cnt = 0;
-  if(_isset(pinA)){
-    pinmap_pinout(analogInputToPinName(pinA), PinMap_ADC);
-    cs_params->pins[cnt++] = pinA;
+  int pins[3] = {pinA, pinB, pinC};
+  const char* port_names[3] = {"A", "B", "C"};
+  for(int i=0; i<3; i++){
+    if(_isset(pins[i])){
+      // check if pin is an analog pin
+      if(pinmap_peripheral(analogInputToPinName(pins[i]), PinMap_ADC) == NP){
+#ifdef SIMPLEFOC_STM32_DEBUG
+        SimpleFOCDebug::print("STM32-CS: ERR: Pin ");
+        SimpleFOCDebug::print(port_names[i]);
+        SimpleFOCDebug::println(" does not belong to any ADC!");
+#endif
+        return -1;
+      }
+      pinmap_pinout(analogInputToPinName(pins[i]), PinMap_ADC);
+      cs_params->pins[i] = pins[i];
+    }
   }
-  if(_isset(pinB)){
-    pinmap_pinout(analogInputToPinName(pinB), PinMap_ADC);
-    cs_params->pins[cnt++] = pinB;
-  }
-  if(_isset(pinC)){ 
-    pinmap_pinout(analogInputToPinName(pinC), PinMap_ADC);
-    cs_params->pins[cnt] = pinC;
-  }
+  return 0;
 }
 
 extern "C" {

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.h
@@ -10,7 +10,7 @@
 #include "stm32l4_utils.h"
 
 int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
-void _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
 
 #endif
 

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.h
@@ -6,8 +6,6 @@
 #if defined(STM32L4xx) 
 
 #include "stm32l4xx_hal.h"
-#include "../../../../common/foc_utils.h"
-#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
 #include "../stm32_mcu.h"
 #include "stm32l4_utils.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_mcu.cpp
@@ -35,7 +35,7 @@ void* _configureADCLowSide(const void* driver_params, const int pinA, const int 
     .pins={(int)NOT_SET, (int)NOT_SET, (int)NOT_SET},
     .adc_voltage_conv = (_ADC_VOLTAGE_L4) / (_ADC_RESOLUTION_L4)
   };
-  _adc_gpio_init(cs_params, pinA,pinB,pinC);
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
   return cs_params;
 }


### PR DESCRIPTION
This PR adds a check in the ADC code that verifies that the timer to which the ADC will be synced does not have TRGO events already in use. 
They can be used in two ways:
- TRGO_UPDATE - by another ADC sync (another motor for example)
- TRGO_ENABLE - by the driver code syncing multiple timers

This code was not necessary for the releases up to v2.3.4 as the driver sync was done after the ADC sync initialisaiton. Then the driver was the only one required to verify if the timers have TRGO in use. But in the new code, the driver is initalised first, and the ADC second, so the ADC code has to verify this as well.

I've also added to the code a check if the pins are ADC pins, and displayed the error. Up until now the init would fail without any error and block the operation.

I think that this PR is probably required for the v2.3.5, as without it the ADC code can overwrite the timer sync and create unaligned PWM signals. What do you think @runger1101001?