### PR TITLE
fixed MT6701 I2C

### DIFF
--- a/src/sensors/MagneticSensorI2C.h
+++ b/src/sensors/MagneticSensorI2C.h
@@ -14,7 +14,7 @@ struct MagneticSensorI2CConfig_s  {
   int data_start_bit; 
 };
 // some predefined structures
-extern MagneticSensorI2CConfig_s AS5600_I2C,AS5048_I2C;
+extern MagneticSensorI2CConfig_s AS5600_I2C,AS5048_I2C, MT6701_I2C;
 
 #if defined(TARGET_RP2040)
 #define SDA I2C_SDA


### PR DESCRIPTION
updated MagneticSensorI2C.h to include MT6701_I2C. Previously threw compile error due to missing declaration. 