### PR TITLE
use default dir only if sensor not connected

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -93,10 +93,13 @@ int BLDCMotor::init() {
   P_angle.limit = velocity_limit;
 
   // if using open loop control, set a CW as the default direction if not already set
-  if ((controller==MotionControlType::angle_openloop
-     ||controller==MotionControlType::velocity_openloop)
-     && (sensor_direction == Direction::UNKNOWN)) {
-      sensor_direction = Direction::CW;
+  // only if no sensor is used
+  if(!sensor){
+    if ((controller==MotionControlType::angle_openloop
+      ||controller==MotionControlType::velocity_openloop)
+      && (sensor_direction == Direction::UNKNOWN)) {
+        sensor_direction = Direction::CW;
+    }
   }
 
   _delay(500);

--- a/src/HybridStepperMotor.cpp
+++ b/src/HybridStepperMotor.cpp
@@ -30,6 +30,7 @@ HybridStepperMotor::HybridStepperMotor(int pp, float _R, float _KV, float _induc
 void HybridStepperMotor::linkDriver(BLDCDriver *_driver)
 {
   driver = _driver;
+  SIMPLEFOC_DEBUG("MOT: BLDCDriver linked, using pin C as the mid-phase");
 }
 
 // init hardware pins
@@ -64,10 +65,13 @@ int HybridStepperMotor::init()
   P_angle.limit = velocity_limit;
 
   // if using open loop control, set a CW as the default direction if not already set
-  if ((controller==MotionControlType::angle_openloop
-     ||controller==MotionControlType::velocity_openloop)
-     && (sensor_direction == Direction::UNKNOWN)) {
-      sensor_direction = Direction::CW;
+  // only if no sensor is used
+  if(!sensor){
+    if ((controller==MotionControlType::angle_openloop
+      ||controller==MotionControlType::velocity_openloop)
+      && (sensor_direction == Direction::UNKNOWN)) {
+        sensor_direction = Direction::CW;
+    }
   }
 
   _delay(500);

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -57,10 +57,13 @@ int StepperMotor::init() {
   P_angle.limit = velocity_limit;
 
   // if using open loop control, set a CW as the default direction if not already set
-  if ((controller==MotionControlType::angle_openloop
-     ||controller==MotionControlType::velocity_openloop)
-     && (sensor_direction == Direction::UNKNOWN)) {
-      sensor_direction = Direction::CW;
+  // only if no sensor is used
+  if(!sensor){
+    if ((controller==MotionControlType::angle_openloop
+      ||controller==MotionControlType::velocity_openloop)
+      && (sensor_direction == Direction::UNKNOWN)) {
+        sensor_direction = Direction::CW;
+    }
   }
 
   _delay(500);

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.cpp
@@ -1,0 +1,207 @@
+#include "stm32h7_hal.h"
+
+#if defined(STM32H7xx)
+
+//#define SIMPLEFOC_STM32_DEBUG
+
+#include "../../../../communication/SimpleFOCDebug.h"
+#define _TRGO_NOT_AVAILABLE 12345
+
+ADC_HandleTypeDef hadc;
+
+/**
+ * Function initializing the ADC and the injected channels for the low-side current sensing
+ * 
+ * @param cs_params - current sense parameters
+ * @param driver_params - driver parameters
+ * 
+ * @return int - 0 if success 
+ */
+int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params)
+{
+  ADC_InjectionConfTypeDef sConfigInjected;
+
+  // check if all pins belong to the same ADC
+  ADC_TypeDef* adc_pin1 = _isset(cs_params->pins[0]) ? (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[0]), PinMap_ADC) : nullptr;
+  ADC_TypeDef* adc_pin2 = _isset(cs_params->pins[1]) ? (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[1]), PinMap_ADC) : nullptr;
+  ADC_TypeDef* adc_pin3 = _isset(cs_params->pins[2]) ? (ADC_TypeDef*)pinmap_peripheral(analogInputToPinName(cs_params->pins[2]), PinMap_ADC) : nullptr;
+ if ( ((adc_pin1 != adc_pin2) &&  (adc_pin1 && adc_pin2))  || 
+      ((adc_pin2 != adc_pin3) &&  (adc_pin2 && adc_pin3))  ||
+      ((adc_pin1 != adc_pin3) &&  (adc_pin1 && adc_pin3)) 
+    ){
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: Analog pins dont belong to the same ADC!");
+#endif
+  return -1;
+ }
+
+
+  /**Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion) 
+  */
+  hadc.Instance = (ADC_TypeDef *)pinmap_peripheral(analogInputToPinName(cs_params->pins[0]), PinMap_ADC);
+
+  if(hadc.Instance == ADC1) __HAL_RCC_ADC12_CLK_ENABLE();
+#ifdef ADC2  // if defined ADC2
+  else if(hadc.Instance == ADC2) __HAL_RCC_ADC12_CLK_ENABLE();
+#endif
+#ifdef ADC3  // if defined ADC3
+  else if(hadc.Instance == ADC3) __HAL_RCC_ADC3_CLK_ENABLE();
+#endif
+  else{
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: Pin does not belong to any ADC!");
+#endif
+    return -1; // error not a valid ADC instance
+  }
+  
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: Using ADC: ", _adcToIndex(&hadc)+1);
+#endif
+
+  hadc.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
+  hadc.Init.Resolution = ADC_RESOLUTION_12B;
+  hadc.Init.ScanConvMode = ENABLE;
+  hadc.Init.ContinuousConvMode = DISABLE;
+  hadc.Init.DiscontinuousConvMode = DISABLE;
+  hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+  hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START; // for now
+#if defined(ADC_VER_V5_V90)
+  // only for ADC3 
+  if(hadc.Instance == ADC3){
+    hadc.Init.DataAlign = ADC3_DATAALIGN_RIGHT;
+  }
+  // more info here
+  // https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h#L170C13-L170C27
+  hadc.Init.DMAContinuousRequests = DISABLE;
+  // not sure about this one!!! maybe use: ADC_SAMPLING_MODE_NORMAL
+  hadc.Init.SamplingMode = ADC_SAMPLING_MODE_TRIGGER_CONTROLED;
+#endif
+  hadc.Init.NbrOfConversion = 1;
+  hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+  if ( HAL_ADC_Init(&hadc) != HAL_OK){
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init ADC!");
+#endif
+    return -1;
+  }
+    
+  /**Configures for the selected ADC injected channel its corresponding rank in the sequencer and its sample time 
+    */
+  sConfigInjected.InjectedNbrOfConversion = _isset(cs_params->pins[2]) ? 3 : 2;
+  // if ADC1 or ADC2
+  if(hadc.Instance == ADC1 || hadc.Instance == ADC2){
+    // more info here: https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h#L658
+    sConfigInjected.InjectedNbrOfConversion = ADC_SAMPLETIME_2CYCLE_5;
+  }else {
+    // adc3
+    // https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h#L673
+    sConfigInjected.InjectedNbrOfConversion = ADC3_SAMPLETIME_2CYCLES_5;
+  }
+  sConfigInjected.ExternalTrigInjecConvEdge = ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING;  
+  sConfigInjected.AutoInjectedConv = DISABLE;
+  sConfigInjected.InjectedDiscontinuousConvMode = DISABLE;
+  sConfigInjected.InjectedOffset = 0;
+
+  // automating TRGO flag finding - hardware specific
+  uint8_t tim_num = 0;
+  for (size_t i=0; i<6; i++) {
+    TIM_HandleTypeDef *timer_to_check = driver_params->timers_handle[tim_num++];
+    TIM_TypeDef *instance_to_check = timer_to_check->Instance;
+
+    uint32_t trigger_flag = _timerToInjectedTRGO(timer_to_check);
+    if(trigger_flag == _TRGO_NOT_AVAILABLE) continue; // timer does not have valid trgo for injected channels
+
+    // check if TRGO used already - if yes use the next timer
+    if((timer_to_check->Instance->CR2 & LL_TIM_TRGO_ENABLE) || // if used for timer sync
+       (timer_to_check->Instance->CR2 & LL_TIM_TRGO_UPDATE)) // if used for ADC sync
+      {
+      continue;
+    }
+
+    // if the code comes here, it has found the timer available
+    // timer does have trgo flag for injected channels  
+    sConfigInjected.ExternalTrigInjecConv = trigger_flag;
+    
+    // this will be the timer with which the ADC will sync
+    cs_params->timer_handle = timer_to_check;
+    // done
+    break;
+  }
+  if( cs_params->timer_handle == NP ){
+    // not possible to use these timers for low-side current sense
+  #ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot sync any timer to injected channels!");
+  #endif
+    return -1;
+  }else{
+#ifdef SIMPLEFOC_STM32_DEBUG
+    SIMPLEFOC_DEBUG("STM32-CS: Using timer: ", stm32_getTimerNumber(cs_params->timer_handle->Instance));
+#endif
+  }
+
+  for(int i=0; i<3; i++){
+    // skip if not set
+    if (!_isset(cs_params->pins[i])) continue;
+    
+    sConfigInjected.InjectedRank = ADC_INJECTED_RANK_1 + i;
+    sConfigInjected.InjectedChannel = _getADCChannel(analogInputToPinName(cs_params->pins[i]));
+    if (HAL_ADCEx_InjectedConfigChannel(&hadc, &sConfigInjected) != HAL_OK){
+  #ifdef SIMPLEFOC_STM32_DEBUG
+      SIMPLEFOC_DEBUG("STM32-CS: ERR: cannot init injected channel: ", (int)_getADCChannel(analogInputToPinName(cs_params->pins[i])) );
+  #endif
+      return -1;
+    }
+  }
+  
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+  // enable interrupt
+  HAL_NVIC_SetPriority(ADC_IRQn, 0, 0);
+  HAL_NVIC_EnableIRQ(ADC_IRQn);
+  #endif
+  
+  cs_params->adc_handle = &hadc;
+  return 0;
+}
+
+
+/**
+ * Function to initialize the ADC GPIO pins
+ * 
+ * @param cs_params current sense parameters
+ * @param pinA pin number for phase A
+ * @param pinB pin number for phase B
+ * @param pinC pin number for phase C
+ * @return int 0 if success, -1 if error
+ */
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC)
+{
+  int pins[3] = {pinA, pinB, pinC};
+  const char* port_names[3] = {"A", "B", "C"};
+  for(int i=0; i<3; i++){
+    if(_isset(pins[i])){
+      // check if pin is an analog pin
+      if(pinmap_peripheral(analogInputToPinName(pins[i]), PinMap_ADC) == NP){
+#ifdef SIMPLEFOC_STM32_DEBUG
+        SimpleFOCDebug::print("STM32-CS: ERR: Pin ");
+        SimpleFOCDebug::print(port_names[i]);
+        SimpleFOCDebug::println(" does not belong to any ADC!");
+#endif
+        return -1;
+      }
+      pinmap_pinout(analogInputToPinName(pins[i]), PinMap_ADC);
+      cs_params->pins[i] = pins[i];
+    }
+  }
+  return 0;
+}
+
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+extern "C" {
+  void ADC_IRQHandler(void)
+  {
+      HAL_ADC_IRQHandler(&hadc);
+  }
+}
+#endif
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Arduino.h"
+
+#if defined(STM32H7xx)
+#include "stm32h7xx_hal.h"
+#include "../stm32_mcu.h"
+#include "stm32h7_utils.h"
+
+int _adc_init(Stm32CurrentSenseParams* cs_params, const STM32DriverParams* driver_params);
+int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int pinB, const int pinC);
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_mcu.cpp
@@ -1,0 +1,116 @@
+#include "../../../hardware_api.h"
+
+#if defined(STM32H7xx)
+#include "../../../../common/foc_utils.h"
+#include "../../../../drivers/hardware_api.h"
+#include "../../../../drivers/hardware_specific/stm32/stm32_mcu.h"
+#include "../../../hardware_api.h"
+#include "../stm32_mcu.h"
+#include "stm32h7_hal.h"
+#include "stm32h7_utils.h"
+#include "Arduino.h"
+
+
+#define _ADC_VOLTAGE 3.3f
+#define _ADC_RESOLUTION 4096.0f
+
+
+// array of values of 4 injected channels per adc instance (3)
+uint32_t adc_val[3][4]={0};
+// does adc interrupt need a downsample - per adc (3)
+bool needs_downsample[3] = {1};
+// downsampling variable - per adc (3)
+uint8_t tim_downsample[3] = {1};
+
+void* _configureADCLowSide(const void* driver_params, const int pinA, const int pinB, const int pinC){
+
+  Stm32CurrentSenseParams* cs_params= new Stm32CurrentSenseParams {
+    .pins={(int)NOT_SET,(int)NOT_SET,(int)NOT_SET},
+    .adc_voltage_conv = (_ADC_VOLTAGE) / (_ADC_RESOLUTION)
+  };
+  if(_adc_gpio_init(cs_params, pinA,pinB,pinC) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
+  if(_adc_init(cs_params, (STM32DriverParams*)driver_params) != 0) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
+  return cs_params;
+}
+
+
+void* _driverSyncLowSide(void* _driver_params, void* _cs_params){
+  STM32DriverParams* driver_params = (STM32DriverParams*)_driver_params;
+  Stm32CurrentSenseParams* cs_params = (Stm32CurrentSenseParams*)_cs_params;
+ 
+  // if compatible timer has not been found
+  if (cs_params->timer_handle == NULL) return SIMPLEFOC_CURRENT_SENSE_INIT_FAILED;
+  
+  // stop all the timers for the driver
+  stm32_pause(driver_params);
+
+  // if timer has repetition counter - it will downsample using it
+  // and it does not need the software downsample
+  if( IS_TIM_REPETITION_COUNTER_INSTANCE(cs_params->timer_handle->Instance) ){
+    // adjust the initial timer state such that the trigger 
+    //   - for DMA transfer aligns with the pwm peaks instead of throughs.
+    //   - for interrupt based ADC transfer 
+    //   - only necessary for the timers that have repetition counters
+
+    cs_params->timer_handle->Instance->CR1 |= TIM_CR1_DIR;
+    cs_params->timer_handle->Instance->CNT = cs_params->timer_handle->Instance->ARR;
+    // remember that this timer has repetition counter - no need to downasmple
+    needs_downsample[_adcToIndex(cs_params->adc_handle)] = 0;
+  }
+  // set the trigger output event
+  LL_TIM_SetTriggerOutput(cs_params->timer_handle->Instance, LL_TIM_TRGO_UPDATE);
+
+  // start the adc
+  #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
+  HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
+  #else
+  HAL_ADCEx_InjectedStart(cs_params->adc_handle);
+  #endif
+
+  // restart all the timers of the driver
+  stm32_resume(driver_params);
+  
+  // return the cs parameters 
+  // successfully initialized
+  // TODO verify if success in future
+  return _cs_params;
+}
+  
+
+// function reading an ADC value and returning the read voltage
+float _readADCVoltageLowSide(const int pin, const void* cs_params){
+  for(int i=0; i < 3; i++){
+    if( pin == ((Stm32CurrentSenseParams*)cs_params)->pins[i]){ // found in the buffer
+      #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+        return adc_val[_adcToIndex(((Stm32CurrentSenseParams*)cs_params)->adc_handle)][i] * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #else
+        // an optimized way to go from i to the channel i=0 -> channel 1, i=1 -> channel 2, i=2 -> channel 3
+        uint32_t channel = (i == 0) ? ADC_INJECTED_RANK_1 : (i == 1) ? ADC_INJECTED_RANK_2 : ADC_INJECTED_RANK_3;
+        return HAL_ADCEx_InjectedGetValue(((Stm32CurrentSenseParams*)cs_params)->adc_handle, channel) * ((Stm32CurrentSenseParams*)cs_params)->adc_voltage_conv;
+      #endif
+    }
+  } 
+  return 0;
+}
+
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
+extern "C" {
+  void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *AdcHandle){
+
+    // calculate the instance
+    int adc_index = _adcToIndex(AdcHandle);
+
+    // if the timer han't repetition counter - downsample two times
+    if( needs_downsample[adc_index] && tim_downsample[adc_index]++ > 0) {
+      tim_downsample[adc_index] = 0;
+      return;
+    }
+    
+    adc_val[adc_index][0]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_1);
+    adc_val[adc_index][1]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_2);
+    adc_val[adc_index][2]=HAL_ADCEx_InjectedGetValue(AdcHandle, ADC_INJECTED_RANK_3);    
+  }
+}
+#endif
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_mcu.cpp
@@ -60,12 +60,16 @@ void* _driverSyncLowSide(void* _driver_params, void* _cs_params){
   // set the trigger output event
   LL_TIM_SetTriggerOutput(cs_params->timer_handle->Instance, LL_TIM_TRGO_UPDATE);
 
+  // Start the adc calibration
+  HAL_ADCEx_Calibration_Start(cs_params->adc_handle, ADC_CALIB_OFFSET_LINEARITY, ADC_SINGLE_ENDED);
+    
   // start the adc
   #ifdef SIMPLEFOC_STM32_ADC_INTERRUPT 
   HAL_ADCEx_InjectedStart_IT(cs_params->adc_handle);
   #else
   HAL_ADCEx_InjectedStart(cs_params->adc_handle);
   #endif
+
 
   // restart all the timers of the driver
   stm32_resume(driver_params);

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_utils.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_utils.cpp
@@ -1,0 +1,240 @@
+#include "stm32h7_utils.h"
+
+#if defined(STM32H7xx)
+
+/* Exported Functions */
+
+
+PinName analog_to_pin(uint32_t pin) {
+  PinName pin_name = analogInputToPinName(pin);
+  if (pin_name == NC) {
+    return (PinName) pin;
+  }
+  return pin_name;
+}
+
+
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin)
+{
+  uint32_t function = pinmap_function(pin, PinMap_ADC);
+  uint32_t channel = 0;
+  switch (STM_PIN_CHANNEL(function)) {
+#ifdef ADC_CHANNEL_0
+    case 0:
+      channel = ADC_CHANNEL_0;
+      break;
+#endif
+    case 1:
+      channel = ADC_CHANNEL_1;
+      break;
+    case 2:
+      channel = ADC_CHANNEL_2;
+      break;
+    case 3:
+      channel = ADC_CHANNEL_3;
+      break;
+    case 4:
+      channel = ADC_CHANNEL_4;
+      break;
+    case 5:
+      channel = ADC_CHANNEL_5;
+      break;
+    case 6:
+      channel = ADC_CHANNEL_6;
+      break;
+    case 7:
+      channel = ADC_CHANNEL_7;
+      break;
+    case 8:
+      channel = ADC_CHANNEL_8;
+      break;
+    case 9:
+      channel = ADC_CHANNEL_9;
+      break;
+    case 10:
+      channel = ADC_CHANNEL_10;
+      break;
+    case 11:
+      channel = ADC_CHANNEL_11;
+      break;
+    case 12:
+      channel = ADC_CHANNEL_12;
+      break;
+    case 13:
+      channel = ADC_CHANNEL_13;
+      break;
+    case 14:
+      channel = ADC_CHANNEL_14;
+      break;
+    case 15:
+      channel = ADC_CHANNEL_15;
+      break;
+#ifdef ADC_CHANNEL_16
+    case 16:
+      channel = ADC_CHANNEL_16;
+      break;
+#endif
+    case 17:
+      channel = ADC_CHANNEL_17;
+      break;
+#ifdef ADC_CHANNEL_18
+    case 18:
+      channel = ADC_CHANNEL_18;
+      break;
+#endif
+#ifdef ADC_CHANNEL_19
+    case 19:
+      channel = ADC_CHANNEL_19;
+      break;
+#endif
+#ifdef ADC_CHANNEL_20
+    case 20:
+      channel = ADC_CHANNEL_20;
+      break;
+    case 21:
+      channel = ADC_CHANNEL_21;
+      break;
+    case 22:
+      channel = ADC_CHANNEL_22;
+      break;
+    case 23:
+      channel = ADC_CHANNEL_23;
+      break;
+#ifdef ADC_CHANNEL_24
+    case 24:
+      channel = ADC_CHANNEL_24;
+      break;
+    case 25:
+      channel = ADC_CHANNEL_25;
+      break;
+    case 26:
+      channel = ADC_CHANNEL_26;
+      break;
+#ifdef ADC_CHANNEL_27
+    case 27:
+      channel = ADC_CHANNEL_27;
+      break;
+    case 28:
+      channel = ADC_CHANNEL_28;
+      break;
+    case 29:
+      channel = ADC_CHANNEL_29;
+      break;
+    case 30:
+      channel = ADC_CHANNEL_30;
+      break;
+    case 31:
+      channel = ADC_CHANNEL_31;
+      break;
+#endif
+#endif
+#endif
+    default:
+      _Error_Handler("ADC: Unknown adc channel", (int)(STM_PIN_CHANNEL(function)));
+      break;
+  }
+  return channel;
+}
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h#L235
+uint32_t _timerToInjectedTRGO(TIM_HandleTypeDef* timer){
+
+  if(timer->Instance == TIM1)  
+    return ADC_EXTERNALTRIGINJEC_T1_TRGO;
+#ifdef TIM2 // if defined timer 2
+  else if(timer->Instance == TIM2) 
+    return ADC_EXTERNALTRIGINJEC_T2_TRGO;
+#endif
+#ifdef TIM4 // if defined timer 4
+  else if(timer->Instance == TIM4) 
+    return ADC_EXTERNALTRIGINJEC_T4_TRGO;
+#endif
+#ifdef TIM3 // if defined timer 3
+  else if(timer->Instance == TIM3) 
+    return ADC_EXTERNALTRIGINJEC_T3_TRGO;
+#endif
+#ifdef TIM6 // if defined timer 6
+  else if(timer->Instance == TIM6) 
+    return ADC_EXTERNALTRIGINJEC_T6_TRGO;
+#endif
+#ifdef TIM8 // if defined timer 8
+  else if(timer->Instance == TIM8) 
+    return ADC_EXTERNALTRIGINJEC_T8_TRGO;
+#endif
+#ifdef TIM15 // if defined timer 15
+  else if(timer->Instance == TIM15) 
+    return ADC_EXTERNALTRIGINJEC_T15_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h#L554
+uint32_t _timerToRegularTRGO(TIM_HandleTypeDef* timer){
+  if(timer->Instance == TIM1)  
+    return ADC_EXTERNALTRIG_T1_TRGO;
+#ifdef TIM2 // if defined timer 2
+  else if(timer->Instance == TIM2) 
+    return ADC_EXTERNALTRIG_T2_TRGO;
+#endif
+#ifdef TIM3 // if defined timer 3
+  else if(timer->Instance == TIM3) 
+    return ADC_EXTERNALTRIG_T3_TRGO;
+#endif
+#ifdef TIM4 // if defined timer 4
+  else if(timer->Instance == TIM4) 
+    return ADC_EXTERNALTRIG_T4_TRGO;
+#endif
+#ifdef TIM6 // if defined timer 6
+  else if(timer->Instance == TIM6) 
+    return ADC_EXTERNALTRIG_T6_TRGO;
+#endif
+#ifdef TIM8 // if defined timer 8
+  else if(timer->Instance == TIM8) 
+    return ADC_EXTERNALTRIG_T8_TRGO;
+#endif
+#ifdef TIM15 // if defined timer 15
+  else if(timer->Instance == TIM15) 
+    return ADC_EXTERNALTRIG_T15_TRGO;
+#endif
+#ifdef TIM23 // if defined timer 23
+  else if(timer->Instance == TIM23) 
+    return ADC_EXTERNALTRIG_T23_TRGO;
+#endif
+#ifdef TIM24 // if defined timer 24
+  else if(timer->Instance == TIM24) 
+    return ADC_EXTERNALTRIG_T24_TRGO;
+#endif
+  else
+    return _TRGO_NOT_AVAILABLE;
+}
+
+
+int _adcToIndex(ADC_TypeDef *AdcHandle){
+  if(AdcHandle == ADC1) return 0;
+#ifdef ADC2 // if ADC2 exists
+  else if(AdcHandle == ADC2) return 1;
+#endif
+#ifdef ADC3 // if ADC3 exists
+  else if(AdcHandle == ADC3) return 2;
+#endif
+#ifdef ADC4 // if ADC4 exists
+  else if(AdcHandle == ADC4) return 3;
+#endif
+#ifdef ADC5 // if ADC5 exists
+  else if(AdcHandle == ADC5) return 4;
+#endif
+  return 0;
+}
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle){
+  return _adcToIndex(AdcHandle->Instance);
+}
+
+#endif

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_utils.h
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Arduino.h"
+
+#if defined(STM32H7xx)
+
+#define _TRGO_NOT_AVAILABLE 12345
+
+
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @retval Valid HAL channel
+  */
+uint32_t _getADCChannel(PinName pin);
+
+// timer to injected TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc_ex.h#L179
+uint32_t _timerToInjectedTRGO(TIM_HandleTypeDef* timer);
+
+// timer to regular TRGO
+// https://github.com/stm32duino/Arduino_Core_STM32/blob/e156c32db24d69cb4818208ccc28894e2f427cfa/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_adc.h#L331
+uint32_t _timerToRegularTRGO(TIM_HandleTypeDef* timer);
+
+// function returning index of the ADC instance
+int _adcToIndex(ADC_HandleTypeDef *AdcHandle);
+int _adcToIndex(ADC_TypeDef *AdcHandle);
+
+#endif

