### PR TITLE
Add support for timer 8

### DIFF
--- a/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040/rp2040_mcu.cpp
@@ -93,7 +93,7 @@ void syncSlices() {
 		pwm_set_counter(i, 0);
 	}
 	// enable all slices
-	pwm_set_mask_enabled(0xFF);
+	pwm_set_mask_enabled(0xFFF);
 }
 
 


### PR DESCRIPTION
We use timer 6,7,8 for phase a,b,c. Timer 8 is only available in RP2350B, not 2040 or A. Therefore, the library does not support it well. We found that everything works except for the syncSlices function which sets pwm mask enabled with a bitmask 0xFF, so timer 0 to 7. Timer 8 was never enabled and did not run.