### PR TITLE
Fix `Pin is not configured as analog channel` error

### DIFF
--- a/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
+++ b/src/current_sense/hardware_specific/esp32/esp32_adc_driver.cpp
@@ -162,8 +162,8 @@ bool IRAM_ATTR adcInit(uint8_t pin){
         analogReadResolution(SIMPLEFOC_ADC_RES);
     }   
     pinMode(pin, ANALOG);
-    analogSetPinAttenuation(pin, SIMPLEFOC_ADC_ATTEN);
     analogRead(pin);
+    analogSetPinAttenuation(pin, SIMPLEFOC_ADC_ATTEN);
 
 #if CONFIG_IDF_TARGET_ESP32 // if esp32 variant
     __configFastADCs();


### PR DESCRIPTION
Forum conversation on the issue here: https://community.simplefoc.com/t/pin-is-not-configured-as-analog-channel/6751/5

Current sense align is currently not working on ESP32 boards due to a `__analogChannelConfig(): Pin is not configured as analog channel` error during `current_sense.init()`.

The error is coming from [this function](https://github.com/espressif/arduino-esp32/blob/bda7c4811728e538b4ea393a5be148cbb614daed/cores/esp32/esp32-hal-adc.c#L157C38-L172) in the `arduino-esp32` framework. It is checking to see if the pin type is `ESP32_BUS_TYPE_ADC_ONESHOT`.

In `arduino-esp32`, it appears that the `ESP32_BUS_TYPE_ADC_ONESHOT` setting is only applied to a pin in the `__analogInit` function, which in turn is only ever invoked during an `analogRead` (or `analogReadMilliVolts`, which SimpleFOC doesn’t use).

This is mainly a bug in `arduino-esp32` (since `analogSetPinAttenuation` should be able to work before an `analogRead` is called). But we can (and should) work around this in the SimpleFOC library since it may be a long time until a fix is released upstream. We can ensure the pin is initialised correctly by reversing the order of the `analogSetPinAttenuation` and the `analogRead` calls in the hardware specific driver for ESP32.