--- a/src/drivers/hardware_specific/stm32/stm32_timerutils.cpp
+++ b/src/drivers/hardware_specific/stm32/stm32_timerutils.cpp
@@ -2,7 +2,7 @@
 #include "./stm32_timerutils.h"
 #include <Arduino.h>
 
-#if defined(_STM32_DEF_) || defined(TARGET_STM32H7)
+#if defined(_STM32_DEF_) || defined(STM32H7xx)
 
 
 void stm32_pauseTimer(TIM_HandleTypeDef* handle){
@@ -213,7 +213,7 @@ int stm32_getInternalSourceTrigger(TIM_HandleTypeDef* master, TIM_HandleTypeDef*
   #endif
   return -1;
 }
-#elif defined(STM32F4xx) || defined(STM32F1xx) || defined(STM32L4xx) || defined(STM32F7xx) || defined(TARGET_STM32H7)
+#elif defined(STM32F4xx) || defined(STM32F1xx) || defined(STM32L4xx) || defined(STM32F7xx) || defined(STM32H7xx)
 
 // function finds the appropriate timer source trigger for the master/slave timer combination
 // returns -1 if no trigger source is found
@@ -252,7 +252,7 @@ int stm32_getInternalSourceTrigger(TIM_HandleTypeDef* master, TIM_HandleTypeDef*
       #if defined(TIM8)
       else if(TIM_slave == TIM8) return LL_TIM_TS_ITR1;
       #endif
-      #if defined(TIM5) && !defined(TARGET_STM32H7)
+      #if defined(TIM5) && !defined(STM32H7xx)
       else if(TIM_slave == TIM5) return LL_TIM_TS_ITR0;
       #endif
     }
@@ -268,10 +268,10 @@ int stm32_getInternalSourceTrigger(TIM_HandleTypeDef* master, TIM_HandleTypeDef*
       #if defined(TIM4)
       else if(TIM_slave == TIM4) return LL_TIM_TS_ITR2;
       #endif
-      #if defined(TIM5) && !defined(TARGET_STM32H7)
+      #if defined(TIM5) && !defined(STM32H7xx)
       else if(TIM_slave == TIM5) return LL_TIM_TS_ITR1;
       #endif
-      #if defined(TIM5) && defined(TARGET_STM32H7)
+      #if defined(TIM5) && defined(STM32H7xx)
       else if(TIM_slave == TIM5) return LL_TIM_TS_ITR2;
       #endif
     }
@@ -290,10 +290,10 @@ int stm32_getInternalSourceTrigger(TIM_HandleTypeDef* master, TIM_HandleTypeDef*
       #if defined(TIM8)
       else if(TIM_slave == TIM8) return LL_TIM_TS_ITR2;
       #endif
-      #if defined(TIM5) && !defined(TARGET_STM32H7)
+      #if defined(TIM5) && !defined(STM32H7xx)
       else if(TIM_slave == TIM5) return LL_TIM_TS_ITR1;
       #endif
-      #if defined(TIM5) && defined(TARGET_STM32H7)
+      #if defined(TIM5) && defined(STM32H7xx)
       else if(TIM_slave == TIM5) return LL_TIM_TS_ITR3;
       #endif
     }
@@ -326,7 +326,7 @@ int stm32_getInternalSourceTrigger(TIM_HandleTypeDef* master, TIM_HandleTypeDef*
       #endif
     }
   #endif
-  #if defined(TIM15) && defined(TARGET_STM32H7)
+  #if defined(TIM15) && defined(STM32H7xx)
     else if (TIM_master == TIM15){
       #if defined(TIM1)
       if(TIM_slave == TIM1) return LL_TIM_TS_ITR0;
@@ -514,7 +514,7 @@ uint32_t stm32_getTimerClockFreq(TIM_HandleTypeDef *handle) {
       return 0;
   }
 
-#if defined(STM32H7xx) || defined(TARGET_STM32H7) 
+#if defined(STM32H7xx) || defined(STM32H7xx) 
   /* When TIMPRE bit of the RCC_CFGR register is reset,
    *   if APBx prescaler is 1 or 2 then TIMxCLK = HCLK,
    *   otherwise TIMxCLK = 2x PCLKx.


### PR DESCRIPTION
Hey @runger1101001,

I think this is a bug, but I am not sure. Let me know if I'm missing something. 
I am not 100% sure what is the motivation behind this part of the code.

The issue that I was having is that if the user uses the openloop mode at the start the initFOC will skip the direction calibration (as the motor.init will set the direction to CW). And this can lead to unstable behaviour later if the real direction is CCW and the user goes to the closed-loop control. Does it make sense to set the default sensor direction only if the sensor is not there?
